### PR TITLE
Tenant-manager users should now fetch details of a tenant

### DIFF
--- a/adapters/diesel/src/repositories/tenant/tenant_fetching.rs
+++ b/adapters/diesel/src/repositories/tenant/tenant_fetching.rs
@@ -171,6 +171,7 @@ impl TenantFetching for TenantFetchingSqlDbRepository {
                     manager_ids.iter().map(|id| id).collect::<Vec<_>>(),
                 ))
                 .select(TenantModel::as_select())
+                .order_by(tenant_model::created.desc())
                 .first::<TenantModel>(conn)
                 .optional()
                 .map_err(|e| {

--- a/core/src/use_cases/role_scoped/tenant_manager/tenant/get_tenant_details.rs
+++ b/core/src/use_cases/role_scoped/tenant_manager/tenant/get_tenant_details.rs
@@ -1,0 +1,38 @@
+use crate::domain::{
+    actors::SystemActor,
+    dtos::{profile::Profile, tenant::Tenant},
+    entities::TenantFetching,
+};
+
+use mycelium_base::{entities::FetchResponseKind, utils::errors::MappedErrors};
+use uuid::Uuid;
+
+#[tracing::instrument(
+    name = "get_tenant_details",
+    fields(profile_id = %profile.acc_id),
+    skip_all
+)]
+pub async fn get_tenant_details(
+    profile: Profile,
+    tenant_id: Uuid,
+    tenant_fetching_repo: Box<&dyn TenantFetching>,
+) -> Result<FetchResponseKind<Tenant, String>, MappedErrors> {
+    // ? -----------------------------------------------------------------------
+    // ? Check if the current account has sufficient privileges to create role
+    // ? -----------------------------------------------------------------------
+
+    let tenant_related_ids = profile
+        .on_tenant(tenant_id)
+        .with_system_accounts_access()
+        .with_read_access()
+        .with_roles(vec![SystemActor::TenantManager])
+        .get_ids_or_error()?;
+
+    // ? -----------------------------------------------------------------------
+    // ? Fetch the tenant details
+    // ? -----------------------------------------------------------------------
+
+    tenant_fetching_repo
+        .get_tenants_by_manager_account(tenant_id, tenant_related_ids)
+        .await
+}

--- a/core/src/use_cases/role_scoped/tenant_manager/tenant/mod.rs
+++ b/core/src/use_cases/role_scoped/tenant_manager/tenant/mod.rs
@@ -1,3 +1,5 @@
 mod create_tenant_associated_connection_string;
+mod get_tenant_details;
 
 pub use create_tenant_associated_connection_string::*;
+pub use get_tenant_details::*;

--- a/ports/api/src/api_docs/mod.rs
+++ b/ports/api/src/api_docs/mod.rs
@@ -39,6 +39,7 @@ use role_scoped::system_manager::error_code_endpoints as System_Manager__Error_C
 use role_scoped::system_manager::webhook_endpoints as System_Manager__Webhook;
 use role_scoped::tenant_manager::account_endpoints as Tenant_Manager__Account;
 use role_scoped::tenant_manager::tag_endpoints as Tenant_Manager__Tag;
+use role_scoped::tenant_manager::tenant_endpoints as Tenant_Manager__Tenant;
 use role_scoped::tenant_manager::token_endpoints as Tenant_Manager__Token;
 use role_scoped::tenant_owner::account_endpoints as Tenant_Owner__Account;
 use role_scoped::tenant_owner::meta_endpoints as Tenant_Owner__Meta;
@@ -538,6 +539,21 @@ struct TenantManagerAccountApiDoc;
 )]
 struct TenantManagerTagApiDoc;
 
+/// Role Scoped Endpoints for Tenant Manager for Tenant Management
+///
+#[derive(OpenApi)]
+#[openapi(
+    info(
+        title = "Tenant Manager | Tenant Endpoints",
+        description = "Endpoints reserved for the application tenant managers to manage tenants",
+    ),
+    paths(
+        Tenant_Manager__Tenant::get_tenant_details_url,
+    ),
+    security(("Bearer" = [])),
+)]
+struct TenantManagerTenantApiDoc;
+
 /// Role Scoped Endpoints for Tenant Manager for Token Management
 ///
 #[derive(OpenApi)]
@@ -652,6 +668,7 @@ struct UsersManagerAccountApiDoc;
         (path = "/adm/rs/tenant-manager/accounts", api = TenantManagerAccountApiDoc),
         (path = "/adm/rs/tenant-manager/tags", api = TenantManagerTagApiDoc),
         (path = "/adm/rs/tenant-manager/tokens", api = TenantManagerTokenApiDoc),
+        (path = "/adm/rs/tenant-manager/tenants", api = TenantManagerTenantApiDoc),
         //
         // Users Manager Endpoints
         //

--- a/ports/api/src/endpoints/role_scoped/mod.rs
+++ b/ports/api/src/endpoints/role_scoped/mod.rs
@@ -42,6 +42,7 @@ use system_manager::{
 use tenant_manager::{
     account_endpoints as tenant_manager_account_endpoints,
     tag_endpoints as tenant_manager_tag_endpoints,
+    tenant_endpoints as tenant_manager_tenant_endpoints,
     token_endpoints as tenant_manager_token_endpoints,
 };
 use tenant_owner::{
@@ -301,6 +302,10 @@ pub(crate) fn configure(config: &mut web::ServiceConfig) {
             .service(
                 web::scope(&format!("/{}", UrlGroup::Tags))
                     .configure(tenant_manager_tag_endpoints::configure),
+            )
+            .service(
+                web::scope(&format!("/{}", UrlGroup::Tenants))
+                    .configure(tenant_manager_tenant_endpoints::configure),
             )
             .service(
                 web::scope(&format!("/{}", UrlGroup::Tokens))

--- a/ports/api/src/endpoints/role_scoped/tenant_manager/mod.rs
+++ b/ports/api/src/endpoints/role_scoped/tenant_manager/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod account_endpoints;
 pub(crate) mod tag_endpoints;
+pub(crate) mod tenant_endpoints;
 pub(crate) mod token_endpoints;

--- a/ports/api/src/endpoints/role_scoped/tenant_manager/tag_endpoints.rs
+++ b/ports/api/src/endpoints/role_scoped/tenant_manager/tag_endpoints.rs
@@ -50,7 +50,7 @@ pub struct CreateTagBody {
 //
 // ? ---------------------------------------------------------------------------
 
-/// Create a user related account
+/// Create a tag
 #[utoipa::path(
     post,
     params(

--- a/ports/api/src/endpoints/role_scoped/tenant_manager/tenant_endpoints.rs
+++ b/ports/api/src/endpoints/role_scoped/tenant_manager/tenant_endpoints.rs
@@ -1,0 +1,84 @@
+use crate::dtos::MyceliumProfileData;
+
+use actix_web::{get, web, Responder};
+use myc_core::{
+    domain::dtos::tenant::Tenant,
+    use_cases::role_scoped::tenant_manager::get_tenant_details,
+};
+use myc_diesel::repositories::SqlAppModule;
+use myc_http_tools::{
+    utils::HttpJsonResponse,
+    wrappers::default_response_to_http_response::{
+        fetch_response_kind, handle_mapped_error,
+    },
+};
+use shaku::HasComponent;
+use uuid::Uuid;
+
+// ? ---------------------------------------------------------------------------
+// ? Configure application
+// ? ---------------------------------------------------------------------------
+
+pub fn configure(config: &mut web::ServiceConfig) {
+    config.service(get_tenant_details_url);
+}
+
+// ? ---------------------------------------------------------------------------
+// ? Define API paths
+//
+// Account
+//
+// ? ---------------------------------------------------------------------------
+
+/// Fetch a user's profile.
+#[utoipa::path(
+    get,
+    responses(
+        (
+            status = 500,
+            description = "Unknown internal server error.",
+            body = HttpJsonResponse,
+        ),
+        (
+            status = 403,
+            description = "Forbidden.",
+            body = HttpJsonResponse,
+        ),
+        (
+            status = 401,
+            description = "Unauthorized.",
+            body = HttpJsonResponse,
+        ),
+        (
+            status = 400,
+            description = "Bad request.",
+            body = HttpJsonResponse,
+        ),
+        (
+            status = 204,
+            description = "Not found.",
+        ),
+        (
+            status = 200,
+            description = "Profile fetching done.",
+            body = Tenant,
+        ),
+    ),
+)]
+#[get("/{tenant_id}")]
+pub async fn get_tenant_details_url(
+    path: web::Path<Uuid>,
+    profile: MyceliumProfileData,
+    app_module: web::Data<SqlAppModule>,
+) -> impl Responder {
+    match get_tenant_details(
+        profile.to_profile(),
+        path.into_inner(),
+        Box::new(&*app_module.resolve_ref()),
+    )
+    .await
+    {
+        Ok(res) => fetch_response_kind(res),
+        Err(err) => handle_mapped_error(err),
+    }
+}


### PR DESCRIPTION
After this PR, tenant-manager users should now fetch details of tenants that he was guest as tenant-manager.