### PR TITLE
Set immutable slug field

### DIFF
--- a/core/src/domain/dtos/account/mod.rs
+++ b/core/src/domain/dtos/account/mod.rs
@@ -112,6 +112,28 @@ pub struct Account {
     pub meta: Option<HashMap<AccountMetaKey, String>>,
 }
 
+impl Default for Account {
+    fn default() -> Self {
+        Self {
+            id: None,
+            name: String::new(),
+            slug: String::new(),
+            tags: None,
+            is_active: true,
+            is_checked: false,
+            is_archived: false,
+            verbose_status: None,
+            is_default: false,
+            owners: Children::Ids([].to_vec()),
+            account_type: AccountType::User,
+            guest_users: None,
+            created: Local::now(),
+            updated: None,
+            meta: None,
+        }
+    }
+}
+
 impl Account {
     /// Create a new subscription account
     ///

--- a/core/src/domain/dtos/profile/mod.rs
+++ b/core/src/domain/dtos/profile/mod.rs
@@ -146,6 +146,25 @@ pub struct Profile {
     filtering_state: Option<Vec<String>>,
 }
 
+impl Default for Profile {
+    fn default() -> Self {
+        Self::new(
+            vec![],
+            Uuid::new_v4(),
+            false,
+            false,
+            false,
+            true,
+            true,
+            true,
+            false,
+            None,
+            None,
+            None,
+        )
+    }
+}
+
 impl Profile {
     pub fn new(
         owners: Vec<Owner>,

--- a/core/src/use_cases/role_scoped/subscriptions_manager/account/update_account_name_and_flags.rs
+++ b/core/src/use_cases/role_scoped/subscriptions_manager/account/update_account_name_and_flags.rs
@@ -1,6 +1,9 @@
 use crate::domain::{
     actors::SystemActor,
-    dtos::{account::Account, profile::Profile},
+    dtos::{
+        account::Account, account_type::AccountType,
+        native_error_codes::NativeErrorCodes, profile::Profile,
+    },
     entities::{AccountFetching, AccountUpdating},
 };
 
@@ -63,6 +66,20 @@ pub async fn update_account_name_and_flags(
 
     if let Some(name) = name {
         account.name = name.to_owned();
+
+        match account.account_type {
+            AccountType::User | AccountType::Staff | AccountType::Manager => {
+                return use_case_err(format!(
+                    "Account type {} does not support name updating",
+                    account.account_type.to_string()
+                ))
+                .with_exp_true()
+                .with_code(NativeErrorCodes::MYC00018)
+                .as_error();
+            }
+            _ => {}
+        }
+
         account.slug = slugify!(&name.as_str());
     }
 
@@ -87,4 +104,153 @@ pub async fn update_account_name_and_flags(
     // ? -----------------------------------------------------------------------
 
     account_updating_repo.update(account).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{
+        dtos::{
+            account::{AccountMeta, AccountMetaKey},
+            related_accounts::RelatedAccounts,
+        },
+        entities::AccountFetching,
+    };
+
+    use async_trait::async_trait;
+    use mycelium_base::entities::FetchManyResponseKind;
+
+    fn account() -> Account {
+        let mut account = Account::default();
+        account.name = "Test Account".to_string();
+        account.slug = slugify!(&account.name);
+        account
+    }
+
+    struct MockAccountFetching;
+
+    impl Default for MockAccountFetching {
+        fn default() -> Self {
+            Self {}
+        }
+    }
+
+    #[async_trait]
+    impl AccountFetching for MockAccountFetching {
+        async fn get(
+            &self,
+            _: Uuid,
+            _: RelatedAccounts,
+        ) -> Result<FetchResponseKind<Account, Uuid>, MappedErrors> {
+            Ok(FetchResponseKind::Found(account()))
+        }
+
+        async fn list(
+            &self,
+            _: RelatedAccounts,
+            _: Option<String>,
+            _: Option<bool>,
+            _: Option<bool>,
+            _: Option<bool>,
+            _: Option<bool>,
+            _: Option<Uuid>,
+            _: Option<String>,
+            _: Option<Uuid>,
+            _: AccountType,
+            _: Option<i32>,
+            _: Option<i32>,
+        ) -> Result<FetchManyResponseKind<Account>, MappedErrors> {
+            unimplemented!()
+        }
+    }
+    struct MockAccountUpdating;
+
+    impl Default for MockAccountUpdating {
+        fn default() -> Self {
+            Self {}
+        }
+    }
+
+    #[async_trait]
+    impl AccountUpdating for MockAccountUpdating {
+        async fn update(
+            &self,
+            _: Account,
+        ) -> Result<UpdatingResponseKind<Account>, MappedErrors> {
+            Ok(UpdatingResponseKind::Updated(Account::default()))
+        }
+
+        async fn update_own_account_name(
+            &self,
+            _: Uuid,
+            _: String,
+        ) -> Result<UpdatingResponseKind<Account>, MappedErrors> {
+            unimplemented!()
+        }
+
+        async fn update_account_type(
+            &self,
+            _: Uuid,
+            _: AccountType,
+        ) -> Result<UpdatingResponseKind<Account>, MappedErrors> {
+            unimplemented!()
+        }
+
+        async fn update_account_meta(
+            &self,
+            _: Uuid,
+            _: AccountMetaKey,
+            _: String,
+        ) -> Result<UpdatingResponseKind<AccountMeta>, MappedErrors> {
+            unimplemented!()
+        }
+    }
+
+    ///
+    /// Test updating the account name and flags
+    ///
+    /// Rules:
+    /// - If it is an user, manager, or staff account, the slug field should
+    ///   not be updated.
+    /// - If it is a subscription account, the slug field should be updated.
+    ///
+    #[tokio::test]
+    async fn test_update_account_name_and_flags() {
+        let mut profile = Profile::default();
+        profile.is_staff = true;
+
+        let original_account = account();
+
+        let account_id = Uuid::new_v4();
+        let tenant_id = Uuid::new_v4();
+        let new_name = original_account.name.clone();
+        let is_active = Some(true);
+        let is_checked = Some(true);
+        let is_archived = Some(false);
+        let is_default = Some(false);
+
+        let fetching = MockAccountFetching::default();
+        let updating = MockAccountUpdating::default();
+
+        let account_fetching_repo = Box::new(&fetching as &dyn AccountFetching);
+        let account_updating_repo = Box::new(&updating as &dyn AccountUpdating);
+
+        let result = update_account_name_and_flags(
+            profile,
+            account_id,
+            tenant_id,
+            Some(new_name.clone()),
+            is_active,
+            is_checked,
+            is_archived,
+            is_default,
+            account_fetching_repo,
+            account_updating_repo,
+        )
+        .await;
+
+        assert!(matches!(result, Err(_)));
+        let error = result.unwrap_err();
+        assert!(error.has_str_code(NativeErrorCodes::MYC00018.as_str()));
+    }
 }


### PR DESCRIPTION
We performed two main modifications on the slug lifecycle:

During the default user account creation, instead to use the account name to generate the account slug, we introduced the primary user email as the slug source.
During the account name updating of the [update_account_name_and_flags](https://github.com/LepistaBioinformatics/mycelium/blob/c407dbe4e66b0581bce17b6be9b6e8623d9148b6/core/src/use_cases/role_scoped/subscriptions_manager/account/update_account_name_and_flags.rs) use-case, we introduced a error dispatcher to restrict slug updating to non-user accounts (account types: user, manager, and staff).
Additionally, we have created a unit test on the former [use-case](https://github.com/LepistaBioinformatics/mycelium/blob/c407dbe4e66b0581bce17b6be9b6e8623d9148b6/core/src/use_cases/role_scoped/subscriptions_manager/account/update_account_name_and_flags.rs#L109) to evaluate future changes on the codebase.