### PR TITLE
fix: add the service name to downstream header

### DIFF
--- a/ports/api/src/router/initialize_downstream_request.rs
+++ b/ports/api/src/router/initialize_downstream_request.rs
@@ -146,12 +146,8 @@ pub(super) async fn initialize_downstream_request(
     // Inform to the downstream service about the target host, protocol and
     // port. Also, inform that the request is coming from the mycelium gateway.
     //
-    if let Some(_) = service.proxy_address.to_owned() {
-        downstream_request = downstream_request.insert_header((
-            MYCELIUM_SERVICE_NAME,
-            format!("{}", service.name),
-        ));
-    };
+    downstream_request = downstream_request
+        .insert_header((MYCELIUM_SERVICE_NAME, format!("{}", service.name)));
 
     Ok(downstream_request)
 }


### PR DESCRIPTION
Add the service name to downstream header using x-mycelium-service-name key.

## Summary

The service name should be used by proxy services to track downstream api usages. Previously the service name was included only if the proxy address is configured.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

Add the service name to downstream header using x-mycelium-service-name key.

## Related Issues

No related issue.

## Checklist

- [ ] Tests added for new functionality
- [x] Existing tests pass
- [x] Code follows the project's style guidelines
- [x] Documentation has been updated (if applicable)
- [x] No new warnings introduced
- [ ] Breaking changes documented (if applicable)
- [x] Commits follow conventional commit format

## Testing

**Test Environment:**
- OS: Ubuntu 22.04
- Rust version: 1.70.0