### PR TITLE
feat: do implements the roles propagation during the api initialization

### DIFF
--- a/core/src/domain/dtos/guest_role.rs
+++ b/core/src/domain/dtos/guest_role.rs
@@ -7,7 +7,9 @@ use tracing::error;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq, ToSchema)]
+#[derive(
+    Clone, Debug, Deserialize, Serialize, Eq, PartialEq, ToSchema, Hash,
+)]
 #[serde(rename_all = "camelCase")]
 #[derive(Default)]
 pub enum Permission {


### PR DESCRIPTION
Detailed Changes

  1. New Role Propagation System (ports/api/src/main.rs)

  - Implemented propagate_declared_roles_to_sql_database() function that:
    - Extracts all roles declared in service routes registered in the in-memory database
    - Identifies unique roles through a HashMap using slug and permission as key
    - Persists roles in SQL database through the GuestRoleRegistration repository
    - Uses get_or_create operation to avoid duplicates
    - Logs informative messages for created and existing roles
  - Integrated into application initialization flow:
    - Executed after SQL and MemDB modules initialization
    - Instrumented with tracing for observability
    - Proper error handling with conversion to std::io::Error

  2. DTO Update (core/src/domain/dtos/guest_role.rs)

  - Added Hash trait to Permission enum
  - Required to allow using Permission as a key in HashMap
  - Maintains compatibility with existing traits (Clone, Debug, Deserialize, Serialize, Eq, PartialEq, ToSchema)

  Benefits

  - Automatic Synchronization: Roles declared in routes are automatically synchronized with SQL database
  - Data Consistency: Ensures downstream services have access to the same roles
  - Duplicate Elimination: HashMap usage prevents creation of duplicate roles
  - Observability: Detailed logs of the propagation process
  - Idempotency: get_or_create operation allows safe multiple executions

  Technical Impact

  - Execution: During application startup, before HTTP server starts
  - Performance: One-time operation at startup, no runtime impact
  - Security: Does not alter existing authorization flow, only synchronizes metadata