### PR TITLE
Deny account downgrade when the operation is performed in third party accounts

### DIFF
--- a/core/src/use_cases/super_users/staff/account/downgrade_account_privileges.rs
+++ b/core/src/use_cases/super_users/staff/account/downgrade_account_privileges.rs
@@ -1,5 +1,8 @@
 use crate::domain::{
-    dtos::{account::Account, account_type::AccountType, profile::Profile},
+    dtos::{
+        account::Account, account_type::AccountType,
+        native_error_codes::NativeErrorCodes, profile::Profile,
+    },
     entities::AccountUpdating,
 };
 
@@ -13,7 +16,14 @@ use uuid::Uuid;
 ///
 /// This action should be used to downgrade Standard and Manager accounts.
 /// Subscription and Staff accounts should not be downgraded.
-#[tracing::instrument(name = "downgrade_account_privileges", skip_all)]
+#[tracing::instrument(
+    name = "downgrade_account_privileges", 
+    fields(
+        profile_id = %profile.acc_id,
+        owners = ?profile.owners.iter().map(|o| o.email.to_owned()).collect::<Vec<_>>(),
+    ),
+    skip(profile, account_updating_repo)
+)]
 pub async fn downgrade_account_privileges(
     profile: Profile,
     account_id: Uuid,
@@ -28,9 +38,10 @@ pub async fn downgrade_account_privileges(
 
     if !profile.is_staff {
         return use_case_err(
-            "The current user has no sufficient privileges to downgrade 
-            accounts.",
+            "The current user has no sufficient privileges to downgrade accounts.",
         )
+        .with_exp_true()
+        .with_code(NativeErrorCodes::MYC00018)
         .as_error();
     }
 
@@ -38,10 +49,22 @@ pub async fn downgrade_account_privileges(
     // ? Check if the account type if allowed
     // ? -----------------------------------------------------------------------
 
+    if account_id != profile.acc_id {
+        return use_case_err(
+            "You cannot downgrade another account. Downgrade your own account instead.",
+        )
+        .with_exp_true()
+        .with_code(NativeErrorCodes::MYC00018)
+        .as_error();
+    }
+
     if !vec![AccountType::User, AccountType::Manager]
         .contains(&target_account_type)
     {
-        return use_case_err("Invalid upgrade target.").as_error();
+        return use_case_err("Invalid downgrade target.")
+            .with_exp_true()
+            .with_code(NativeErrorCodes::MYC00018)
+            .as_error();
     }
 
     // ? -----------------------------------------------------------------------
@@ -51,4 +74,103 @@ pub async fn downgrade_account_privileges(
     account_updating_repo
         .update_account_type(account_id, target_account_type)
         .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::dtos::account::{AccountMeta, AccountMetaKey};
+    use crate::domain::dtos::account_type::AccountType;
+    use crate::domain::dtos::profile::Profile;
+
+    use async_trait::async_trait;
+
+    struct MockAccountUpdating;
+
+    impl Default for MockAccountUpdating {
+        fn default() -> Self {
+            Self {}
+        }
+    }
+
+    #[async_trait]
+    impl AccountUpdating for MockAccountUpdating {
+        async fn update(
+            &self,
+            _: Account,
+        ) -> Result<UpdatingResponseKind<Account>, MappedErrors> {
+            unimplemented!()
+        }
+
+        async fn update_own_account_name(
+            &self,
+            _: Uuid,
+            _: String,
+        ) -> Result<UpdatingResponseKind<Account>, MappedErrors> {
+            unimplemented!()
+        }
+
+        async fn update_account_meta(
+            &self,
+            _: Uuid,
+            _: AccountMetaKey,
+            _: String,
+        ) -> Result<UpdatingResponseKind<AccountMeta>, MappedErrors> {
+            unimplemented!()
+        }
+
+        async fn update_account_type(
+            &self,
+            _: Uuid,
+            _: AccountType,
+        ) -> Result<UpdatingResponseKind<Account>, MappedErrors> {
+            Ok(UpdatingResponseKind::Updated(Account::default()))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_downgrade_account_privileges_with_non_self_account() {
+        let mut profile = Profile::default();
+        profile.is_staff = true;
+
+        let account_id = Uuid::new_v4();
+        let target_account_type = AccountType::User;
+
+        let updating = MockAccountUpdating::default();
+        let account_updating_repo = Box::new(&updating as &dyn AccountUpdating);
+
+        let result = downgrade_account_privileges(
+            profile,
+            account_id,
+            target_account_type,
+            account_updating_repo,
+        )
+        .await;
+
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert!(error.has_str_code(NativeErrorCodes::MYC00018.as_str()));
+    }
+
+    #[tokio::test]
+    async fn test_downgrade_account_privileges_with_self_account() {
+        let mut profile = Profile::default();
+        profile.is_staff = true;
+
+        let account_id = profile.acc_id;
+        let target_account_type = AccountType::User;
+
+        let updating = MockAccountUpdating::default();
+        let account_updating_repo = Box::new(&updating as &dyn AccountUpdating);
+
+        let result = downgrade_account_privileges(
+            profile,
+            account_id,
+            target_account_type,
+            account_updating_repo,
+        )
+        .await;
+
+        assert!(result.is_ok());
+    }
 }


### PR DESCRIPTION
Previously the downgrade operations had not account restrictions. Now, the account privileges downgrade is restricted to be a self-account operation. 