### PR TITLE
fix: review the information injection to sendo to callback scripts

### DIFF
--- a/core/src/domain/dtos/callback/context.rs
+++ b/core/src/domain/dtos/callback/context.rs
@@ -1,4 +1,6 @@
-use crate::domain::dtos::http::HttpMethod;
+use crate::domain::dtos::{
+    callback::UserInfo, http::HttpMethod, security_group::SecurityGroup,
+};
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -6,7 +8,7 @@ use std::collections::HashMap;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CallbackContext {
     pub status_code: u16,
-    pub headers: HashMap<String, String>,
+    pub response_headers: HashMap<String, String>,
     pub duration_ms: u64,
     pub upstream_path: String,
     pub downstream_url: String,
@@ -14,12 +16,14 @@ pub struct CallbackContext {
     pub timestamp: String,
     pub request_id: Option<String>,
     pub client_ip: Option<String>,
+    pub user_info: Option<UserInfo>,
+    pub security_group: SecurityGroup,
 }
 
 impl CallbackContext {
     pub fn new(
         status_code: u16,
-        headers: HashMap<String, String>,
+        response_headers: HashMap<String, String>,
         duration_ms: u64,
         upstream_path: String,
         downstream_url: String,
@@ -27,10 +31,12 @@ impl CallbackContext {
         timestamp: String,
         request_id: Option<String>,
         client_ip: Option<String>,
+        user_info: Option<UserInfo>,
+        security_group: SecurityGroup,
     ) -> Self {
         Self {
             status_code,
-            headers,
+            response_headers,
             duration_ms,
             upstream_path,
             downstream_url,
@@ -38,6 +44,8 @@ impl CallbackContext {
             timestamp,
             request_id,
             client_ip,
+            user_info,
+            security_group,
         }
     }
 }

--- a/core/src/domain/dtos/callback/mod.rs
+++ b/core/src/domain/dtos/callback/mod.rs
@@ -5,6 +5,7 @@ mod error;
 mod execution_mode;
 mod executor;
 mod manager;
+mod user_info;
 
 pub use callback_filters::*;
 pub use callback_type::*;
@@ -13,6 +14,7 @@ pub use error::*;
 pub use execution_mode::*;
 pub use executor::*;
 pub use manager::*;
+pub use user_info::*;
 
 use crate::domain::dtos::http::HttpMethod;
 

--- a/core/src/domain/dtos/callback/user_info.rs
+++ b/core/src/domain/dtos/callback/user_info.rs
@@ -1,0 +1,20 @@
+use crate::domain::dtos::{email::Email, profile::Profile};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum UserInfo {
+    Email(Email),
+    Profile(Profile),
+}
+
+impl UserInfo {
+    pub fn new_email(email: Email) -> Self {
+        Self::Email(email)
+    }
+
+    pub fn new_profile(profile: Profile) -> Self {
+        Self::Profile(profile)
+    }
+}

--- a/ports/api/src/callback_engines/http_engine.rs
+++ b/ports/api/src/callback_engines/http_engine.rs
@@ -54,7 +54,7 @@ impl CallbackExecutor for HttpCallback {
     ) -> Result<(), CallbackError> {
         let payload = serde_json::json!({
             "status_code": context.status_code,
-            "headers": context.headers,
+            "headers": context.response_headers,
             "duration_ms": context.duration_ms,
             "upstream_path": context.upstream_path,
             "downstream_url": context.downstream_url,

--- a/ports/api/src/callback_engines/rhai_engine.rs
+++ b/ports/api/src/callback_engines/rhai_engine.rs
@@ -4,6 +4,7 @@ use myc_core::domain::dtos::callback::{
     CallbackContext, CallbackError, CallbackExecutor,
 };
 use rhai::{Dynamic, Engine, Map, Scope, AST};
+use serde_json::Value as JsonValue;
 use shaku::Component;
 use std::sync::Arc;
 use tonic::async_trait;
@@ -61,21 +62,35 @@ impl CallbackExecutor for RhaiCallback {
         tokio::task::spawn_blocking(move || -> Result<(), CallbackError> {
             let mut scope = Scope::new();
 
-            // Expose context variables
-            scope.push("status_code", context.status_code as i64);
-            scope.push("duration_ms", context.duration_ms as i64);
-            scope.push("upstream_path", context.upstream_path);
-            scope.push("downstream_url", context.downstream_url);
-            scope.push("method", context.method);
-            scope.push("timestamp", context.timestamp);
+            // Convert context to JSON value to preserve exact field names
+            let context_json = serde_json::to_value(&context).map_err(|e| {
+                CallbackError::ScriptError(format!(
+                    "Failed to serialize context: {}",
+                    e
+                ))
+            })?;
 
-            // Headers as map
-            let headers_map: Map = context
-                .headers
-                .into_iter()
-                .map(|(k, v)| (k.into(), Dynamic::from(v)))
+            // Convert JSON value to Rhai Dynamic and expose all fields
+            if let JsonValue::Object(map) = context_json {
+                for (key, value) in map {
+                    let rhai_value = json_value_to_rhai_dynamic(value);
+                    scope.push(key, rhai_value);
+                }
+            }
+
+            // Also expose response_headers as array for iteration (backward compatibility)
+            let headers_array: rhai::Array = context
+                .response_headers
+                .iter()
+                .map(|(k, v)| {
+                    let mut header_obj = Map::new();
+                    header_obj.insert("key".into(), Dynamic::from(k.clone()));
+                    header_obj.insert("value".into(), Dynamic::from(v.clone()));
+                    Dynamic::from(header_obj)
+                })
                 .collect();
-            scope.push("headers", headers_map);
+
+            scope.push("headers_array", headers_array);
 
             engine
                 .run_ast_with_scope(&mut scope, &script)
@@ -87,5 +102,35 @@ impl CallbackExecutor for RhaiCallback {
 
     fn name(&self) -> &str {
         &self.name
+    }
+}
+
+/// Convert a serde_json::Value to a Rhai Dynamic value
+fn json_value_to_rhai_dynamic(value: JsonValue) -> Dynamic {
+    match value {
+        JsonValue::Null => Dynamic::UNIT,
+        JsonValue::Bool(b) => Dynamic::from(b),
+        JsonValue::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Dynamic::from(i)
+            } else if let Some(f) = n.as_f64() {
+                Dynamic::from(f)
+            } else {
+                Dynamic::from(n.to_string())
+            }
+        }
+        JsonValue::String(s) => Dynamic::from(s),
+        JsonValue::Array(arr) => {
+            let rhai_array: rhai::Array =
+                arr.into_iter().map(json_value_to_rhai_dynamic).collect();
+            Dynamic::from(rhai_array)
+        }
+        JsonValue::Object(obj) => {
+            let mut rhai_map = Map::new();
+            for (k, v) in obj {
+                rhai_map.insert(k.into(), json_value_to_rhai_dynamic(v));
+            }
+            Dynamic::from(rhai_map)
+        }
     }
 }

--- a/ports/api/src/middleware/fetch_and_inject_email_to_forward.rs
+++ b/ports/api/src/middleware/fetch_and_inject_email_to_forward.rs
@@ -2,7 +2,9 @@ use super::check_credentials_with_multi_identity_provider;
 
 use actix_web::HttpRequest;
 use awc::ClientRequest;
-use myc_http_tools::{responses::GatewayError, settings::DEFAULT_EMAIL_KEY};
+use myc_http_tools::{
+    responses::GatewayError, settings::DEFAULT_EMAIL_KEY, Email,
+};
 use opentelemetry::{global, KeyValue};
 use reqwest::header::{HeaderName, HeaderValue};
 use std::str::FromStr;
@@ -18,7 +20,7 @@ pub async fn fetch_and_inject_email_to_forward(
     req: HttpRequest,
     mut forwarded_req: ClientRequest,
     service_name: String,
-) -> Result<ClientRequest, GatewayError> {
+) -> Result<(ClientRequest, Email), GatewayError> {
     let span = tracing::Span::current();
 
     tracing::trace!("Injecting email to forward");
@@ -64,5 +66,5 @@ pub async fn fetch_and_inject_email_to_forward(
 
     tracing::trace!("Email injected to forward");
 
-    Ok(forwarded_req)
+    Ok((forwarded_req, email))
 }

--- a/ports/api/src/middleware/fetch_and_inject_profile_from_token_to_forward.rs
+++ b/ports/api/src/middleware/fetch_and_inject_profile_from_token_to_forward.rs
@@ -8,6 +8,7 @@ use myc_http_tools::{
     functions::compress_and_encode_profile_to_base64,
     responses::GatewayError,
     settings::{DEFAULT_CONNECTION_STRING_KEY, DEFAULT_PROFILE_KEY},
+    Profile,
 };
 use opentelemetry::{global, KeyValue};
 use reqwest::header::{HeaderName, HeaderValue};
@@ -43,7 +44,7 @@ pub async fn fetch_and_inject_profile_from_token_to_forward(
     tenant: Option<Uuid>,
     roles: Option<Vec<PermissionedRole>>,
     service_name: String,
-) -> Result<ClientRequest, GatewayError> {
+) -> Result<(ClientRequest, Profile), GatewayError> {
     let span = tracing::Span::current();
 
     tracing::trace!("Injecting profile to forward");
@@ -125,5 +126,5 @@ pub async fn fetch_and_inject_profile_from_token_to_forward(
 
     tracing::trace!("Profile injected to forward");
 
-    Ok(forwarded_req)
+    Ok((forwarded_req, profile.to_profile()))
 }

--- a/ports/api/src/router/check_security_group.rs
+++ b/ports/api/src/router/check_security_group.rs
@@ -5,7 +5,9 @@ use crate::middleware::{
 
 use actix_web::HttpRequest;
 use awc::ClientRequest;
-use myc_core::domain::dtos::{route::Route, security_group::SecurityGroup};
+use myc_core::domain::dtos::{
+    callback::UserInfo, route::Route, security_group::SecurityGroup,
+};
 use myc_http_tools::{
     responses::GatewayError, settings::MYCELIUM_SECURITY_GROUP,
 };
@@ -30,7 +32,7 @@ pub(super) async fn check_security_group(
     req: HttpRequest,
     mut downstream_request: ClientRequest,
     route: Route,
-) -> Result<ClientRequest, GatewayError> {
+) -> Result<(ClientRequest, SecurityGroup, Option<UserInfo>), GatewayError> {
     let span = tracing::Span::current();
 
     let security_group = route.security_group.to_owned();
@@ -38,8 +40,8 @@ pub(super) async fn check_security_group(
     //
     // Inject security group as header
     //
-    let serialized_security_group = serde_json::to_string(&security_group)
-        .map_err(|e| {
+    let serialized_security_group =
+        serde_json::to_string(&security_group.to_owned()).map_err(|e| {
             tracing::error!("Failed to serialize security group: {e}");
 
             GatewayError::BadGateway(
@@ -65,11 +67,11 @@ pub(super) async fn check_security_group(
     //
     // Check requester permissions given the security group
     //
-    match security_group {
+    let (new_downstream_request, user_info) = match security_group.to_owned() {
         //
         // Public routes do not need any authentication or profile injection.
         //
-        SecurityGroup::Public => (),
+        SecurityGroup::Public => (downstream_request, None),
         //
         // Authenticated routes should include the user email into the request
         // token
@@ -79,13 +81,16 @@ pub(super) async fn check_security_group(
             // Try to extract user email from the request and inject it into the
             // request headers
             //
-            downstream_request = fetch_and_inject_email_to_forward(
-                req,
-                downstream_request,
-                service_name,
-            )
-            .instrument(span.to_owned())
-            .await?;
+            let (mod_downstream_request, email) =
+                fetch_and_inject_email_to_forward(
+                    req,
+                    downstream_request,
+                    service_name,
+                )
+                .instrument(span.to_owned())
+                .await?;
+
+            (mod_downstream_request, Some(UserInfo::new_email(email)))
         }
         //
         // Protected routes should include the full qualified user profile into
@@ -95,7 +100,7 @@ pub(super) async fn check_security_group(
             //
             // Try to populate profile from the request
             //
-            downstream_request =
+            let (mod_downstream_request, profile) =
                 fetch_and_inject_profile_from_token_to_forward(
                     req,
                     downstream_request,
@@ -105,6 +110,8 @@ pub(super) async fn check_security_group(
                 )
                 .instrument(span.to_owned())
                 .await?;
+
+            (mod_downstream_request, Some(UserInfo::new_profile(profile)))
         }
         //
         // Protected routes should include the user profile filtered by roles
@@ -115,7 +122,7 @@ pub(super) async fn check_security_group(
             // Try to populate profile from the request filtering licensed
             // resources by roles
             //
-            downstream_request =
+            let (mod_downstream_request, profile) =
                 fetch_and_inject_profile_from_token_to_forward(
                     req,
                     downstream_request,
@@ -125,8 +132,10 @@ pub(super) async fn check_security_group(
                 )
                 .instrument(span.to_owned())
                 .await?;
-        }
-    }
 
-    Ok(downstream_request)
+            (mod_downstream_request, Some(UserInfo::new_profile(profile)))
+        }
+    };
+
+    Ok((new_downstream_request, security_group, user_info))
 }

--- a/ports/api/src/router/mod.rs
+++ b/ports/api/src/router/mod.rs
@@ -153,7 +153,7 @@ pub(crate) async fn route_request(
     //
     // ? -----------------------------------------------------------------------
 
-    let mut downstream_request = initialize_downstream_request(
+    let downstream_request = initialize_downstream_request(
         upstream_request.clone(),
         &route,
         client.clone(),
@@ -170,7 +170,7 @@ pub(crate) async fn route_request(
     //
     // ? -----------------------------------------------------------------------
 
-    downstream_request = check_security_group(
+    let (downstream_request, security_group, user_info) = check_security_group(
         upstream_request.clone(),
         downstream_request,
         route.clone(),
@@ -210,6 +210,8 @@ pub(crate) async fn route_request(
         payload,
         route.callbacks.to_owned(),
         &app_module,
+        user_info,
+        security_group,
     )
     .instrument(span.to_owned())
     .await?;

--- a/test/callbacks/python_callback_script.py
+++ b/test/callbacks/python_callback_script.py
@@ -19,7 +19,7 @@ print(f"Path: {context['upstream_path']}")
 
 # Access headers
 print("\n=== Headers ===")
-for key, value in context['headers'].items():
+for key, value in context['response_headers'].items():
     print(f"{key}: {value}")
 
 # Custom logic


### PR DESCRIPTION
This PR fixes the information injection mechanism for callback scripts by improving the context data passed to callback engines. The changes address inconsistencies in header field naming and add critical missing information (user context and security group data) to the callback context, enabling scripts to make more informed decisions based on request authentication and authorization state.

The main issue was that callback scripts received incomplete context information and had inconsistent field naming (headers vs response_headers), which prevented them from accessing user authentication details and security group information needed for proper request tracking and auditing.

Type of Change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Refactoring (no functional changes)
- Documentation update
- Performance improvement
- Other (please describe):

Changes Made

- Renamed headers field to response_headers in CallbackContext for clarity and consistency
- Added user_info: Option<UserInfo> field to CallbackContext to provide user authentication information to callbacks
- Added security_group: SecurityGroup field to CallbackContext to provide authorization context to callbacks
- Created new UserInfo enum type to represent either Email or Profile user information
- Refactored fetch_and_inject_email_to_forward to return tuple (ClientRequest, Email) instead of just ClientRequest
- Refactored fetch_and_inject_profile_from_token_to_forward to return tuple (ClientRequest, Profile) instead of just ClientRequest
- Updated check_security_group function to return (ClientRequest, SecurityGroup, Option<UserInfo>) to propagate user context
- Enhanced Rhai callback engine to properly serialize the entire context using JSON, preserving exact field names
- Added json_value_to_rhai_dynamic conversion function for better JSON-to-Rhai type mapping
- Updated stream_request_to_downstream to accept and pass user_info and security_group to callback context
- Fixed headers collection in downstream request processing
- Updated Python test callback script to use response_headers instead of headers

Related Issues

Relates to #138

Checklist

- Tests added for new functionality
- Existing tests pass
- Code follows the project's style guidelines
- Documentation has been updated (if applicable)
- No new warnings introduced
- Breaking changes documented (if applicable)
- Commits follow conventional commit format

Testing

Test Environment:
- OS: Linux 6.14.0-37-generic
- Rust version: 1.70.0+

Test Steps:
1. Run the API gateway with callback scripts configured
2. Make authenticated requests through different security groups (Public, Authenticated, Protected)
3. Verify callback scripts receive complete context with user_info and security_group fields
4. Verify response_headers field is properly populated and accessible
5. Test Rhai callback scripts can access all context fields with correct serialization

Test Commands:
# Build and run tests
cargo test -p myc-api

# Test callback execution
cargo test -p myc-api callback

# Run integration tests with callback scripts
cargo test --test callback_integration

Screenshots/Logs

N/A

Additional Notes

Breaking Changes:
- Callback scripts that accessed context.headers must now use context.response_headers
- The CallbackContext constructor signature has changed to include user_info and security_group parameters

Migration Guide:
For callback scripts (Python, Rhai, etc.):
# Before
for key, value in context['headers'].items():
    print(f"{key}: {value}")

# After
for key, value in context['response_headers'].items():
    print(f"{key}: {value}")

For Rhai scripts, the context now includes additional fields that can be accessed directly:
- user_info - Contains either email or profile information (if authenticated)
- security_group - Contains the security group of the route (Public, Authenticated, Protected, etc.)

Deployment Considerations:
- Existing callback scripts should be reviewed and updated to use response_headers instead of headers
- Scripts can now access user authentication and authorization context for better auditing and decision-making