### PR TITLE
Increase the granularity of the tenant details

### DIFF
--- a/adapters/diesel/src/repositories/account/mod.rs
+++ b/adapters/diesel/src/repositories/account/mod.rs
@@ -9,3 +9,4 @@ pub(super) use account_deletion::*;
 pub(super) use account_fetching::*;
 pub(super) use account_registration::*;
 pub(super) use account_updating::*;
+pub(crate) use shared::*;

--- a/adapters/diesel/src/repositories/account/shared.rs
+++ b/adapters/diesel/src/repositories/account/shared.rs
@@ -6,7 +6,7 @@ use mycelium_base::dtos::Children;
 use serde_json::from_value;
 use std::{collections::HashMap, str::FromStr};
 
-pub(super) fn map_account_model_to_dto(model: AccountModel) -> Account {
+pub(crate) fn map_account_model_to_dto(model: AccountModel) -> Account {
     Account {
         id: Some(model.id),
         name: model.name,

--- a/adapters/diesel/src/repositories/tenant/tenant_fetching.rs
+++ b/adapters/diesel/src/repositories/tenant/tenant_fetching.rs
@@ -1,16 +1,20 @@
 use crate::{
     models::{
-        config::DbPoolProvider,
+        account::Account as AccountModel, config::DbPoolProvider,
         owner_on_tenant::OwnerOnTenant as OwnerOnTenantModel,
         tenant::Tenant as TenantModel, tenant_tag::TenantTag as TenantTagModel,
+        user::User as UserModel,
     },
+    repositories::account::map_account_model_to_dto,
     schema::{
+        account::{self as account_model},
         manager_account_on_tenant::{self as manager_account_on_tenant_model},
         owner_on_tenant::{
             self as owner_on_tenant_model, dsl as owner_on_tenant_dsl,
         },
         tenant::{self as tenant_model, dsl as tenant_dsl},
         tenant_tag::dsl as tenant_tag_dsl,
+        user::{self as user_model},
     },
 };
 
@@ -20,13 +24,14 @@ use diesel::{dsl::sql, prelude::*, BelongingToDsl, QueryDsl};
 use myc_core::domain::{
     dtos::{
         native_error_codes::NativeErrorCodes,
+        profile::Owner,
         tag::Tag,
         tenant::{Tenant, TenantMetaKey},
     },
     entities::TenantFetching,
 };
 use mycelium_base::{
-    dtos::Children,
+    dtos::{Children, Parent},
     entities::{FetchManyResponseKind, FetchResponseKind},
     utils::errors::{fetching_err, MappedErrors},
 };
@@ -163,7 +168,7 @@ impl TenantFetching for TenantFetchingSqlDbRepository {
                 .with_code(NativeErrorCodes::MYC00001)
         })?;
 
-        let tenant =
+        let record =
             tenant_model::table
                 .inner_join(manager_account_on_tenant_model::table)
                 .filter(tenant_model::id.eq(id))
@@ -178,34 +183,94 @@ impl TenantFetching for TenantFetchingSqlDbRepository {
                     fetching_err(format!("Failed to fetch tenant: {}", e))
                 })?;
 
-        match tenant {
-            Some(record) => Ok(FetchResponseKind::Found(Tenant {
-                id: Some(record.id),
-                name: record.name,
-                description: record.description,
-                meta: record.meta.map(|m| {
-                    serde_json::from_value::<HashMap<String, String>>(m)
-                        .unwrap()
-                        .iter()
-                        .map(|(k, v)| {
-                            (TenantMetaKey::from_str(k).unwrap(), v.to_string())
-                        })
-                        .collect()
-                }),
-                status: record
-                    .status
-                    .unwrap_or_default()
+        match record {
+            Some(record) => {
+                let owners = OwnerOnTenantModel::belonging_to(&record)
+                    .inner_join(user_model::table)
+                    .select(UserModel::as_select())
+                    .load::<UserModel>(conn)
+                    .map_err(|e| {
+                        fetching_err(format!("Failed to fetch owners: {}", e))
+                    })?
                     .into_iter()
-                    .map(|s| serde_json::from_value(s).unwrap())
-                    .collect(),
-                created: record.created.and_local_timezone(Local).unwrap(),
-                updated: record
-                    .updated
-                    .map(|dt| dt.and_local_timezone(Local).unwrap()),
-                owners: Children::Records(vec![]),
-                manager: None,
-                tags: None,
-            })),
+                    .map(|u| Owner {
+                        id: u.id,
+                        email: u.email,
+                        first_name: Some(u.first_name),
+                        last_name: Some(u.last_name),
+                        username: Some(u.username),
+                        is_principal: u.is_principal,
+                    })
+                    .collect::<Vec<Owner>>();
+
+                let manager = manager_account_on_tenant_model::table
+                    .inner_join(account_model::table)
+                    .filter(manager_account_on_tenant_model::tenant_id.eq(id))
+                    .select(AccountModel::as_select())
+                    .first::<AccountModel>(conn)
+                    .optional()
+                    .map_err(|e| {
+                        fetching_err(format!("Failed to fetch manager: {e}"))
+                    })?;
+
+                let tags = TenantTagModel::belonging_to(&record)
+                    .select(TenantTagModel::as_select())
+                    .load::<TenantTagModel>(conn)
+                    .map_err(|e| {
+                        fetching_err(format!("Failed to fetch tags: {}", e))
+                    })?
+                    .into_iter()
+                    .map(|t| Tag {
+                        id: t.id,
+                        value: t.value,
+                        meta: t
+                            .meta
+                            .map(|m| serde_json::from_value(m).unwrap()),
+                    })
+                    .collect::<Vec<Tag>>();
+
+                Ok(FetchResponseKind::Found(Tenant {
+                    id: Some(record.id),
+                    name: record.name,
+                    description: record.description,
+                    meta: record.meta.map(|m| {
+                        serde_json::from_value::<HashMap<String, String>>(m)
+                            .unwrap()
+                            .iter()
+                            .map(|(k, v)| {
+                                (
+                                    TenantMetaKey::from_str(k).unwrap(),
+                                    v.to_string(),
+                                )
+                            })
+                            .collect()
+                    }),
+                    status: record
+                        .status
+                        .unwrap_or_default()
+                        .into_iter()
+                        .map(|s| serde_json::from_value(s).unwrap())
+                        .collect(),
+                    created: record.created.and_local_timezone(Local).unwrap(),
+                    updated: record
+                        .updated
+                        .map(|dt| dt.and_local_timezone(Local).unwrap()),
+                    owners: match owners.len() {
+                        0 => Children::Records(vec![]),
+                        _ => Children::Records(owners),
+                    },
+                    manager: match manager {
+                        None => None,
+                        Some(account) => Some(Parent::Record(
+                            map_account_model_to_dto(account),
+                        )),
+                    },
+                    tags: match tags.len() {
+                        0 => None,
+                        _ => Some(tags),
+                    },
+                }))
+            }
             None => Ok(FetchResponseKind::NotFound(Some(id.to_string()))),
         }
     }

--- a/core/src/use_cases/role_scoped/tenant_manager/tenant/get_tenant_details.rs
+++ b/core/src/use_cases/role_scoped/tenant_manager/tenant/get_tenant_details.rs
@@ -32,7 +32,24 @@ pub async fn get_tenant_details(
     // ? Fetch the tenant details
     // ? -----------------------------------------------------------------------
 
-    tenant_fetching_repo
-        .get_tenants_by_manager_account(tenant_id, tenant_related_ids)
-        .await
+    //
+    // If the current account is a tenant manager, we need to fetch the tenant
+    // details from the tenant manager account.
+    //
+    if tenant_related_ids.len() > 0 {
+        tenant_fetching_repo
+            .get_tenants_by_manager_account(tenant_id, tenant_related_ids)
+            .await
+    //
+    // Otherwise, we need to fetch the tenant details from the tenant owner
+    // account. This is because the tenant owner account is the one that
+    // has the full access to the tenant details.
+    //
+    } else {
+        profile.with_tenant_ownership_or_error(tenant_id)?;
+
+        tenant_fetching_repo
+            .get_tenant_owned_by_me(tenant_id, vec![profile.acc_id])
+            .await
+    }
 }


### PR DESCRIPTION
Granularity of the tenant details was increased to include owner, tags, and management account information. Additionally, now the tenant-owners can perform requests to the same tenant-manager endpoint.