### PR TITLE
Gh/task/54

### DIFF
--- a/adapters/diesel/sql/up.sql
+++ b/adapters/diesel/sql/up.sql
@@ -144,13 +144,18 @@ CREATE TABLE guest_role (
     slug VARCHAR(140) NOT NULL,
     description VARCHAR(255),
     permission INT DEFAULT 0,
-    system BOOLEAN DEFAULT FALSE NOT NULL
+    system BOOLEAN DEFAULT FALSE NOT NULL,
+    created TIMESTAMPTZ DEFAULT now(),
+    updated TIMESTAMPTZ DEFAULT NULL
 );
 
 -- Guest role children table
 CREATE TABLE guest_role_children (
     parent_id UUID NOT NULL,
-    child_role_id UUID NOT NULL
+    child_role_id UUID NOT NULL,
+    created_by UUID NOT NULL,
+    created TIMESTAMPTZ DEFAULT now(),
+    updated TIMESTAMPTZ DEFAULT NULL
 );
 
 -- Guest user table

--- a/adapters/diesel/src/models/guest_role.rs
+++ b/adapters/diesel/src/models/guest_role.rs
@@ -1,3 +1,4 @@
+use chrono::NaiveDateTime;
 use diesel::prelude::*;
 use uuid::Uuid;
 
@@ -12,4 +13,6 @@ pub struct GuestRole {
     pub permission: i32,
     pub slug: String,
     pub system: bool,
+    pub created: NaiveDateTime,
+    pub updated: Option<NaiveDateTime>,
 }

--- a/adapters/diesel/src/models/guest_role_children.rs
+++ b/adapters/diesel/src/models/guest_role_children.rs
@@ -1,5 +1,6 @@
 use super::guest_role::GuestRole;
 
+use chrono::NaiveDateTime;
 use diesel::prelude::*;
 use uuid::Uuid;
 
@@ -13,4 +14,8 @@ pub struct GuestRoleChildren {
     pub parent_id: Uuid,
     #[diesel(sql_type = diesel::sql_types::Uuid)]
     pub child_role_id: Uuid,
+    #[diesel(sql_type = diesel::sql_types::Uuid)]
+    pub created_by: Uuid,
+    pub created: NaiveDateTime,
+    pub updated: Option<NaiveDateTime>,
 }

--- a/adapters/diesel/src/repositories/guest_role/guest_role_fetching.rs
+++ b/adapters/diesel/src/repositories/guest_role/guest_role_fetching.rs
@@ -113,6 +113,10 @@ impl GuestRoleFetching for GuestRoleFetchingSqlDbRepository {
 
         let records = query_records
             .select(GuestRoleModel::as_select())
+            .order((
+                guest_role_model::updated.desc().nulls_last(),
+                guest_role_model::system.desc(),
+            ))
             .limit(page_size)
             .offset(skip)
             .load::<GuestRoleModel>(conn)

--- a/adapters/diesel/src/repositories/guest_role/guest_role_registration.rs
+++ b/adapters/diesel/src/repositories/guest_role/guest_role_registration.rs
@@ -67,6 +67,8 @@ impl GuestRoleRegistration for GuestRoleRegistrationSqlDbRepository {
             description: guest_role.description,
             permission: guest_role.permission.to_i32(),
             system: guest_role.system,
+            created: chrono::Utc::now().naive_utc(),
+            updated: None,
         };
 
         let created = diesel::insert_into(guest_role_model::table)

--- a/adapters/diesel/src/repositories/guest_role/guest_role_updating.rs
+++ b/adapters/diesel/src/repositories/guest_role/guest_role_updating.rs
@@ -51,6 +51,7 @@ impl GuestRoleUpdating for GuestRoleUpdatingSqlDbRepository {
                 guest_role_model::slug.eq(&user_role.slug),
                 guest_role_model::description.eq(user_role.description.clone()),
                 guest_role_model::permission.eq(user_role.permission.to_i32()),
+                guest_role_model::updated.eq(chrono::Utc::now()),
             ))
             .get_result::<GuestRoleModel>(conn)
             .optional()

--- a/adapters/diesel/src/repositories/guest_role/shared.rs
+++ b/adapters/diesel/src/repositories/guest_role/shared.rs
@@ -1,5 +1,6 @@
 use crate::models::guest_role::GuestRole as GuestRoleModel;
 
+use chrono::Local;
 use myc_core::domain::dtos::guest_role::{GuestRole, Permission};
 
 pub(super) fn map_model_to_dto(model: GuestRoleModel) -> GuestRole {
@@ -11,5 +12,9 @@ pub(super) fn map_model_to_dto(model: GuestRoleModel) -> GuestRole {
         permission: Permission::from_i32(model.permission),
         children: None,
         system: model.system,
+        created: model.created.and_local_timezone(Local).unwrap(),
+        updated: model
+            .updated
+            .map(|dt| dt.and_local_timezone(Local).unwrap()),
     }
 }

--- a/adapters/diesel/src/schema.rs
+++ b/adapters/diesel/src/schema.rs
@@ -54,6 +54,8 @@ diesel::table! {
         #[max_length = 140]
         slug -> Varchar,
         system -> Bool,
+        created -> Timestamptz,
+        updated -> Nullable<Timestamptz>,
     }
 }
 
@@ -61,6 +63,9 @@ diesel::table! {
     guest_role_children (parent_id, child_role_id) {
         parent_id -> Uuid,
         child_role_id -> Uuid,
+        created_by -> Uuid,
+        created -> Timestamptz,
+        updated -> Nullable<Timestamptz>,
     }
 }
 

--- a/core/src/domain/dtos/guest_role.rs
+++ b/core/src/domain/dtos/guest_role.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Local};
 use mycelium_base::dtos::Children;
 use serde::{Deserialize, Serialize};
 use slugify::slugify;
@@ -69,6 +70,12 @@ pub struct GuestRole {
     pub description: Option<String>,
     pub permission: Permission,
 
+    /// The date and time the role was created
+    pub created: DateTime<Local>,
+
+    /// The date and time the role was last updated
+    pub updated: Option<DateTime<Local>>,
+
     /// If it is a system role
     ///
     /// System roles represents standard core actors of the Mycelium API
@@ -99,6 +106,8 @@ impl GuestRole {
             permission,
             children,
             system,
+            created: Local::now(),
+            updated: None,
         }
     }
 }

--- a/core/src/domain/entities/guest_role/guest_role_updating.rs
+++ b/core/src/domain/entities/guest_role/guest_role_updating.rs
@@ -18,11 +18,13 @@ pub trait GuestRoleUpdating: Interface + Send + Sync {
         &self,
         role_id: Uuid,
         child_id: Uuid,
+        created_by: Uuid,
     ) -> Result<UpdatingResponseKind<Option<GuestRole>>, MappedErrors>;
 
     async fn remove_role_child(
         &self,
         role_id: Uuid,
         child_id: Uuid,
+        created_by: Uuid,
     ) -> Result<UpdatingResponseKind<Option<GuestRole>>, MappedErrors>;
 }

--- a/core/src/use_cases/role_scoped/guest_manager/guest_role/insert_role_child.rs
+++ b/core/src/use_cases/role_scoped/guest_manager/guest_role/insert_role_child.rs
@@ -91,6 +91,6 @@ pub async fn insert_role_child(
     // ? -----------------------------------------------------------------------
 
     guest_role_updating_repo
-        .insert_role_child(guest_role_id, child_id)
+        .insert_role_child(guest_role_id, child_id, profile.acc_id)
         .await
 }

--- a/core/src/use_cases/role_scoped/guest_manager/guest_role/remove_role_child.rs
+++ b/core/src/use_cases/role_scoped/guest_manager/guest_role/remove_role_child.rs
@@ -31,6 +31,6 @@ pub async fn remove_role_child(
     // ? ----------------------------------------------------------------------
 
     guest_role_updating_repo
-        .remove_role_child(guest_role_id, child_id)
+        .remove_role_child(guest_role_id, child_id, profile.acc_id)
         .await
 }


### PR DESCRIPTION
Upgrade guest-roles model to include date fields and upgrade dependent elements as diesel models, schema, guest-roles fetching adapters.

After this change, users should attempt to upgrade SQL database with new columns as explained below:

Original schema:

```sql
-- Guest role table
CREATE TABLE guest_role (
    id UUID DEFAULT gen_random_uuid(),
    name VARCHAR(140) NOT NULL,
    slug VARCHAR(140) NOT NULL,
    description VARCHAR(255),
    permission INT DEFAULT 0,
    system BOOLEAN DEFAULT FALSE NOT NULL
);

-- Guest role children table
CREATE TABLE guest_role_children (
    parent_id UUID NOT NULL,
    child_role_id UUID NOT NULL
);
```

New schema:


```sql
-- Guest role table
CREATE TABLE guest_role (
    id UUID DEFAULT gen_random_uuid(),
    name VARCHAR(140) NOT NULL,
    slug VARCHAR(140) NOT NULL,
    description VARCHAR(255),
    permission INT DEFAULT 0,
    system BOOLEAN DEFAULT FALSE NOT NULL,
    created TIMESTAMPTZ DEFAULT now(),
    updated TIMESTAMPTZ DEFAULT NULL
);

-- Guest role children table
CREATE TABLE guest_role_children (
    parent_id UUID NOT NULL,
    child_role_id UUID NOT NULL,
    created_by UUID NOT NULL,
    created TIMESTAMPTZ DEFAULT now(),
    updated TIMESTAMPTZ DEFAULT NULL
);
```