### PR TITLE
feat(hmac-rotation)KVR versioned signing — independent rotation of HMAC + KEK (BREAKING)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3916,9 +3916,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,12 @@ zip = "2.4.2"
 # Transitive via aws-lc-rs → jsonwebtoken.
 #
 aws-lc-sys = "0.39.0"
+#
+# RUSTSEC-2026-0104: force rustls-webpki >= 0.103.13 (Reachable panic in
+# certificate revocation list parsing). Transitive via rustls → tokio-rustls
+# → tonic → opentelemetry-otlp.
+#
+rustls-webpki = "0.103.13"
 
 [workspace.metadata.release]
 

--- a/adapters/diesel/src/migration/migrate_dek.rs
+++ b/adapters/diesel/src/migration/migrate_dek.rs
@@ -1,3 +1,4 @@
+use super::tenant_iteration::{acquire_conn, load_tenants};
 use crate::{
     models::{
         config::DbPool, tenant::Tenant as TenantModel, user::User as UserModel,
@@ -48,9 +49,7 @@ pub async fn migrate_dek(
     dry_run: bool,
 ) -> Result<MigrateDekReport, MappedErrors> {
     let kek = life_cycle.derive_kek_bytes().await?;
-    let conn = &mut pool.get().map_err(|e| {
-        execution_err(format!("Failed to get DB connection: {e}"))
-    })?;
+    let conn = &mut acquire_conn(pool)?;
 
     let mut report = MigrateDekReport {
         tenants_scanned: 0,
@@ -64,21 +63,7 @@ pub async fn migrate_dek(
     // ? Load tenants to process
     // ? -----------------------------------------------------------------------
 
-    let tenants: Vec<TenantModel> = match tenant_id {
-        Some(tid) => tenant_dsl::tenant
-            .filter(tenant_model::id.eq(tid))
-            .select(TenantModel::as_select())
-            .load::<TenantModel>(conn)
-            .map_err(|e| {
-                execution_err(format!("Failed to load tenant: {e}"))
-            })?,
-        None => tenant_dsl::tenant
-            .select(TenantModel::as_select())
-            .load::<TenantModel>(conn)
-            .map_err(|e| {
-                execution_err(format!("Failed to load tenants: {e}"))
-            })?,
-    };
+    let tenants = load_tenants(conn, tenant_id)?;
 
     report.tenants_scanned = tenants.len();
 

--- a/adapters/diesel/src/migration/mod.rs
+++ b/adapters/diesel/src/migration/mod.rs
@@ -1,3 +1,7 @@
 mod migrate_dek;
+mod rotate_kek;
+mod tenant_iteration;
 
 pub use migrate_dek::{migrate_dek, MigrateDekReport};
+pub use rotate_kek::{rotate_kek, RotateKekReport};
+pub use tenant_iteration::{RowOutcome, Summary};

--- a/adapters/diesel/src/migration/rotate_kek.rs
+++ b/adapters/diesel/src/migration/rotate_kek.rs
@@ -1,0 +1,136 @@
+use super::tenant_iteration::{
+    acquire_conn, load_tenants, RowOutcome, Summary,
+};
+use crate::{
+    models::{config::DbPool, tenant::Tenant as TenantModel},
+    schema::tenant::{self as tenant_model, dsl as tenant_dsl},
+};
+
+use diesel::prelude::*;
+use myc_core::{
+    domain::utils::{unwrap_dek, wrap_dek},
+    models::AccountLifeCycle,
+};
+use mycelium_base::utils::errors::{execution_err, MappedErrors};
+
+/// Summary of a `rotate-kek` pass.
+///
+/// User-data ciphertexts (`v2:` prefixed fields under `user.mfa`,
+/// `tenant.meta`, `webhook.secret`) are **not** touched — only the
+/// per-tenant DEK wrapping is rewrapped under the new KEK.
+pub struct RotateKekReport {
+    pub from_version: i32,
+    pub to_version: i32,
+    pub summary: Summary,
+}
+
+/// Rewrap every eligible tenant's `encrypted_dek` column from an old KEK
+/// to a new KEK without touching any user-data ciphertext.
+///
+/// Eligible rows are those whose `kek_version == from_version` AND whose
+/// `encrypted_dek` is set. Rows whose `kek_version == to_version` already
+/// are reported as `RowOutcome::AlreadyDone` so the command is idempotent
+/// across re-runs. Rows in any other state are `Skipped` (they belong to a
+/// different rotation window and must be handled by the matching pair of
+/// configs).
+///
+/// # Parameters
+///
+/// - `old_config` resolves the **old** `token_secret` (used to unwrap the
+///   stored DEK).
+/// - `new_config` resolves the **new** `token_secret` (used to wrap the
+///   DEK for persistence).
+/// - `dry_run` short-circuits the UPDATE so operators can preview counts.
+#[tracing::instrument(name = "rotate_kek", skip_all)]
+pub async fn rotate_kek(
+    pool: &DbPool,
+    from_version: u32,
+    to_version: u32,
+    old_config: &AccountLifeCycle,
+    new_config: &AccountLifeCycle,
+    dry_run: bool,
+) -> Result<RotateKekReport, MappedErrors> {
+    if from_version == to_version {
+        return execution_err("rotate_kek requires from_version != to_version")
+            .as_error();
+    }
+
+    let from_version_i32 = i32::try_from(from_version).map_err(|_| {
+        execution_err(format!("from_version {from_version} exceeds i32 range",))
+    })?;
+
+    let to_version_i32 = i32::try_from(to_version).map_err(|_| {
+        execution_err(format!("to_version {to_version} exceeds i32 range",))
+    })?;
+
+    let old_kek = old_config.derive_kek_bytes().await?;
+    let new_kek = new_config.derive_kek_bytes().await?;
+
+    let conn = &mut acquire_conn(pool)?;
+
+    let tenants = load_tenants(conn, None)?;
+    let mut summary = Summary::new(dry_run);
+
+    for tenant in &tenants {
+        let outcome = rewrap_one(
+            conn,
+            tenant,
+            from_version_i32,
+            to_version_i32,
+            &old_kek,
+            &new_kek,
+            dry_run,
+        )?;
+        summary.record(outcome);
+    }
+
+    Ok(RotateKekReport {
+        from_version: from_version_i32,
+        to_version: to_version_i32,
+        summary,
+    })
+}
+
+fn rewrap_one(
+    conn: &mut PgConnection,
+    tenant: &TenantModel,
+    from_version: i32,
+    to_version: i32,
+    old_kek: &[u8; 32],
+    new_kek: &[u8; 32],
+    dry_run: bool,
+) -> Result<RowOutcome, MappedErrors> {
+    if tenant.kek_version == to_version {
+        return Ok(RowOutcome::AlreadyDone);
+    }
+
+    if tenant.kek_version != from_version {
+        return Ok(RowOutcome::Skipped);
+    }
+
+    let Some(wrapped) = tenant.encrypted_dek.as_deref() else {
+        return Ok(RowOutcome::Skipped);
+    };
+
+    let tid = tenant.id;
+    let dek = unwrap_dek(wrapped, old_kek, tid.as_bytes())?;
+    let rewrapped = wrap_dek(&dek, new_kek, tid.as_bytes())?;
+
+    if dry_run {
+        return Ok(RowOutcome::Migrated);
+    }
+
+    diesel::update(tenant_dsl::tenant.filter(tenant_model::id.eq(tid)))
+        .set((
+            tenant_model::encrypted_dek.eq(&rewrapped),
+            tenant_model::kek_version.eq(to_version),
+        ))
+        .execute(conn)
+        .map_err(|e| {
+            execution_err(format!(
+                "Failed to persist rewrapped DEK for tenant {tid}: {e}",
+            ))
+        })?;
+
+    Ok(RowOutcome::Migrated)
+}

--- a/adapters/diesel/src/migration/tenant_iteration.rs
+++ b/adapters/diesel/src/migration/tenant_iteration.rs
@@ -1,0 +1,85 @@
+use crate::{
+    models::{config::DbPool, tenant::Tenant as TenantModel},
+    schema::tenant::{self as tenant_model, dsl as tenant_dsl},
+};
+
+use diesel::prelude::*;
+use mycelium_base::utils::errors::{execution_err, MappedErrors};
+use uuid::Uuid;
+
+/// Outcome of processing a single tenant row in a migration pass.
+///
+/// Shared by both `migrate_dek` and `rotate_kek` so the two adapters
+/// classify per-row results consistently.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RowOutcome {
+    Migrated,
+    Skipped,
+    AlreadyDone,
+}
+
+/// Aggregate report produced by a per-tenant migration pass.
+#[derive(Debug, Clone, Copy)]
+pub struct Summary {
+    pub scanned: usize,
+    pub migrated: usize,
+    pub skipped: usize,
+    pub already_done: usize,
+    pub dry_run: bool,
+}
+
+impl Summary {
+    pub(crate) fn new(dry_run: bool) -> Self {
+        Self {
+            scanned: 0,
+            migrated: 0,
+            skipped: 0,
+            already_done: 0,
+            dry_run,
+        }
+    }
+
+    pub(crate) fn record(&mut self, outcome: RowOutcome) {
+        self.scanned += 1;
+        match outcome {
+            RowOutcome::Migrated => self.migrated += 1,
+            RowOutcome::Skipped => self.skipped += 1,
+            RowOutcome::AlreadyDone => self.already_done += 1,
+        }
+    }
+}
+
+/// Open a pooled connection for a migration pass.
+pub(crate) fn acquire_conn(
+    pool: &DbPool,
+) -> Result<
+    diesel::r2d2::PooledConnection<
+        diesel::r2d2::ConnectionManager<PgConnection>,
+    >,
+    MappedErrors,
+> {
+    pool.get()
+        .map_err(|e| execution_err(format!("Failed to get DB connection: {e}")))
+}
+
+/// Load every tenant (optionally restricted to a single id) using the
+/// canonical ordering so all migrators agree on the row set.
+pub(crate) fn load_tenants(
+    conn: &mut PgConnection,
+    tenant_id: Option<Uuid>,
+) -> Result<Vec<TenantModel>, MappedErrors> {
+    let Some(tid) = tenant_id else {
+        return tenant_dsl::tenant
+            .select(TenantModel::as_select())
+            .load::<TenantModel>(conn)
+            .map_err(|e| {
+                execution_err(format!("Failed to load tenants: {e}"))
+            });
+    };
+
+    tenant_dsl::tenant
+        .filter(tenant_model::id.eq(tid))
+        .select(TenantModel::as_select())
+        .load::<TenantModel>(conn)
+        .map_err(|e| execution_err(format!("Failed to load tenant: {e}")))
+}

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to this project will be documented in this file.
 
+## [unreleased]
+
+### 💥 BREAKING
+
+- *(hmac-rotation)* **Connection-string signing is now versioned (KVR).**
+  Every newly-issued connection string carries a `kvr` bean and is signed
+  with `hmacSecrets[hmacPrimaryVersion]`. Verification rejects tokens
+  missing `kvr` (MYC00030), citing an unconfigured version (MYC00031),
+  or failing HMAC comparison (MYC00032).
+
+  **Deploying this release invalidates every connection string issued
+  before the deploy.** Tokens issued pre-KVR carry no `kvr` bean and are
+  rejected with MYC00030. Users must re-authenticate. Pick a maintenance
+  window before rolling out.
+
+  The gateway **refuses to start** if `hmacPrimaryVersion` is not listed
+  in `hmacSecrets` or the set is empty — enforced at config load.
+
+  See [docs/book/src/22-hmac-key-rotation.md](../docs/book/src/22-hmac-key-rotation.md)
+  for the rotation procedure, anti-downgrade guarantee, and native error
+  code reference.
+
+### 🚀 Features
+
+- *(hmac-rotation)* Add `HmacSecretSet`/`HmacSecretEntry` models with
+  versioned lookup and startup validation.
+- *(hmac-rotation)* Wire HMAC verification into the connection-string
+  middleware so forged tokens are rejected before any DB round-trip.
+
+### 🐛 Bug Fixes
+
+### 🚜 Refactor
+
 ## [8.3.1-rc.1] - 2026-04-15
 
 ### 🚀 Features

--- a/core/src/domain/dtos/native_error_codes.rs
+++ b/core/src/domain/dtos/native_error_codes.rs
@@ -222,6 +222,33 @@ pub enum NativeErrorCodes {
     /// is_native: true
     ///
     MYC00023,
+
+    ///
+    /// code: "MYC00030",
+    /// message: "Connection string is missing the HMAC key version (KVR).",
+    /// details: "Dispatched when a connection string parses but does not carry a KVR bean; the signature cannot be located without a key version.",
+    /// is_internal: false,
+    /// is_native: true
+    ///
+    MYC00030,
+
+    ///
+    /// code: "MYC00031",
+    /// message: "Connection string references an unknown HMAC key version.",
+    /// details: "Dispatched when the KVR bean points to a version that is not listed in the configured HMAC key set (key retired or never provisioned).",
+    /// is_internal: false,
+    /// is_native: true
+    ///
+    MYC00031,
+
+    ///
+    /// code: "MYC00032",
+    /// message: "Connection string signature mismatch.",
+    /// details: "Dispatched when HMAC verification fails: the stored SIG does not match the recomputed signature under the version-selected HMAC key.",
+    /// is_internal: false,
+    /// is_native: true
+    ///
+    MYC00032,
 }
 
 impl NativeErrorCodes {
@@ -268,6 +295,9 @@ impl NativeErrorCodes {
             Self::MYC00021 => "MYC00021",
             Self::MYC00022 => "MYC00022",
             Self::MYC00023 => "MYC00023",
+            Self::MYC00030 => "MYC00030",
+            Self::MYC00031 => "MYC00031",
+            Self::MYC00032 => "MYC00032",
         }
     }
 
@@ -415,6 +445,24 @@ impl NativeErrorCodes {
                 "Totp Token invalid".to_string(),
                 true,
             )?.with_details("Indicates that the TOTP token is invalid.".to_string())),
+            Self::MYC00030 => Ok(ErrorCode::new_external_error(
+                "MYC".to_string(),
+                30,
+                "Connection string is missing the HMAC key version (KVR).".to_string(),
+                true,
+            )?.with_details("Dispatched when a connection string parses but does not carry a KVR bean; the signature cannot be located without a key version.".to_string())),
+            Self::MYC00031 => Ok(ErrorCode::new_external_error(
+                "MYC".to_string(),
+                31,
+                "Connection string references an unknown HMAC key version.".to_string(),
+                true,
+            )?.with_details("Dispatched when the KVR bean points to a version that is not listed in the configured HMAC key set (key retired or never provisioned).".to_string())),
+            Self::MYC00032 => Ok(ErrorCode::new_external_error(
+                "MYC".to_string(),
+                32,
+                "Connection string signature mismatch.".to_string(),
+                true,
+            )?.with_details("Dispatched when HMAC verification fails: the stored SIG does not match the recomputed signature under the version-selected HMAC key.".to_string())),
         }
     }
 

--- a/core/src/domain/dtos/token/connection_string/connection_string_beans.rs
+++ b/core/src/domain/dtos/token/connection_string/connection_string_beans.rs
@@ -30,6 +30,12 @@ pub enum ConnectionStringBean {
 
     /// The endpoint URL
     URL(String),
+
+    /// The HMAC key version used to sign the token (Key Version for
+    /// Rotation). Present in every token issued at/after Etapa 3 of the
+    /// HMAC rotation rollout; required by `verify_signature` to locate
+    /// the right HMAC key for constant-time comparison.
+    KVR(u32),
 }
 
 impl ToString for ConnectionStringBean {
@@ -74,6 +80,9 @@ impl ToString for ConnectionStringBean {
             }
             ConnectionStringBean::URL(endpoint) => {
                 format!("url={}", endpoint)
+            }
+            ConnectionStringBean::KVR(version) => {
+                format!("kvr={}", version)
             }
         }
     }
@@ -151,6 +160,10 @@ impl TryFrom<String> for ConnectionStringBean {
                 Ok(ConnectionStringBean::RLS(roles))
             }
             "URL" | "url" => Ok(ConnectionStringBean::URL(value.to_string())),
+            "KVR" | "kvr" => {
+                let version = value.parse::<u32>().map_err(|_| ())?;
+                Ok(ConnectionStringBean::KVR(version))
+            }
             _ => Err(()),
         }
     }
@@ -256,5 +269,39 @@ mod tests {
             ConnectionStringBean::try_from(url_bean.to_string()).unwrap(),
             url_bean
         );
+    }
+
+    #[test]
+    fn test_kvr_to_string() {
+        assert_eq!(ConnectionStringBean::KVR(0).to_string(), "kvr=0");
+        assert_eq!(ConnectionStringBean::KVR(7).to_string(), "kvr=7");
+    }
+
+    #[test]
+    fn test_kvr_try_from() {
+        assert_eq!(
+            ConnectionStringBean::try_from(
+                ConnectionStringBean::KVR(7).to_string()
+            )
+            .unwrap(),
+            ConnectionStringBean::KVR(7),
+        );
+        assert_eq!(
+            ConnectionStringBean::try_from("KVR=42".to_string()).unwrap(),
+            ConnectionStringBean::KVR(42),
+        );
+        assert!(ConnectionStringBean::try_from("kvr=abc".to_string()).is_err());
+        assert!(ConnectionStringBean::try_from("kvr=-1".to_string()).is_err());
+    }
+
+    #[test]
+    fn test_kvr_serde_roundtrip() {
+        let bean = ConnectionStringBean::KVR(7);
+        let json = serde_json::to_string(&bean).unwrap();
+        assert_eq!(json, "{\"kvr\":7}");
+
+        let decoded: ConnectionStringBean =
+            serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, bean);
     }
 }

--- a/core/src/domain/dtos/token/connection_string/user_account_connection_string.rs
+++ b/core/src/domain/dtos/token/connection_string/user_account_connection_string.rs
@@ -8,6 +8,7 @@
 use super::ConnectionStringBean;
 use crate::{
     domain::dtos::{
+        native_error_codes::NativeErrorCodes,
         security_group::PermissionedRole,
         token::{HmacSha256, ScopedBehavior, ServiceAccountRelatedMeta},
     },
@@ -58,6 +59,8 @@ impl UserAccountScope {
         if let Some(subscription_account_id) = subscription_account_id {
             beans.push(ConnectionStringBean::SID(subscription_account_id));
         }
+
+        beans.push(ConnectionStringBean::KVR(config.hmac_primary_version));
 
         let mut self_signed_scope = Self(beans);
 
@@ -132,40 +135,83 @@ impl UserAccountScope {
         })
     }
 
+    /// Return the HMAC key version (KVR bean) carried by the scope, if
+    /// any.
+    #[tracing::instrument(name = "get_kvr", skip(self))]
+    fn get_kvr(&self) -> Option<u32> {
+        self.0.iter().find_map(|bean| {
+            if let ConnectionStringBean::KVR(version) = bean {
+                return Some(*version);
+            }
+
+            None
+        })
+    }
+
     /// Verify that the scope's `SIG` bean matches the HMAC of the other
-    /// beans under the currently-configured HMAC key.
+    /// beans under the HMAC key identified by the `KVR` bean.
     ///
-    /// Etapa 1 wires the HMAC key resolver (with fallback to
-    /// `token_secret`); Etapa 3 will upgrade the key lookup to per-version
-    /// (KVR) and add an anti-downgrade guarantee. The method is added now
-    /// so the verification path exists as a no-op shim — the request
-    /// middleware will start calling it in Etapa 3.
+    /// Failure modes map to native error codes so callers (middleware,
+    /// audit logs) can discriminate reasons:
+    ///
+    /// - `MYC00030` — the token is missing the `KVR` bean.
+    /// - `MYC00031` — the version referenced by `KVR` is not in the
+    ///   configured key set (retired or never provisioned).
+    /// - `MYC00032` — HMAC recomputation does not match the stored `SIG`.
+    ///
+    /// The KVR value is part of the HMAC input (via
+    /// `serialize_beans_for_hmac`), so tampering with it yields
+    /// `MYC00032` rather than a false success.
     #[tracing::instrument(name = "verify_signature", skip_all)]
     pub async fn verify_signature(
         &self,
         config: &AccountLifeCycle,
     ) -> Result<(), MappedErrors> {
         let Some(stored_hex) = self.get_signature() else {
-            return dto_err("missing signature").as_error();
+            return dto_err("connection_string_missing_signature")
+                .with_code(NativeErrorCodes::MYC00030)
+                .with_exp_true()
+                .as_error();
+        };
+
+        let Some(version) = self.get_kvr() else {
+            return dto_err("connection_string_missing_key_version")
+                .with_code(NativeErrorCodes::MYC00030)
+                .with_exp_true()
+                .as_error();
         };
 
         let expected = hex::decode(stored_hex.as_bytes()).map_err(|err| {
-            dto_err(format!("invalid signature encoding: {err}"))
+            dto_err(format!("invalid_signature_encoding: {err}"))
+                .with_code(NativeErrorCodes::MYC00032)
+                .with_exp_true()
         })?;
 
+        let key_bytes = config
+            .hmac_signing_key_for_version(version)
+            .await
+            .map_err(|_| {
+                dto_err(format!("hmac_key_version_not_configured: {version}",))
+                    .with_code(NativeErrorCodes::MYC00031)
+                    .with_exp_true()
+            })?;
+
         let payload = serialize_beans_for_hmac(&self.0);
-        let key_bytes = config.hmac_signing_key_bytes().await?;
 
         let mut mac =
             HmacSha256::new_from_slice(&key_bytes).map_err(|err| {
                 tracing::error!("Could not create HMAC: {err}");
-                dto_err("Unable to verify signature")
+                dto_err("unable_to_verify_signature")
+                    .with_code(NativeErrorCodes::MYC00032)
             })?;
 
         mac.update(payload.as_bytes());
 
-        mac.verify_slice(&expected)
-            .map_err(|_| dto_err("signature mismatch"))?;
+        mac.verify_slice(&expected).map_err(|_| {
+            dto_err("connection_string_signature_mismatch")
+                .with_code(NativeErrorCodes::MYC00032)
+                .with_exp_true()
+        })?;
 
         Ok(())
     }
@@ -194,22 +240,21 @@ impl ScopedBehavior for UserAccountScope {
     /// Sign the token with secret and data
     ///
     /// Add or replace a signature to self with the HMAC of the data and the
-    /// secret
+    /// secret.
     ///
-    /// The HMAC key is `AccountLifeCycle::hmac_secret`, falling back to
-    /// `token_secret` when `hmac_secret` is not configured (Etapa 1+2 of
-    /// the HMAC rotation rollout). While the fallback is active, rotating
-    /// `token_secret` also invalidates every signature previously produced
-    /// here, and there is no re-signing path. See
-    /// `AccountLifeCycle::derive_kek_bytes` for the full list of
-    /// `token_secret` consumers and rotation caveats.
+    /// The HMAC key is read from `AccountLifeCycle::hmac_primary_signing_key`,
+    /// which returns the `(version, key_bytes)` pair tied to the current
+    /// `hmac_primary_version`. `UserAccountScope::new` pushes a matching
+    /// `KVR` bean **before** this method runs so the version is included in
+    /// the HMAC input (anti-downgrade guarantee — see
+    /// `docs/book/src/22-hmac-key-rotation.md`).
     #[tracing::instrument(name = "sign_token", skip(self, config))]
     async fn sign_token(
         &mut self,
         config: AccountLifeCycle,
         extra_data: Option<String>,
     ) -> Result<String, MappedErrors> {
-        let key_bytes = config.hmac_signing_key_bytes().await?;
+        let (_version, key_bytes) = config.hmac_primary_signing_key().await?;
 
         let mut mac = match HmacSha256::new_from_slice(&key_bytes) {
             Ok(mac) => mac,
@@ -350,7 +395,10 @@ impl UserAccountConnectionString {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::dtos::email::Email;
+    use crate::{
+        domain::dtos::email::Email,
+        models::{HmacSecretEntry, HmacSecretSet},
+    };
 
     use myc_config::secret_resolver::SecretResolver;
 
@@ -358,7 +406,17 @@ mod tests {
     // ? Helpers
     // ? -----------------------------------------------------------------
 
-    fn base_config() -> AccountLifeCycle {
+    fn make_entry(version: u32, value: &str) -> HmacSecretEntry {
+        HmacSecretEntry {
+            version,
+            secret: SecretResolver::Value(value.to_string()),
+        }
+    }
+
+    fn base_config_with_versions(
+        primary: u32,
+        entries: Vec<HmacSecretEntry>,
+    ) -> AccountLifeCycle {
         AccountLifeCycle {
             domain_url: None,
             domain_name: SecretResolver::Value("test".to_string()),
@@ -369,10 +427,15 @@ mod tests {
             support_name: None,
             support_email: SecretResolver::Value("test".to_string()),
             token_secret: SecretResolver::Value(
-                "fallback-token-secret".to_string(),
+                "ab4c0550-310b-4218-9edf-58edc87979b9".to_string(),
             ),
-            hmac_secret: None,
+            hmac_primary_version: primary,
+            hmac_secrets: HmacSecretSet::new(entries),
         }
+    }
+
+    fn base_config() -> AccountLifeCycle {
+        base_config_with_versions(1, vec![make_entry(1, "k-v1")])
     }
 
     async fn issue_scope(
@@ -390,57 +453,105 @@ mod tests {
     }
 
     // ? -----------------------------------------------------------------
-    // ? Etapa 1 — sign / verify / fallback coverage
+    // ? Etapa 3 — KVR contract coverage
     // ? -----------------------------------------------------------------
 
     #[tokio::test]
-    async fn test_sign_then_verify_with_hmac_secret_present(
-    ) -> Result<(), MappedErrors> {
-        let mut config = base_config();
-        config.hmac_secret =
-            Some(SecretResolver::Value("dedicated-hmac-secret".to_string()));
+    async fn signs_with_primary_then_verifies() -> Result<(), MappedErrors> {
+        let config = base_config_with_versions(
+            2,
+            vec![make_entry(1, "k-v1"), make_entry(2, "k-v2")],
+        );
 
         let scope = issue_scope(config.clone()).await?;
         scope.verify_signature(&config).await?;
 
+        assert_eq!(
+            scope.get_kvr(),
+            Some(2),
+            "issued scope must carry KVR=primary",
+        );
         assert!(scope.get_signature().is_some());
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_sign_then_verify_falls_back_to_token_secret(
-    ) -> Result<(), MappedErrors> {
-        let config = base_config();
-        assert!(config.hmac_secret.is_none());
+    async fn verifies_non_primary_known_version() -> Result<(), MappedErrors> {
+        let issuing_config =
+            base_config_with_versions(1, vec![make_entry(1, "k-v1")]);
 
-        let scope = issue_scope(config.clone()).await?;
-        scope.verify_signature(&config).await?;
+        let scope = issue_scope(issuing_config).await?;
+        assert_eq!(scope.get_kvr(), Some(1));
 
+        let rotated_config = base_config_with_versions(
+            2,
+            vec![make_entry(1, "k-v1"), make_entry(2, "k-v2")],
+        );
+
+        scope.verify_signature(&rotated_config).await?;
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_verify_rejects_tampered_payload() -> Result<(), MappedErrors>
-    {
+    async fn rejects_unknown_version() -> Result<(), MappedErrors> {
+        let issuing_config = base_config_with_versions(
+            2,
+            vec![make_entry(1, "k-v1"), make_entry(2, "k-v2")],
+        );
+        let scope = issue_scope(issuing_config).await?;
+        assert_eq!(scope.get_kvr(), Some(2));
+
+        let retired_config =
+            base_config_with_versions(1, vec![make_entry(1, "k-v1")]);
+
+        let outcome = scope.verify_signature(&retired_config).await;
+        let err = outcome.expect_err("retired key must fail verification");
+        assert_eq!(err.code().to_string(), "MYC00031");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn rejects_missing_kvr() -> Result<(), MappedErrors> {
         let config = base_config();
         let scope = issue_scope(config.clone()).await?;
 
-        let mut tampered_beans = scope.get_scope_beans();
-        let mut aid_swapped = false;
-        for bean in tampered_beans.iter_mut() {
-            if let ConnectionStringBean::AID(_) = bean {
-                *bean = ConnectionStringBean::AID(Uuid::new_v4());
-                aid_swapped = true;
-                break;
-            }
-        }
-        assert!(aid_swapped, "expected AID bean in issued scope");
+        let stripped: Vec<ConnectionStringBean> = scope
+            .get_scope_beans()
+            .into_iter()
+            .filter(|bean| !matches!(bean, ConnectionStringBean::KVR(_)))
+            .collect();
 
-        let tampered_scope = UserAccountScope(tampered_beans);
+        let scope_without_kvr = UserAccountScope(stripped);
+        let outcome = scope_without_kvr.verify_signature(&config).await;
 
+        let err = outcome.expect_err("missing KVR must fail verification");
+        assert_eq!(err.code().to_string(), "MYC00030");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn rejects_tampered_kvr_anti_downgrade() -> Result<(), MappedErrors> {
+        let config = base_config_with_versions(
+            2,
+            vec![make_entry(1, "k-v1"), make_entry(2, "k-v2")],
+        );
+        let scope = issue_scope(config.clone()).await?;
+
+        let tampered: Vec<ConnectionStringBean> = scope
+            .get_scope_beans()
+            .into_iter()
+            .map(|bean| match bean {
+                ConnectionStringBean::KVR(_) => ConnectionStringBean::KVR(1),
+                other => other,
+            })
+            .collect();
+
+        let tampered_scope = UserAccountScope(tampered);
         let outcome = tampered_scope.verify_signature(&config).await;
-        assert!(outcome.is_err(), "tampered scope must fail verification");
 
+        let err =
+            outcome.expect_err("downgrade attempt must fail verification");
+        assert_eq!(err.code().to_string(), "MYC00032");
         Ok(())
     }
 

--- a/core/src/domain/dtos/token/connection_string/user_account_connection_string.rs
+++ b/core/src/domain/dtos/token/connection_string/user_account_connection_string.rs
@@ -131,6 +131,63 @@ impl UserAccountScope {
             None
         })
     }
+
+    /// Verify that the scope's `SIG` bean matches the HMAC of the other
+    /// beans under the currently-configured HMAC key.
+    ///
+    /// Etapa 1 wires the HMAC key resolver (with fallback to
+    /// `token_secret`); Etapa 3 will upgrade the key lookup to per-version
+    /// (KVR) and add an anti-downgrade guarantee. The method is added now
+    /// so the verification path exists as a no-op shim — the request
+    /// middleware will start calling it in Etapa 3.
+    #[tracing::instrument(name = "verify_signature", skip_all)]
+    pub async fn verify_signature(
+        &self,
+        config: &AccountLifeCycle,
+    ) -> Result<(), MappedErrors> {
+        let Some(stored_hex) = self.get_signature() else {
+            return dto_err("missing signature").as_error();
+        };
+
+        let expected = hex::decode(stored_hex.as_bytes()).map_err(|err| {
+            dto_err(format!("invalid signature encoding: {err}"))
+        })?;
+
+        let payload = serialize_beans_for_hmac(&self.0);
+        let key_bytes = config.hmac_signing_key_bytes().await?;
+
+        let mut mac =
+            HmacSha256::new_from_slice(&key_bytes).map_err(|err| {
+                tracing::error!("Could not create HMAC: {err}");
+                dto_err("Unable to verify signature")
+            })?;
+
+        mac.update(payload.as_bytes());
+
+        mac.verify_slice(&expected)
+            .map_err(|_| dto_err("signature mismatch"))?;
+
+        Ok(())
+    }
+}
+
+/// Serialise a bean list for HMAC input.
+///
+/// Filters the `SIG` bean out (so signing and verification agree on the
+/// payload) and then applies the same base64-of-joined-pairs encoding as
+/// `UserAccountScope::to_string`. Both `sign_token` and `verify_signature`
+/// must route through this helper so the two paths stay in lock-step.
+fn serialize_beans_for_hmac(beans: &[ConnectionStringBean]) -> String {
+    let raw_string = beans
+        .iter()
+        .filter(|bean| !matches!(bean, ConnectionStringBean::SIG(_)))
+        .fold(String::new(), |acc, bean| {
+            format!("{}{};", acc, bean.to_string())
+        })
+        .trim_end_matches(';')
+        .to_string();
+
+    general_purpose::STANDARD.encode(raw_string)
 }
 
 impl ScopedBehavior for UserAccountScope {
@@ -139,11 +196,11 @@ impl ScopedBehavior for UserAccountScope {
     /// Add or replace a signature to self with the HMAC of the data and the
     /// secret
     ///
-    /// The HMAC key is `AccountLifeCycle::token_secret` — the same secret
-    /// used to derive the envelope-encryption KEK. Rotating `token_secret`
-    /// therefore invalidates every signature previously produced here, and
-    /// there is no re-signing path (signatures carry user-facing tokens
-    /// that are already in circulation). See
+    /// The HMAC key is `AccountLifeCycle::hmac_secret`, falling back to
+    /// `token_secret` when `hmac_secret` is not configured (Etapa 1+2 of
+    /// the HMAC rotation rollout). While the fallback is active, rotating
+    /// `token_secret` also invalidates every signature previously produced
+    /// here, and there is no re-signing path. See
     /// `AccountLifeCycle::derive_kek_bytes` for the full list of
     /// `token_secret` consumers and rotation caveats.
     #[tracing::instrument(name = "sign_token", skip(self, config))]
@@ -152,9 +209,9 @@ impl ScopedBehavior for UserAccountScope {
         config: AccountLifeCycle,
         extra_data: Option<String>,
     ) -> Result<String, MappedErrors> {
-        let secret = config.token_secret.async_get_or_error().await;
+        let key_bytes = config.hmac_signing_key_bytes().await?;
 
-        let mut mac = match HmacSha256::new_from_slice(secret?.as_bytes()) {
+        let mut mac = match HmacSha256::new_from_slice(&key_bytes) {
             Ok(mac) => mac,
             Err(err) => {
                 tracing::error!("Could not create HMAC: {}", err);
@@ -162,7 +219,7 @@ impl ScopedBehavior for UserAccountScope {
             }
         };
 
-        mac.update(self.to_string().as_bytes());
+        mac.update(serialize_beans_for_hmac(&self.0).as_bytes());
         let result = mac.finalize();
 
         let hmac_bytes = result.into_bytes();
@@ -297,14 +354,12 @@ mod tests {
 
     use myc_config::secret_resolver::SecretResolver;
 
-    /// Test new signed token
-    ///
-    /// Test the creation of a new signed token with the
-    /// AccountScopedConnectionStringMeta struct and test if the signature and
-    /// the further password check are correct
-    #[tokio::test]
-    async fn test_new_signed_token() {
-        let config = AccountLifeCycle {
+    // ? -----------------------------------------------------------------
+    // ? Helpers
+    // ? -----------------------------------------------------------------
+
+    fn base_config() -> AccountLifeCycle {
+        AccountLifeCycle {
             domain_url: None,
             domain_name: SecretResolver::Value("test".to_string()),
             locale: None,
@@ -313,8 +368,90 @@ mod tests {
             noreply_email: SecretResolver::Value("test".to_string()),
             support_name: None,
             support_email: SecretResolver::Value("test".to_string()),
-            token_secret: SecretResolver::Value("test".to_string()),
-        };
+            token_secret: SecretResolver::Value(
+                "fallback-token-secret".to_string(),
+            ),
+            hmac_secret: None,
+        }
+    }
+
+    async fn issue_scope(
+        config: AccountLifeCycle,
+    ) -> Result<UserAccountScope, MappedErrors> {
+        UserAccountScope::new(
+            Uuid::new_v4(),
+            Local::now(),
+            None,
+            None,
+            None,
+            config,
+        )
+        .await
+    }
+
+    // ? -----------------------------------------------------------------
+    // ? Etapa 1 — sign / verify / fallback coverage
+    // ? -----------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_sign_then_verify_with_hmac_secret_present(
+    ) -> Result<(), MappedErrors> {
+        let mut config = base_config();
+        config.hmac_secret =
+            Some(SecretResolver::Value("dedicated-hmac-secret".to_string()));
+
+        let scope = issue_scope(config.clone()).await?;
+        scope.verify_signature(&config).await?;
+
+        assert!(scope.get_signature().is_some());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_sign_then_verify_falls_back_to_token_secret(
+    ) -> Result<(), MappedErrors> {
+        let config = base_config();
+        assert!(config.hmac_secret.is_none());
+
+        let scope = issue_scope(config.clone()).await?;
+        scope.verify_signature(&config).await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_verify_rejects_tampered_payload() -> Result<(), MappedErrors>
+    {
+        let config = base_config();
+        let scope = issue_scope(config.clone()).await?;
+
+        let mut tampered_beans = scope.get_scope_beans();
+        let mut aid_swapped = false;
+        for bean in tampered_beans.iter_mut() {
+            if let ConnectionStringBean::AID(_) = bean {
+                *bean = ConnectionStringBean::AID(Uuid::new_v4());
+                aid_swapped = true;
+                break;
+            }
+        }
+        assert!(aid_swapped, "expected AID bean in issued scope");
+
+        let tampered_scope = UserAccountScope(tampered_beans);
+
+        let outcome = tampered_scope.verify_signature(&config).await;
+        assert!(outcome.is_err(), "tampered scope must fail verification");
+
+        Ok(())
+    }
+
+    /// Test new signed token
+    ///
+    /// Test the creation of a new signed token with the
+    /// AccountScopedConnectionStringMeta struct and test if the signature and
+    /// the further password check are correct
+    #[tokio::test]
+    async fn test_new_signed_token() {
+        let config = base_config();
 
         let account_scope = UserAccountScope::new(
             Uuid::new_v4(),

--- a/core/src/domain/dtos/user.rs
+++ b/core/src/domain/dtos/user.rs
@@ -523,7 +523,10 @@ check if user is internal or not. The user provider is None.",
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{domain::utils::generate_dek, models::AccountLifeCycle};
+    use crate::{
+        domain::utils::generate_dek,
+        models::{AccountLifeCycle, HmacSecretEntry, HmacSecretSet},
+    };
     use myc_config::secret_resolver::SecretResolver;
 
     fn make_config() -> AccountLifeCycle {
@@ -539,7 +542,11 @@ mod tests {
             token_secret: SecretResolver::Value(
                 "ab4c0550-310b-4218-9edf-58edc87979b9".to_string(),
             ),
-            hmac_secret: None,
+            hmac_primary_version: 1,
+            hmac_secrets: HmacSecretSet::new(vec![HmacSecretEntry {
+                version: 1,
+                secret: SecretResolver::Value("test-hmac".to_string()),
+            }]),
         }
     }
 

--- a/core/src/domain/dtos/user.rs
+++ b/core/src/domain/dtos/user.rs
@@ -539,6 +539,7 @@ mod tests {
             token_secret: SecretResolver::Value(
                 "ab4c0550-310b-4218-9edf-58edc87979b9".to_string(),
             ),
+            hmac_secret: None,
         }
     }
 

--- a/core/src/domain/utils/encrypt_string.rs
+++ b/core/src/domain/utils/encrypt_string.rs
@@ -177,6 +177,7 @@ mod tests {
             token_secret: SecretResolver::Value(
                 "550e8400-e29b-41d4-a716-446655440000".to_string(),
             ),
+            hmac_secret: None,
         }
     }
 

--- a/core/src/domain/utils/encrypt_string.rs
+++ b/core/src/domain/utils/encrypt_string.rs
@@ -157,7 +157,10 @@ async fn build_aes_key(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::utils::envelope::{encrypt_with_dek, generate_dek};
+    use crate::{
+        domain::utils::envelope::{encrypt_with_dek, generate_dek},
+        models::{HmacSecretEntry, HmacSecretSet},
+    };
     use myc_config::secret_resolver::SecretResolver;
 
     fn make_config() -> AccountLifeCycle {
@@ -177,7 +180,11 @@ mod tests {
             token_secret: SecretResolver::Value(
                 "550e8400-e29b-41d4-a716-446655440000".to_string(),
             ),
-            hmac_secret: None,
+            hmac_primary_version: 1,
+            hmac_secrets: HmacSecretSet::new(vec![HmacSecretEntry {
+                version: 1,
+                secret: SecretResolver::Value("test-hmac".to_string()),
+            }]),
         }
     }
 

--- a/core/src/models/account_life_cycle_config.rs
+++ b/core/src/models/account_life_cycle_config.rs
@@ -1,4 +1,4 @@
-use crate::domain::utils::derive_key_from_uuid;
+use crate::{domain::utils::derive_key_from_uuid, models::HmacSecretSet};
 
 use myc_config::secret_resolver::SecretResolver;
 use mycelium_base::utils::errors::{dto_err, MappedErrors};
@@ -45,14 +45,15 @@ pub struct AccountLifeCycle {
     /// Toke secret is used to sign tokens
     pub(crate) token_secret: SecretResolver<String>,
 
-    /// HMAC secret used to sign connection-string tokens.
-    ///
-    /// Optional during Etapa 1+2 of the HMAC key rotation rollout: when
-    /// absent, `hmac_signing_key_bytes` falls back to `token_secret` and
-    /// emits a structured `warn!` line so operators can audit deployments
-    /// still running on the legacy shared secret. Will become required in
-    /// Etapa 3.
-    pub(crate) hmac_secret: Option<SecretResolver<String>>,
+    /// Version of the HMAC key used to sign every newly-issued
+    /// connection string. Must be present in `hmac_secrets` — enforced by
+    /// `validate_hmac_config` at startup.
+    pub(crate) hmac_primary_version: u32,
+
+    /// Versioned set of HMAC keys. All entries are available for
+    /// verification; only the entry matching `hmac_primary_version` is
+    /// used for signing.
+    pub(crate) hmac_secrets: HmacSecretSet,
 }
 
 impl AccountLifeCycle {
@@ -88,10 +89,11 @@ impl AccountLifeCycle {
     /// - `core/src/domain/dtos/user.rs` (`Totp::decrypt_me`) — v1 legacy
     ///   decrypt path.
     /// - `core/src/domain/dtos/token/connection_string/user_account_connection_string.rs`
-    ///   — HMAC signing consumes `hmac_secret` (with fallback to
-    ///   `token_secret` when `hmac_secret` is unset). While a deployment
-    ///   still relies on the fallback, rotating `token_secret` also
-    ///   invalidates every active connection-string signature.
+    ///   — HMAC signing consumes `hmac_secrets[hmac_primary_version]`
+    ///   (no fallback to `token_secret`). Rotating `token_secret`
+    ///   therefore no longer invalidates connection strings; HMAC key
+    ///   rotation is a separate, versioned procedure documented in
+    ///   `docs/book/src/22-hmac-key-rotation.md`.
     ///
     /// # KEK rotation (not yet implemented — planned as `myc-cli rotate-kek`)
     ///
@@ -117,15 +119,6 @@ impl AccountLifeCycle {
         Ok(derive_key_from_uuid(&key_uuid))
     }
 
-    /// Return the raw HMAC signing key bytes used for connection-string
-    /// signatures.
-    ///
-    /// Reads `hmac_secret` when it is configured. When it is absent, falls
-    /// back to `token_secret` and emits a single structured `warn!` line
-    /// per call so operators can audit deployments still riding the
-    /// legacy shared secret. The fallback path exists only during
-    /// Etapa 1 and Etapa 2 of the HMAC rotation rollout; Etapa 3 removes
-    /// it.
     /// Return a clone of this config with `token_secret` replaced by the
     /// supplied literal value.
     ///
@@ -139,21 +132,45 @@ impl AccountLifeCycle {
         clone
     }
 
-    #[tracing::instrument(name = "hmac_signing_key_bytes", skip_all)]
-    pub(crate) async fn hmac_signing_key_bytes(
+    /// Return the HMAC signing-key bytes for a specific version.
+    ///
+    /// Used by `verify_signature` to locate the key matching the `KVR`
+    /// bean carried by the connection string — including tokens issued
+    /// under a previous primary that has not yet been retired.
+    #[tracing::instrument(name = "hmac_signing_key_for_version", skip_all)]
+    pub(crate) async fn hmac_signing_key_for_version(
         &self,
+        version: u32,
     ) -> Result<Vec<u8>, MappedErrors> {
-        let Some(resolver) = self.hmac_secret.as_ref() else {
-            tracing::warn!(
-                hmac_secret_missing_fallback_to_token_secret = true,
-                "hmac_secret not configured; falling back to token_secret \
-                 for connection-string signing",
-            );
-            let secret = self.token_secret.async_get_or_error().await?;
-            return Ok(secret.into_bytes());
+        let Some(entry) = self.hmac_secrets.lookup(version) else {
+            return dto_err(format!(
+                "hmac_key_version_not_configured: {version}",
+            ))
+            .as_error();
         };
 
-        let secret = resolver.async_get_or_error().await?;
+        let secret = entry.secret.async_get_or_error().await?;
         Ok(secret.into_bytes())
+    }
+
+    /// Return the current primary `(version, key_bytes)` used for
+    /// signing. `sign_token` consumes this so the KVR bean and the HMAC
+    /// key stay aligned.
+    #[tracing::instrument(name = "hmac_primary_signing_key", skip_all)]
+    pub(crate) async fn hmac_primary_signing_key(
+        &self,
+    ) -> Result<(u32, Vec<u8>), MappedErrors> {
+        let version = self.hmac_primary_version;
+        let key = self.hmac_signing_key_for_version(version).await?;
+        Ok((version, key))
+    }
+
+    /// Check that `hmac_primary_version` is present in `hmac_secrets` and
+    /// that the set is internally consistent.
+    ///
+    /// Invoked during config load; a failure aborts startup so the gateway
+    /// never runs without a reachable primary HMAC key.
+    pub fn validate_hmac_config(&self) -> Result<(), MappedErrors> {
+        self.hmac_secrets.validate(self.hmac_primary_version)
     }
 }

--- a/core/src/models/account_life_cycle_config.rs
+++ b/core/src/models/account_life_cycle_config.rs
@@ -44,6 +44,15 @@ pub struct AccountLifeCycle {
     ///
     /// Toke secret is used to sign tokens
     pub(crate) token_secret: SecretResolver<String>,
+
+    /// HMAC secret used to sign connection-string tokens.
+    ///
+    /// Optional during Etapa 1+2 of the HMAC key rotation rollout: when
+    /// absent, `hmac_signing_key_bytes` falls back to `token_secret` and
+    /// emits a structured `warn!` line so operators can audit deployments
+    /// still running on the legacy shared secret. Will become required in
+    /// Etapa 3.
+    pub(crate) hmac_secret: Option<SecretResolver<String>>,
 }
 
 impl AccountLifeCycle {
@@ -79,7 +88,10 @@ impl AccountLifeCycle {
     /// - `core/src/domain/dtos/user.rs` (`Totp::decrypt_me`) — v1 legacy
     ///   decrypt path.
     /// - `core/src/domain/dtos/token/connection_string/user_account_connection_string.rs`
-    ///   — HMAC signing (no migration path; signatures get invalidated).
+    ///   — HMAC signing consumes `hmac_secret` (with fallback to
+    ///   `token_secret` when `hmac_secret` is unset). While a deployment
+    ///   still relies on the fallback, rotating `token_secret` also
+    ///   invalidates every active connection-string signature.
     ///
     /// # KEK rotation (not yet implemented — planned as `myc-cli rotate-kek`)
     ///
@@ -103,5 +115,32 @@ impl AccountLifeCycle {
             dto_err(format!("failed_to_parse_token_secret_as_uuid: {err}"))
         })?;
         Ok(derive_key_from_uuid(&key_uuid))
+    }
+
+    /// Return the raw HMAC signing key bytes used for connection-string
+    /// signatures.
+    ///
+    /// Reads `hmac_secret` when it is configured. When it is absent, falls
+    /// back to `token_secret` and emits a single structured `warn!` line
+    /// per call so operators can audit deployments still riding the
+    /// legacy shared secret. The fallback path exists only during
+    /// Etapa 1 and Etapa 2 of the HMAC rotation rollout; Etapa 3 removes
+    /// it.
+    #[tracing::instrument(name = "hmac_signing_key_bytes", skip_all)]
+    pub(crate) async fn hmac_signing_key_bytes(
+        &self,
+    ) -> Result<Vec<u8>, MappedErrors> {
+        let Some(resolver) = self.hmac_secret.as_ref() else {
+            tracing::warn!(
+                hmac_secret_missing_fallback_to_token_secret = true,
+                "hmac_secret not configured; falling back to token_secret \
+                 for connection-string signing",
+            );
+            let secret = self.token_secret.async_get_or_error().await?;
+            return Ok(secret.into_bytes());
+        };
+
+        let secret = resolver.async_get_or_error().await?;
+        Ok(secret.into_bytes())
     }
 }

--- a/core/src/models/account_life_cycle_config.rs
+++ b/core/src/models/account_life_cycle_config.rs
@@ -126,6 +126,19 @@ impl AccountLifeCycle {
     /// legacy shared secret. The fallback path exists only during
     /// Etapa 1 and Etapa 2 of the HMAC rotation rollout; Etapa 3 removes
     /// it.
+    /// Return a clone of this config with `token_secret` replaced by the
+    /// supplied literal value.
+    ///
+    /// Used by `myc-cli rotate-kek` to construct the **old** KEK's
+    /// resolver from an operator-supplied env var while keeping the
+    /// **new** KEK's resolver in the normal config file. All other fields
+    /// are unchanged.
+    pub fn with_token_secret_override(&self, token_secret: String) -> Self {
+        let mut clone = self.clone();
+        clone.token_secret = SecretResolver::Value(token_secret);
+        clone
+    }
+
     #[tracing::instrument(name = "hmac_signing_key_bytes", skip_all)]
     pub(crate) async fn hmac_signing_key_bytes(
         &self,

--- a/core/src/models/config.rs
+++ b/core/src/models/config.rs
@@ -31,7 +31,10 @@ impl CoreConfig {
         }
 
         match load_config_from_file::<TmpConfig>(file) {
-            Ok(config) => Ok(config.core),
+            Ok(config) => {
+                config.core.account_life_cycle.validate_hmac_config()?;
+                Ok(config.core)
+            }
             Err(err) => Err(err),
         }
     }

--- a/core/src/models/hmac_secret_set.rs
+++ b/core/src/models/hmac_secret_set.rs
@@ -1,0 +1,115 @@
+use myc_config::secret_resolver::SecretResolver;
+use mycelium_base::utils::errors::{dto_err, MappedErrors};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
+/// A single HMAC key identified by its rotation version.
+///
+/// The version is embedded in every newly-signed connection string (via
+/// the `KVR` bean) so verification can locate the right key at request
+/// time — including for signatures issued under a previous primary.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct HmacSecretEntry {
+    pub version: u32,
+    pub secret: SecretResolver<String>,
+}
+
+/// Versioned set of HMAC keys available for connection-string signing
+/// and verification.
+///
+/// First-class collection (object-calisthenics rule) — owns the
+/// invariant that versions are unique and that lookups go through
+/// `lookup(version)`. The primary write version lives on
+/// `AccountLifeCycle::hmac_primary_version` and is cross-validated
+/// against this set at startup.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(transparent)]
+pub struct HmacSecretSet(Vec<HmacSecretEntry>);
+
+impl HmacSecretSet {
+    pub fn new(entries: Vec<HmacSecretEntry>) -> Self {
+        Self(entries)
+    }
+
+    /// Look up the entry for `version`, if any.
+    pub fn lookup(&self, version: u32) -> Option<&HmacSecretEntry> {
+        self.0.iter().find(|entry| entry.version == version)
+    }
+
+    /// Validate the set against a declared primary version.
+    ///
+    /// Fails if the set is empty, if any two entries share a version, or
+    /// if `primary` is not present in the set.
+    pub fn validate(&self, primary: u32) -> Result<(), MappedErrors> {
+        if self.0.is_empty() {
+            return dto_err("hmac_secrets_set_is_empty").as_error();
+        }
+
+        let mut seen: HashSet<u32> = HashSet::with_capacity(self.0.len());
+        for entry in &self.0 {
+            if !seen.insert(entry.version) {
+                return dto_err(format!(
+                    "hmac_secrets_duplicate_version: {}",
+                    entry.version,
+                ))
+                .as_error();
+            }
+        }
+
+        if !seen.contains(&primary) {
+            return dto_err(format!(
+                "hmac_primary_version_not_in_set: {primary}",
+            ))
+            .as_error();
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(version: u32, value: &str) -> HmacSecretEntry {
+        HmacSecretEntry {
+            version,
+            secret: SecretResolver::Value(value.to_string()),
+        }
+    }
+
+    #[test]
+    fn validate_rejects_missing_primary() {
+        let set = HmacSecretSet::new(vec![entry(1, "k1")]);
+        let outcome = set.validate(2);
+        assert!(outcome.is_err());
+    }
+
+    #[test]
+    fn validate_rejects_duplicate_versions() {
+        let set = HmacSecretSet::new(vec![entry(1, "k1"), entry(1, "k1-bis")]);
+        let outcome = set.validate(1);
+        assert!(outcome.is_err());
+    }
+
+    #[test]
+    fn validate_accepts_minimal_valid_set() {
+        let set = HmacSecretSet::new(vec![entry(1, "k1")]);
+        set.validate(1).expect("single-entry set is valid");
+    }
+
+    #[test]
+    fn lookup_returns_some() {
+        let set = HmacSecretSet::new(vec![entry(1, "k1"), entry(2, "k2")]);
+        let found = set.lookup(2);
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().version, 2);
+    }
+
+    #[test]
+    fn lookup_returns_none_for_unknown() {
+        let set = HmacSecretSet::new(vec![entry(1, "k1")]);
+        assert!(set.lookup(99).is_none());
+    }
+}

--- a/core/src/models/mod.rs
+++ b/core/src/models/mod.rs
@@ -1,7 +1,9 @@
 mod account_life_cycle_config;
 mod config;
+mod hmac_secret_set;
 mod webhook_config;
 
 pub use account_life_cycle_config::*;
 pub use config::*;
+pub use hmac_secret_set::*;
 pub use webhook_config::*;

--- a/core/src/use_cases/support/dispatch_notification.rs
+++ b/core/src/use_cases/support/dispatch_notification.rs
@@ -446,7 +446,13 @@ mod tests {
                 "support@test.com".to_string(),
             ),
             token_secret: SecretResolver::Value("test-secret".to_string()),
-            hmac_secret: None,
+            hmac_primary_version: 1,
+            hmac_secrets: crate::models::HmacSecretSet::new(vec![
+                crate::models::HmacSecretEntry {
+                    version: 1,
+                    secret: SecretResolver::Value("test-hmac".to_string()),
+                },
+            ]),
         }
     }
 

--- a/core/src/use_cases/support/dispatch_notification.rs
+++ b/core/src/use_cases/support/dispatch_notification.rs
@@ -446,6 +446,7 @@ mod tests {
                 "support@test.com".to_string(),
             ),
             token_secret: SecretResolver::Value("test-secret".to_string()),
+            hmac_secret: None,
         }
     }
 

--- a/docs/book/po/pt-BR.po
+++ b/docs/book/po/pt-BR.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Mycelium API Gateway Documentation\n"
-"POT-Creation-Date: 2026-04-21T18:19:19-03:00\n"
+"POT-Creation-Date: 2026-04-23T12:51:17-03:00\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -7847,13 +7847,17 @@ msgid "`UserAccountScope::sign_token`"
 msgstr ""
 
 #: src/20-encryption-inventory.md:100
-msgid "HMAC-SHA512 key for connection-string signatures"
+msgid ""
+"HMAC-SHA512 key for connection-string signatures — now consumes "
+"`hmac_secret` with fallback to `token_secret` when `hmac_secret` is unset"
 msgstr ""
 
 #: src/20-encryption-inventory.md:100
 msgid ""
-"**No re-signing path.** All currently-issued connection strings are "
-"invalidated on rotation — treat as revoked."
+"**No re-signing path.** While the fallback is active, rotating "
+"`token_secret` invalidates every live connection-string signature — treat as "
+"revoked. Configure `hmac_secret` separately to decouple this from KEK "
+"rotation."
 msgstr ""
 
 #: src/20-encryption-inventory.md:102
@@ -7867,10 +7871,28 @@ msgstr ""
 #: src/20-encryption-inventory.md:105
 msgid ""
 "The operational impact of invalidating every live connection-string "
-"signature is understood and accepted."
+"signature is understood and accepted — or `hmac_secret` is configured "
+"separately so connection strings no longer depend on `token_secret`."
+msgstr ""
+
+#: src/20-encryption-inventory.md:107
+msgid "HMAC rotation rollout — Etapa 1 (non-breaking)"
 msgstr ""
 
 #: src/20-encryption-inventory.md:109
+msgid ""
+"Etapa 1 adds the optional `hmacSecret` field to `AccountLifeCycle`. When "
+"set, `UserAccountScope::sign_token` uses it as the HMAC key; when unset, the "
+"signer falls back to `token_secret` and logs a structured "
+"`hmac_secret_missing_fallback_to_token_secret=true` warning per call. "
+"Existing deployments keep working unchanged because the field is optional "
+"and the fallback preserves prior behaviour byte-for-byte. Etapa 3 will "
+"remove the fallback and require an explicit `hmacPrimaryVersion` + "
+"`hmacSecrets` set, so operators should start populating `hmacSecret` now to "
+"smooth that transition."
+msgstr ""
+
+#: src/20-encryption-inventory.md:121
 msgid ""
 "See [Envelope Encryption Migration Guide](./21-envelope-encryption-migration."
 "md) for step-by-step operator instructions."

--- a/docs/book/po/pt-BR.po
+++ b/docs/book/po/pt-BR.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Mycelium API Gateway Documentation\n"
-"POT-Creation-Date: 2026-04-23T12:51:17-03:00\n"
+"POT-Creation-Date: 2026-04-23T13:14:09-03:00\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -8147,6 +8147,115 @@ msgid ""
 msgstr ""
 
 #: src/21-envelope-encryption-migration.md:158
+msgid "KEK Rotation (`myc-cli kek rotate-kek`)"
+msgstr ""
+
+#: src/21-envelope-encryption-migration.md:160
+msgid ""
+"`rotate-kek` rewraps every tenant's Data Encryption Key (DEK) under a new "
+"Key Encryption Key (KEK) without touching any user-data ciphertext. Because "
+"the DEKs themselves are unchanged, existing `v2:`\\-prefixed ciphertexts "
+"stay readable after rotation."
+msgstr ""
+
+#: src/21-envelope-encryption-migration.md:165
+#, fuzzy
+msgid "Precondition"
+msgstr "Configuração por tenant"
+
+#: src/21-envelope-encryption-migration.md:167
+msgid ""
+"Run `migrate-dek --dry-run` and confirm zero remaining `v1` rows. Any `v1` "
+"ciphertext encountered after a KEK rotation is unrecoverable: it is pinned "
+"to the old `token_secret` and not protected by a DEK at all."
+msgstr ""
+
+#: src/21-envelope-encryption-migration.md:171
+msgid "Step-by-step"
+msgstr ""
+
+#: src/21-envelope-encryption-migration.md:173
+msgid ""
+"**Keep the old `token_secret` reachable.** Export it under the "
+"`MYC_OLD_TOKEN_SECRET` environment variable before invoking the CLI. It is "
+"used to unwrap each tenant's stored DEK."
+msgstr ""
+
+#: src/21-envelope-encryption-migration.md:176
+msgid ""
+"**Set the new `token_secret`** in `settings/config.toml` (or the backing "
+"Vault secret). This is the KEK that every rewrapped DEK will be bound to."
+msgstr ""
+
+#: src/21-envelope-encryption-migration.md:179
+msgid "**Dry-run first:**"
+msgstr ""
+
+#: src/21-envelope-encryption-migration.md:181
+#: src/21-envelope-encryption-migration.md:189
+msgid "<old-uuid>"
+msgstr ""
+
+#: src/21-envelope-encryption-migration.md:184
+msgid ""
+"Inspect the counters. `Migrated` should equal the number of tenants on "
+"`kek_version == 1` with an `encrypted_dek` set; `Skipped` should be zero "
+"unless some rows are intentionally on a different generation."
+msgstr ""
+
+#: src/21-envelope-encryption-migration.md:187
+msgid "**Run live:**"
+msgstr ""
+
+#: src/21-envelope-encryption-migration.md:192
+msgid ""
+"**Verify** that the gateway starts cleanly under the new `token_secret` and "
+"that authenticated traffic still reaches tenant-scoped features (Telegram "
+"bot tokens, TOTP verification, webhook secrets)."
+msgstr ""
+
+#: src/21-envelope-encryption-migration.md:195
+msgid ""
+"**Discard** the old `token_secret` from Vault / env only after the live run "
+"is confirmed."
+msgstr ""
+
+#: src/21-envelope-encryption-migration.md:198
+#, fuzzy
+msgid "Connection strings stay valid"
+msgstr "**Connection string emitida**"
+
+#: src/21-envelope-encryption-migration.md:200
+msgid ""
+"`rotate-kek` does **not** touch the HMAC key used to sign user-facing "
+"connection strings — see the dedicated HMAC Key Rotation guide (Etapa 3) for "
+"that procedure. Issued connection strings remain usable across a KEK "
+"rotation as long as `hmac_secret` (or the Etapa-1 fallback to the previous "
+"`token_secret` value) is kept available."
+msgstr ""
+
+#: src/21-envelope-encryption-migration.md:206
+#, fuzzy
+msgid "Idempotence and rollback"
+msgstr "Callbacks de Resposta"
+
+#: src/21-envelope-encryption-migration.md:208
+msgid ""
+"Re-running `rotate-kek` with the same `--from-version` / `--to-version` "
+"reports the already-rotated rows as `Already done` and is safe to run "
+"repeatedly."
+msgstr ""
+
+#: src/21-envelope-encryption-migration.md:212
+msgid ""
+"The rewrap itself is **irreversible per row** — once a tenant's "
+"`encrypted_dek` is persisted under the new KEK, unwrapping requires the new "
+"`token_secret`. Keep both old and new secrets resolvable (Vault versioning, "
+"dual env vars, or a short overlap in config) until you have confirmed the "
+"rotation end-to-end."
+msgstr ""
+
+#: src/21-envelope-encryption-migration.md:220
 msgid ""
 "See [Encryption Inventory](./20-encryption-inventory.md) for the complete "
 "field classification table."

--- a/docs/book/po/pt-BR.po
+++ b/docs/book/po/pt-BR.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Mycelium API Gateway Documentation\n"
-"POT-Creation-Date: 2026-04-23T13:14:09-03:00\n"
+"POT-Creation-Date: 2026-04-23T13:28:45-03:00\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -115,15 +115,19 @@ msgstr ""
 msgid "Envelope Encryption Migration Guide"
 msgstr ""
 
-#: src/SUMMARY.md:40 src/07-running-tests.md:1
+#: src/SUMMARY.md:40 src/22-hmac-key-rotation.md:1
+msgid "HMAC Key Rotation"
+msgstr ""
+
+#: src/SUMMARY.md:41 src/07-running-tests.md:1
 msgid "Running Tests"
 msgstr "Executando Testes"
 
-#: src/SUMMARY.md:41 src/08-release-process.md:1
+#: src/SUMMARY.md:42 src/08-release-process.md:1
 msgid "Release Process"
 msgstr "Processo de Lançamento"
 
-#: src/SUMMARY.md:42 src/09-log-cache-tests.md:1
+#: src/SUMMARY.md:43 src/09-log-cache-tests.md:1
 msgid "Log Tests for Cache and Identity Flow"
 msgstr "Testes de Log para Cache e Fluxo de Identidade"
 
@@ -5501,7 +5505,7 @@ msgstr ""
 "Downstream services and client SDKs can `switch` on `code` rather than "
 "parsing the `message` string."
 
-#: src/17-error-codes.md:27
+#: src/17-error-codes.md:27 src/22-hmac-key-rotation.md:113
 msgid "Native error codes"
 msgstr "Códigos de erro nativos"
 
@@ -6866,11 +6870,11 @@ msgstr ""
 msgid "Standard error codes:"
 msgstr "Códigos de erro padrão:"
 
-#: src/14-json-rpc.md:370
+#: src/14-json-rpc.md:370 src/22-hmac-key-rotation.md:115
 msgid "Code"
 msgstr ""
 
-#: src/14-json-rpc.md:370
+#: src/14-json-rpc.md:370 src/22-hmac-key-rotation.md:115
 msgid "Meaning"
 msgstr ""
 
@@ -7848,16 +7852,14 @@ msgstr ""
 
 #: src/20-encryption-inventory.md:100
 msgid ""
-"HMAC-SHA512 key for connection-string signatures — now consumes "
-"`hmac_secret` with fallback to `token_secret` when `hmac_secret` is unset"
+"Independent — consumes `hmacSecrets[hmacPrimaryVersion]`, no longer routes "
+"through `token_secret`"
 msgstr ""
 
 #: src/20-encryption-inventory.md:100
 msgid ""
-"**No re-signing path.** While the fallback is active, rotating "
-"`token_secret` invalidates every live connection-string signature — treat as "
-"revoked. Configure `hmac_secret` separately to decouple this from KEK "
-"rotation."
+"Decoupled from KEK rotation. Rotate via the separate versioned procedure "
+"documented in [HMAC Key Rotation](./22-hmac-key-rotation.md)."
 msgstr ""
 
 #: src/20-encryption-inventory.md:102
@@ -7870,32 +7872,19 @@ msgstr ""
 
 #: src/20-encryption-inventory.md:105
 msgid ""
-"The operational impact of invalidating every live connection-string "
-"signature is understood and accepted — or `hmac_secret` is configured "
-"separately so connection strings no longer depend on `token_secret`."
+"A `rotate-kek` pass (see the Envelope Encryption Migration Guide) has re-"
+"wrapped every tenant's DEK under the new KEK. HMAC-protected connection "
+"strings are **no longer tied to `token_secret`** — rotating the HMAC key is "
+"a separate, versioned procedure (see [HMAC Key Rotation](./22-hmac-key-"
+"rotation.md))."
 msgstr ""
 
-#: src/20-encryption-inventory.md:107
-msgid "HMAC rotation rollout — Etapa 1 (non-breaking)"
-msgstr ""
-
-#: src/20-encryption-inventory.md:109
-msgid ""
-"Etapa 1 adds the optional `hmacSecret` field to `AccountLifeCycle`. When "
-"set, `UserAccountScope::sign_token` uses it as the HMAC key; when unset, the "
-"signer falls back to `token_secret` and logs a structured "
-"`hmac_secret_missing_fallback_to_token_secret=true` warning per call. "
-"Existing deployments keep working unchanged because the field is optional "
-"and the fallback preserves prior behaviour byte-for-byte. Etapa 3 will "
-"remove the fallback and require an explicit `hmacPrimaryVersion` + "
-"`hmacSecrets` set, so operators should start populating `hmacSecret` now to "
-"smooth that transition."
-msgstr ""
-
-#: src/20-encryption-inventory.md:121
+#: src/20-encryption-inventory.md:113
 msgid ""
 "See [Envelope Encryption Migration Guide](./21-envelope-encryption-migration."
-"md) for step-by-step operator instructions."
+"md) for step-by-step operator instructions on KEK rotation. See [HMAC Key "
+"Rotation](./22-hmac-key-rotation.md) for the connection-string signing-key "
+"rotation procedure."
 msgstr ""
 
 #: src/21-envelope-encryption-migration.md:3
@@ -8259,6 +8248,253 @@ msgstr ""
 msgid ""
 "See [Encryption Inventory](./20-encryption-inventory.md) for the complete "
 "field classification table."
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:3
+msgid ""
+"`UserAccountScope` connection strings are signed with an HMAC key. Starting "
+"from the deploy that introduces this document, the gateway manages signing "
+"keys as a **versioned set** and embeds the key version inside every token "
+"(the `kvr` bean). Verification picks the key by version, so multiple keys "
+"can coexist during rotation."
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:9
+msgid "**!!!!!! DEPLOYMENT WARNING !!!!!!**"
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:11
+msgid ""
+"Deploying the HMAC key-rotation release **invalidates every connection "
+"string issued before the deploy**. Pre-existing tokens carry no `kvr` bean; "
+"verification fails with `MYC00030` (MissingKeyVersion) and users must re-"
+"authenticate. Plan a maintenance window."
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:16
+msgid ""
+"The gateway **refuses to start** when `hmacPrimaryVersion` is absent from "
+"`hmacSecrets` or when the set is empty. This is enforced at config load."
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:22
+msgid "Why versioned keys"
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:24
+msgid ""
+"Prior to this release, the HMAC signing key was tied to the global "
+"`token_secret`. Rotating `token_secret` for any reason (KEK rotation, "
+"compliance refresh) invalidated every connection string in circulation "
+"because there was no way to verify tokens under the previous key while the "
+"new one was active."
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:30
+msgid "A versioned key set decouples rotation from invalidation:"
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:32
+msgid "New tokens are signed with the **primary** version."
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:33
+msgid ""
+"Verification looks up the key by the `kvr` bean, so tokens signed with a "
+"still-listed previous version stay valid until the operator removes the "
+"entry."
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:36
+msgid ""
+"Tampering with the `kvr` bean does not help an attacker: the HMAC is "
+"computed over the `kvr` value (anti-downgrade), so changing it after "
+"issuance yields `MYC00032` (SignatureMismatch)."
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:42
+#, fuzzy
+msgid "Configuration reference"
+msgstr "Configuração"
+
+#: src/22-hmac-key-rotation.md:44
+msgid ""
+"```toml\n"
+"[core.accountLifeCycle]\n"
+"# …other fields…\n"
+"tokenSecret = { vault = { path = \"myc/core/accountLifeCycle\", key = "
+"\"tokenSecret\" } }\n"
+"\n"
+"# Version of the HMAC key used to sign new connection strings.\n"
+"# MUST match a `version` listed in `hmacSecrets` below.\n"
+"hmacPrimaryVersion = 2\n"
+"\n"
+"[[core.accountLifeCycle.hmacSecrets]]\n"
+"version = 1\n"
+"secret = { vault = { path = \"myc/core/accountLifeCycle\", key = "
+"\"hmacSecretV1\" } }\n"
+"\n"
+"[[core.accountLifeCycle.hmacSecrets]]\n"
+"version = 2\n"
+"secret = { vault = { path = \"myc/core/accountLifeCycle\", key = "
+"\"hmacSecretV2\" } }\n"
+"```"
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:62
+msgid ""
+"Validation rules (checked at startup, gateway refuses to boot on failure):"
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:65
+msgid "`hmacSecrets` must be non-empty."
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:66
+msgid "No two entries may share the same `version`."
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:67
+msgid "`hmacPrimaryVersion` must equal one of the `version` values."
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:69
+msgid ""
+"Key material is resolved through `SecretResolver`, so Vault, env vars and "
+"literal values are all supported — follow the same operational practices you "
+"already use for `tokenSecret`."
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:75
+msgid "Rotation procedure"
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:77
+msgid ""
+"The goal is to introduce a new signing key, let the fleet pick it up, switch "
+"signing to it, let old tokens age out, then retire the old key."
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:80
+msgid "**Provision the new secret** (e.g. as `hmacSecretV2` in Vault)."
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:81
+msgid ""
+"**Add a new `[[hmacSecrets]]` entry** to every config replica. Keep "
+"`hmacPrimaryVersion` pointing at the **old** version for now; the gateway "
+"will start verifying new tokens carrying either version. Roll out the config."
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:85
+msgid ""
+"**Bump `hmacPrimaryVersion`** to the new version once every replica has the "
+"new entry loaded. From this point, freshly-issued tokens carry `kvr=<new>`."
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:88
+msgid ""
+"**Wait for the connection-string TTL** (`tokenExpiration`) so that every "
+"token issued under the old version has naturally expired."
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:90
+msgid ""
+"**Remove the old `[[hmacSecrets]]` entry** and the corresponding secret. "
+"Tokens still citing that version will now fail with `MYC00031` "
+"(UnknownKeyVersion); this is the desired retirement outcome."
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:95
+msgid ""
+"Reverse the procedure (un-bump primary, then remove the new entry) if you "
+"need to roll back before step 4."
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:100
+msgid "Anti-downgrade"
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:102
+msgid ""
+"The `kvr` bean is part of the HMAC input — not an out-of-band hint. An "
+"attacker who intercepts a token signed under `kvr=2` cannot rewrite the bean "
+"to `kvr=1` and have verification succeed, because the recomputed HMAC over "
+"the rewritten payload no longer matches the stored `SIG`. Verification "
+"returns `MYC00032` in that case, not a silent fallback."
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:108
+msgid ""
+"Similarly, stripping the `kvr` bean yields `MYC00030` rather than a guess at "
+"the default version."
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:115
+#, fuzzy
+msgid "Typical cause"
+msgstr "Escopo típico"
+
+#: src/22-hmac-key-rotation.md:117
+msgid "`MYC00030`"
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:117
+msgid "Connection string is missing the HMAC key version (`kvr` bean)."
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:117
+msgid "Pre-rotation token, or tampering."
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:118
+msgid "`MYC00031`"
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:118
+msgid "Connection string references an unknown HMAC key version."
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:118
+msgid "Retired key, misconfigured replica, or tampering."
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:119
+msgid "`MYC00032`"
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:119
+#, fuzzy
+msgid "Connection string signature mismatch."
+msgstr "**Connection string emitida**"
+
+#: src/22-hmac-key-rotation.md:119
+msgid ""
+"Tampering (including `kvr` downgrade) or wrong key provisioned for the "
+"version."
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:121
+msgid ""
+"All three are surfaced verbatim in `Unauthorized` responses from the "
+"connection-string middleware, and structured-logged with "
+"`connection_string_verification_failed=true` for operator audit."
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:127
+msgid "See also:"
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:129
+msgid ""
+"[Envelope Encryption Migration Guide](./21-envelope-encryption-migration.md) "
+"for KEK rotation (different key, different procedure)."
+msgstr ""
+
+#: src/22-hmac-key-rotation.md:131
+msgid ""
+"[Encryption Inventory](./20-encryption-inventory.md) for the full list of "
+"`token_secret` consumers."
 msgstr ""
 
 #: src/07-running-tests.md:3

--- a/docs/book/src/20-encryption-inventory.md
+++ b/docs/book/src/20-encryption-inventory.md
@@ -97,26 +97,20 @@ source. Its bytes are also consumed directly by non-envelope code paths:
 | `encrypt_string::build_aes_key` (v1 legacy path) | KEK for ciphertexts written before Phase 1 | Stays readable only while `token_secret` is unchanged; migrate to v2 before rotating. |
 | `HttpSecret::decrypt_me` (v1 branch) | Indirect — routes through the legacy path | Same as above. |
 | `Totp::decrypt_me` (v1 branch) | Indirect — routes through the legacy path | Same as above. |
-| `UserAccountScope::sign_token` | HMAC-SHA512 key for connection-string signatures — now consumes `hmac_secret` with fallback to `token_secret` when `hmac_secret` is unset | **No re-signing path.** While the fallback is active, rotating `token_secret` invalidates every live connection-string signature — treat as revoked. Configure `hmac_secret` separately to decouple this from KEK rotation. |
+| `UserAccountScope::sign_token` | Independent — consumes `hmacSecrets[hmacPrimaryVersion]`, no longer routes through `token_secret` | Decoupled from KEK rotation. Rotate via the separate versioned procedure documented in [HMAC Key Rotation](./22-hmac-key-rotation.md). |
 
 Rotate `token_secret` only after:
 
 1. `migrate-dek --dry-run` reports zero `v1` fields remaining, **and**
-2. The operational impact of invalidating every live connection-string signature is understood and accepted — or `hmac_secret` is configured separately so connection strings no longer depend on `token_secret`.
-
-### HMAC rotation rollout — Etapa 1 (non-breaking)
-
-Etapa 1 adds the optional `hmacSecret` field to `AccountLifeCycle`. When
-set, `UserAccountScope::sign_token` uses it as the HMAC key; when unset,
-the signer falls back to `token_secret` and logs a structured
-`hmac_secret_missing_fallback_to_token_secret=true` warning per call.
-Existing deployments keep working unchanged because the field is optional
-and the fallback preserves prior behaviour byte-for-byte. Etapa 3 will
-remove the fallback and require an explicit `hmacPrimaryVersion` +
-`hmacSecrets` set, so operators should start populating `hmacSecret` now
-to smooth that transition.
+2. A `rotate-kek` pass (see the Envelope Encryption Migration Guide) has
+   re-wrapped every tenant's DEK under the new KEK. HMAC-protected
+   connection strings are **no longer tied to `token_secret`** — rotating
+   the HMAC key is a separate, versioned procedure (see
+   [HMAC Key Rotation](./22-hmac-key-rotation.md)).
 
 ---
 
 See [Envelope Encryption Migration Guide](./21-envelope-encryption-migration.md)
-for step-by-step operator instructions.
+for step-by-step operator instructions on KEK rotation.
+See [HMAC Key Rotation](./22-hmac-key-rotation.md) for the connection-string
+signing-key rotation procedure.

--- a/docs/book/src/20-encryption-inventory.md
+++ b/docs/book/src/20-encryption-inventory.md
@@ -97,12 +97,24 @@ source. Its bytes are also consumed directly by non-envelope code paths:
 | `encrypt_string::build_aes_key` (v1 legacy path) | KEK for ciphertexts written before Phase 1 | Stays readable only while `token_secret` is unchanged; migrate to v2 before rotating. |
 | `HttpSecret::decrypt_me` (v1 branch) | Indirect — routes through the legacy path | Same as above. |
 | `Totp::decrypt_me` (v1 branch) | Indirect — routes through the legacy path | Same as above. |
-| `UserAccountScope::sign_token` | HMAC-SHA512 key for connection-string signatures | **No re-signing path.** All currently-issued connection strings are invalidated on rotation — treat as revoked. |
+| `UserAccountScope::sign_token` | HMAC-SHA512 key for connection-string signatures — now consumes `hmac_secret` with fallback to `token_secret` when `hmac_secret` is unset | **No re-signing path.** While the fallback is active, rotating `token_secret` invalidates every live connection-string signature — treat as revoked. Configure `hmac_secret` separately to decouple this from KEK rotation. |
 
 Rotate `token_secret` only after:
 
 1. `migrate-dek --dry-run` reports zero `v1` fields remaining, **and**
-2. The operational impact of invalidating every live connection-string signature is understood and accepted.
+2. The operational impact of invalidating every live connection-string signature is understood and accepted — or `hmac_secret` is configured separately so connection strings no longer depend on `token_secret`.
+
+### HMAC rotation rollout — Etapa 1 (non-breaking)
+
+Etapa 1 adds the optional `hmacSecret` field to `AccountLifeCycle`. When
+set, `UserAccountScope::sign_token` uses it as the HMAC key; when unset,
+the signer falls back to `token_secret` and logs a structured
+`hmac_secret_missing_fallback_to_token_secret=true` warning per call.
+Existing deployments keep working unchanged because the field is optional
+and the fallback preserves prior behaviour byte-for-byte. Etapa 3 will
+remove the fallback and require an explicit `hmacPrimaryVersion` +
+`hmacSecrets` set, so operators should start populating `hmacSecret` now
+to smooth that transition.
 
 ---
 

--- a/docs/book/src/21-envelope-encryption-migration.md
+++ b/docs/book/src/21-envelope-encryption-migration.md
@@ -155,5 +155,67 @@ manual action is required.
 
 ---
 
+## KEK Rotation (`myc-cli kek rotate-kek`)
+
+`rotate-kek` rewraps every tenant's Data Encryption Key (DEK) under a new Key
+Encryption Key (KEK) without touching any user-data ciphertext. Because the
+DEKs themselves are unchanged, existing `v2:`-prefixed ciphertexts stay
+readable after rotation.
+
+### Precondition
+
+Run `migrate-dek --dry-run` and confirm zero remaining `v1` rows. Any `v1`
+ciphertext encountered after a KEK rotation is unrecoverable: it is pinned to
+the old `token_secret` and not protected by a DEK at all.
+
+### Step-by-step
+
+1. **Keep the old `token_secret` reachable.** Export it under the
+   `MYC_OLD_TOKEN_SECRET` environment variable before invoking the CLI. It is
+   used to unwrap each tenant's stored DEK.
+2. **Set the new `token_secret`** in `settings/config.toml` (or the
+   backing Vault secret). This is the KEK that every rewrapped DEK will be
+   bound to.
+3. **Dry-run first:**
+   ```bash
+   MYC_OLD_TOKEN_SECRET=<old-uuid> \
+     myc-cli kek rotate-kek --from-version 1 --to-version 2 --dry-run
+   ```
+   Inspect the counters. `Migrated` should equal the number of tenants on
+   `kek_version == 1` with an `encrypted_dek` set; `Skipped` should be zero
+   unless some rows are intentionally on a different generation.
+4. **Run live:**
+   ```bash
+   MYC_OLD_TOKEN_SECRET=<old-uuid> \
+     myc-cli kek rotate-kek --from-version 1 --to-version 2
+   ```
+5. **Verify** that the gateway starts cleanly under the new `token_secret`
+   and that authenticated traffic still reaches tenant-scoped features
+   (Telegram bot tokens, TOTP verification, webhook secrets).
+6. **Discard** the old `token_secret` from Vault / env only after the live
+   run is confirmed.
+
+### Connection strings stay valid
+
+`rotate-kek` does **not** touch the HMAC key used to sign user-facing
+connection strings — see the dedicated HMAC Key Rotation guide (Etapa 3)
+for that procedure. Issued connection strings remain usable across a KEK
+rotation as long as `hmac_secret` (or the Etapa-1 fallback to the previous
+`token_secret` value) is kept available.
+
+### Idempotence and rollback
+
+Re-running `rotate-kek` with the same `--from-version` / `--to-version`
+reports the already-rotated rows as `Already done` and is safe to run
+repeatedly.
+
+The rewrap itself is **irreversible per row** — once a tenant's
+`encrypted_dek` is persisted under the new KEK, unwrapping requires the new
+`token_secret`. Keep both old and new secrets resolvable (Vault versioning,
+dual env vars, or a short overlap in config) until you have confirmed the
+rotation end-to-end.
+
+---
+
 See [Encryption Inventory](./20-encryption-inventory.md) for the complete field
 classification table.

--- a/docs/book/src/22-hmac-key-rotation.md
+++ b/docs/book/src/22-hmac-key-rotation.md
@@ -1,0 +1,132 @@
+# HMAC Key Rotation
+
+`UserAccountScope` connection strings are signed with an HMAC key. Starting
+from the deploy that introduces this document, the gateway manages signing
+keys as a **versioned set** and embeds the key version inside every token
+(the `kvr` bean). Verification picks the key by version, so multiple keys
+can coexist during rotation.
+
+> **!!!!!! DEPLOYMENT WARNING !!!!!!**
+>
+> Deploying the HMAC key-rotation release **invalidates every connection
+> string issued before the deploy**. Pre-existing tokens carry no `kvr`
+> bean; verification fails with `MYC00030` (MissingKeyVersion) and users
+> must re-authenticate. Plan a maintenance window.
+>
+> The gateway **refuses to start** when `hmacPrimaryVersion` is absent
+> from `hmacSecrets` or when the set is empty. This is enforced at config
+> load.
+
+---
+
+## Why versioned keys
+
+Prior to this release, the HMAC signing key was tied to the global
+`token_secret`. Rotating `token_secret` for any reason (KEK rotation,
+compliance refresh) invalidated every connection string in circulation
+because there was no way to verify tokens under the previous key while
+the new one was active.
+
+A versioned key set decouples rotation from invalidation:
+
+- New tokens are signed with the **primary** version.
+- Verification looks up the key by the `kvr` bean, so tokens signed with
+  a still-listed previous version stay valid until the operator removes
+  the entry.
+- Tampering with the `kvr` bean does not help an attacker: the HMAC is
+  computed over the `kvr` value (anti-downgrade), so changing it after
+  issuance yields `MYC00032` (SignatureMismatch).
+
+---
+
+## Configuration reference
+
+```toml
+[core.accountLifeCycle]
+# …other fields…
+tokenSecret = { vault = { path = "myc/core/accountLifeCycle", key = "tokenSecret" } }
+
+# Version of the HMAC key used to sign new connection strings.
+# MUST match a `version` listed in `hmacSecrets` below.
+hmacPrimaryVersion = 2
+
+[[core.accountLifeCycle.hmacSecrets]]
+version = 1
+secret = { vault = { path = "myc/core/accountLifeCycle", key = "hmacSecretV1" } }
+
+[[core.accountLifeCycle.hmacSecrets]]
+version = 2
+secret = { vault = { path = "myc/core/accountLifeCycle", key = "hmacSecretV2" } }
+```
+
+Validation rules (checked at startup, gateway refuses to boot on
+failure):
+
+- `hmacSecrets` must be non-empty.
+- No two entries may share the same `version`.
+- `hmacPrimaryVersion` must equal one of the `version` values.
+
+Key material is resolved through `SecretResolver`, so Vault, env vars
+and literal values are all supported — follow the same operational
+practices you already use for `tokenSecret`.
+
+---
+
+## Rotation procedure
+
+The goal is to introduce a new signing key, let the fleet pick it up,
+switch signing to it, let old tokens age out, then retire the old key.
+
+1. **Provision the new secret** (e.g. as `hmacSecretV2` in Vault).
+2. **Add a new `[[hmacSecrets]]` entry** to every config replica. Keep
+   `hmacPrimaryVersion` pointing at the **old** version for now; the
+   gateway will start verifying new tokens carrying either version. Roll
+   out the config.
+3. **Bump `hmacPrimaryVersion`** to the new version once every replica
+   has the new entry loaded. From this point, freshly-issued tokens
+   carry `kvr=<new>`.
+4. **Wait for the connection-string TTL** (`tokenExpiration`) so that
+   every token issued under the old version has naturally expired.
+5. **Remove the old `[[hmacSecrets]]` entry** and the corresponding
+   secret. Tokens still citing that version will now fail with
+   `MYC00031` (UnknownKeyVersion); this is the desired retirement
+   outcome.
+
+Reverse the procedure (un-bump primary, then remove the new entry) if
+you need to roll back before step 4.
+
+---
+
+## Anti-downgrade
+
+The `kvr` bean is part of the HMAC input — not an out-of-band hint. An
+attacker who intercepts a token signed under `kvr=2` cannot rewrite the
+bean to `kvr=1` and have verification succeed, because the recomputed
+HMAC over the rewritten payload no longer matches the stored `SIG`.
+Verification returns `MYC00032` in that case, not a silent fallback.
+
+Similarly, stripping the `kvr` bean yields `MYC00030` rather than a
+guess at the default version.
+
+---
+
+## Native error codes
+
+| Code | Meaning | Typical cause |
+|------|---------|---------------|
+| `MYC00030` | Connection string is missing the HMAC key version (`kvr` bean). | Pre-rotation token, or tampering. |
+| `MYC00031` | Connection string references an unknown HMAC key version. | Retired key, misconfigured replica, or tampering. |
+| `MYC00032` | Connection string signature mismatch. | Tampering (including `kvr` downgrade) or wrong key provisioned for the version. |
+
+All three are surfaced verbatim in `Unauthorized` responses from the
+connection-string middleware, and structured-logged with
+`connection_string_verification_failed=true` for operator audit.
+
+---
+
+See also:
+
+- [Envelope Encryption Migration Guide](./21-envelope-encryption-migration.md)
+  for KEK rotation (different key, different procedure).
+- [Encryption Inventory](./20-encryption-inventory.md) for the full list
+  of `token_secret` consumers.

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -37,6 +37,7 @@
 
 - [Encryption Inventory](./20-encryption-inventory.md)
 - [Envelope Encryption Migration Guide](./21-envelope-encryption-migration.md)
+- [HMAC Key Rotation](./22-hmac-key-rotation.md)
 - [Running Tests](./07-running-tests.md)
 - [Release Process](./08-release-process.md)
 - [Log Tests for Cache and Identity Flow](./09-log-cache-tests.md)

--- a/ports/api/src/middleware/fetch_connection_string_from_request.rs
+++ b/ports/api/src/middleware/fetch_connection_string_from_request.rs
@@ -1,9 +1,12 @@
 use crate::dtos::MyceliumConnectionStringData;
 
 use actix_web::{web, HttpRequest};
-use myc_core::domain::{
-    dtos::token::{MultiTypeMeta, UserAccountScope},
-    entities::TokenFetching,
+use myc_core::{
+    domain::{
+        dtos::token::{MultiTypeMeta, UserAccountScope},
+        entities::TokenFetching,
+    },
+    models::AccountLifeCycle,
 };
 use myc_diesel::repositories::SqlAppModule;
 use myc_http_tools::{
@@ -11,7 +14,7 @@ use myc_http_tools::{
 };
 use mycelium_base::entities::FetchResponseKind;
 use shaku::HasComponent;
-use tracing::error;
+use tracing::{error, warn};
 
 #[tracing::instrument(name = "fetch_connection_string_from_request", skip_all)]
 pub async fn fetch_connection_string_from_request(
@@ -57,6 +60,40 @@ pub async fn fetch_connection_string_from_request(
             ))
         }
     };
+
+    // ? -----------------------------------------------------------------------
+    // ? Verify HMAC before touching the database
+    //
+    // Reject forged or downgraded tokens up-front. Native error codes
+    // MYC00030 / MYC00031 / MYC00032 are carried through so logs can be
+    // searched by reason. See `22-hmac-key-rotation.md` for the contract.
+    //
+    // ? -----------------------------------------------------------------------
+
+    let life_cycle = match req.app_data::<web::Data<AccountLifeCycle>>() {
+        Some(value) => value,
+        None => {
+            error!(
+                "AccountLifeCycle is not registered as app data; cannot \
+                 verify connection-string signature",
+            );
+            return Err(GatewayError::InternalServerError(
+                "Server misconfiguration: HMAC key set unavailable".to_string(),
+            ));
+        }
+    };
+
+    if let Err(err) = scope.verify_signature(life_cycle.get_ref()).await {
+        warn!(
+            connection_string_verification_failed = true,
+            code = %err.code(),
+            "Rejecting connection string: {err}",
+        );
+        return Err(GatewayError::Unauthorized(format!(
+            "Invalid connection string: {}",
+            err.code(),
+        )));
+    }
 
     // ? -----------------------------------------------------------------------
     // ? Build dependencies

--- a/ports/cli/src/cmds/mod.rs
+++ b/ports/cli/src/cmds/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod accounts;
 pub(crate) mod error_codes;
 pub(crate) mod migrate_dek;
+pub(crate) mod rotate_kek;

--- a/ports/cli/src/cmds/rotate_kek.rs
+++ b/ports/cli/src/cmds/rotate_kek.rs
@@ -1,0 +1,118 @@
+use crate::functions::try_to_resolve_database_url;
+
+use clap::Parser;
+use myc_core::models::CoreConfig;
+use myc_diesel::{migration::rotate_kek, repositories::DieselDbPoolProvider};
+use std::{env::var, path::PathBuf};
+
+/// Environment variable the operator sets to the **old** `token_secret`
+/// while running `rotate-kek`. The current/new `token_secret` stays in
+/// the config file.
+const OLD_TOKEN_SECRET_ENV: &str = "MYC_OLD_TOKEN_SECRET";
+
+#[derive(Parser, Debug)]
+pub(crate) struct Arguments {
+    #[clap(subcommand)]
+    pub cmd: Commands,
+}
+
+#[derive(Parser, Debug)]
+pub(crate) enum Commands {
+    /// Rewrap every tenant's DEK from an old KEK (derived from the old
+    /// `token_secret`) to the new KEK currently configured.
+    ///
+    /// The old `token_secret` value is provided via the
+    /// `MYC_OLD_TOKEN_SECRET` env var. User-data ciphertexts are never
+    /// touched — only the per-tenant DEK wrapping is rewrapped.
+    RotateKek(RotateKekArguments),
+}
+
+#[derive(Parser, Debug)]
+pub(crate) struct RotateKekArguments {
+    /// KEK generation currently stored on each tenant row (the `from` side
+    /// of the rotation).
+    #[clap(long, value_name = "N")]
+    pub from_version: u32,
+
+    /// KEK generation to persist after rewrap (the `to` side of the
+    /// rotation).
+    #[clap(long, value_name = "M")]
+    pub to_version: u32,
+
+    /// Scan and report without writing any changes.
+    #[clap(long)]
+    pub dry_run: bool,
+}
+
+#[tracing::instrument(name = "rotate_kek_cmd", skip_all)]
+pub(crate) async fn rotate_kek_cmd(args: RotateKekArguments) {
+    let settings_path = match var("SETTINGS_PATH") {
+        Ok(p) => p,
+        Err(_) => {
+            tracing::error!("SETTINGS_PATH env var is required for rotate-kek",);
+            return;
+        }
+    };
+
+    let old_token_secret = match var(OLD_TOKEN_SECRET_ENV) {
+        Ok(v) => v,
+        Err(_) => {
+            tracing::error!(
+                "{OLD_TOKEN_SECRET_ENV} env var is required for rotate-kek",
+            );
+            return;
+        }
+    };
+
+    let core_config = match CoreConfig::from_default_config_file(PathBuf::from(
+        &settings_path,
+    )) {
+        Ok(c) => c,
+        Err(err) => {
+            tracing::error!("Failed to load core config: {err}");
+            return;
+        }
+    };
+
+    let new_config = core_config.account_life_cycle.clone();
+    let old_config = new_config.with_token_secret_override(old_token_secret);
+
+    let database_url = try_to_resolve_database_url();
+    let pool = DieselDbPoolProvider::new(&database_url);
+
+    if args.dry_run {
+        tracing::info!("Running in dry-run mode — no changes will be written");
+    }
+
+    match rotate_kek(
+        &pool,
+        args.from_version,
+        args.to_version,
+        &old_config,
+        &new_config,
+        args.dry_run,
+    )
+    .await
+    {
+        Err(err) => tracing::error!("rotate-kek failed: {err}"),
+        Ok(report) => {
+            tracing::info!(
+                "rotate-kek {}",
+                if report.summary.dry_run {
+                    "(dry-run)"
+                } else {
+                    "complete"
+                },
+            );
+            tracing::info!("  From version:    {}", report.from_version,);
+            tracing::info!("  To version:      {}", report.to_version);
+            tracing::info!("  Tenants scanned: {}", report.summary.scanned,);
+            tracing::info!("  Migrated:        {}", report.summary.migrated,);
+            tracing::info!(
+                "  Already done:    {}",
+                report.summary.already_done,
+            );
+            tracing::info!("  Skipped:         {}", report.summary.skipped);
+        }
+    }
+}

--- a/ports/cli/src/main.rs
+++ b/ports/cli/src/main.rs
@@ -2,7 +2,7 @@ mod cmds;
 mod functions;
 
 use clap::Parser;
-use cmds::{accounts, error_codes, migrate_dek};
+use cmds::{accounts, error_codes, migrate_dek, rotate_kek};
 use std::env::set_var;
 
 #[derive(Parser, Debug)]
@@ -15,6 +15,10 @@ enum Cli {
 
     /// Migrate v1 encrypted fields to v2 envelope encryption format
     Encryption(migrate_dek::Arguments),
+
+    /// Rewrap every tenant's DEK under a new KEK (without touching
+    /// user-data ciphertexts or invalidating connection strings).
+    Kek(rotate_kek::Arguments),
 }
 
 #[tokio::main]
@@ -41,6 +45,11 @@ pub async fn main() {
         Cli::Encryption(sub_args) => match sub_args.cmd {
             migrate_dek::Commands::MigrateDek(args) => {
                 migrate_dek::migrate_dek_cmd(args).await
+            }
+        },
+        Cli::Kek(sub_args) => match sub_args.cmd {
+            rotate_kek::Commands::RotateKek(args) => {
+                rotate_kek::rotate_kek_cmd(args).await
             }
         },
     }

--- a/settings/config.example.toml
+++ b/settings/config.example.toml
@@ -33,6 +33,8 @@ supportName = "Samuel Galvão Elias"
 supportEmail = "elias.samuel.galvao@gmail.com"
 locale = "en-us"
 tokenSecret = { vault = { path = "myc/core/accountLifeCycle", key = "tokenSecret" } }
+# Optional during Etapa 1+2; will become required in Etapa 3.
+# hmacSecret = { vault = { path = "myc/core/accountLifeCycle", key = "hmacSecret" } }
 
 [core.webhook]
 acceptInvalidCertificates = true

--- a/settings/config.example.toml
+++ b/settings/config.example.toml
@@ -33,8 +33,38 @@ supportName = "Samuel Galvão Elias"
 supportEmail = "elias.samuel.galvao@gmail.com"
 locale = "en-us"
 tokenSecret = { vault = { path = "myc/core/accountLifeCycle", key = "tokenSecret" } }
-# Optional during Etapa 1+2; will become required in Etapa 3.
-# hmacSecret = { vault = { path = "myc/core/accountLifeCycle", key = "hmacSecret" } }
+
+# ------------------------------------------------------------------------------
+# !!!!!! DEPLOYMENT WARNING — HMAC key set is now MANDATORY !!!!!!
+#
+# Every newly-issued connection string is signed with the HMAC key at
+# `hmacPrimaryVersion`. Verification reads the version from the token's KVR
+# bean; if the version is missing (older tokens) or retired, the token is
+# rejected with a native error code (MYC00030 / MYC00031 / MYC00032).
+#
+# DEPLOYING THIS VERSION INVALIDATES EVERY CONNECTION STRING ISSUED BEFORE
+# THE DEPLOY. Users must re-authenticate. Pick a maintenance window before
+# rolling out.
+#
+# The gateway REFUSES TO START if `hmacPrimaryVersion` is not present in
+# `hmacSecrets` or if the set is empty — this is enforced by the startup
+# config validator.
+#
+# See docs/book/src/22-hmac-key-rotation.md for the rotation procedure.
+# ------------------------------------------------------------------------------
+
+hmacPrimaryVersion = 1
+
+[[core.accountLifeCycle.hmacSecrets]]
+version = 1
+secret = { vault = { path = "myc/core/accountLifeCycle", key = "hmacSecretV1" } }
+
+# When rotating, uncomment and populate the next version; then bump
+# `hmacPrimaryVersion` once the new secret is known to every replica.
+#
+# [[core.accountLifeCycle.hmacSecrets]]
+# version = 2
+# secret = { vault = { path = "myc/core/accountLifeCycle", key = "hmacSecretV2" } }
 
 [core.webhook]
 acceptInvalidCertificates = true


### PR DESCRIPTION
## Summary

`AccountLifeCycle::token_secret` previously played two independent roles: KEK material for envelope encryption AND HMAC-SHA512 signing key for connection strings. Rotating it atomically revoked every live connection string — unacceptable for operators who need to rotate the KEK independently.

This PR ships the three-etapa rollout decoupling those roles and introducing versioned HMAC (KVR) so signing keys can be rotated without invalidating live tokens.

## Type of Change

- [x] **Breaking change** (Etapa 3 — see deployment warning below)
- [x] New feature
- [x] Documentation update

## Changes Made

**Etapa 1 — Decouple `hmac_secret` from `token_secret`** (commit `d4e21e94`, non-breaking)
- New `AccountLifeCycle::hmac_secret: Option<SecretResolver<String>>` field (`hmacSecret` in TOML)
- `UserAccountScope::sign_token` reads `hmac_secret` with fallback to `token_secret` + `tracing::warn!` when absent
- New `verify_signature(config)` shim on `UserAccountScope` (constant-time via `Mac::verify_slice`)
- Spec: `.claude/specs/features/hmac-key-rotation/spec.md` §1

**Etapa 2 — `myc-cli rotate-kek`** (commit `2a6ebfbf`, non-breaking)
- `adapters/diesel/src/migration/rotate_kek.rs` — re-wraps every DEK under the new KEK; idempotent; does NOT touch user ciphertexts and does NOT invalidate connection strings
- `ports/cli/src/cmds/rotate_kek.rs` — CLI command with `--from-version`, `--to-version`, `--dry-run`
- Operator runbook section in `docs/book/src/21-envelope-encryption-migration.md`
- Spec: `.claude/specs/features/hmac-key-rotation/spec.md` §2

**Etapa 3 — Versioned HMAC (KVR)** (commit `b2d4685f`, **BREAKING**)
- New `ConnectionStringBean::KVR(u32)` (anti-downgrade: KVR is part of the HMAC input)
- New `HmacSecretSet` first-class collection + `hmac_primary_version` + `[[hmacSecrets]]` config
- Startup validation: gateway refuses to boot if `hmacPrimaryVersion` is missing or not in `hmacSecrets`
- `verify_signature` wired into `fetch_connection_string_from_request` middleware (verification happens before DB lookup)
- New error codes: `MYC00030` (MissingKeyVersion), `MYC00031` (UnknownKeyVersion), `MYC00032` (SignatureMismatch)
- Etapa 1 fallback removed
- Operator guide at `docs/book/src/22-hmac-key-rotation.md`
- Spec: `.claude/specs/features/hmac-key-rotation/spec.md` §3

## !!!!!! DEPLOYMENT WARNING (Etapa 3) !!!!!!

> **BREAKING:** Once Etapa 3 is deployed, connection strings issued before the rollout are **permanently invalid**. The server rejects any connection string that does not carry a `KVR` bean — there is **no legacy fallback**. All active users must re-authenticate and receive a freshly signed connection string on their next request.
>
> Plan the rollout during a window where you can tolerate full re-authentication.

The same warning is reproduced in `settings/config.example.toml` and the operator guide.

## Testing

**Unit tests (16 cases, all green):**
- E1-T6 (×3): `test_sign_then_verify_with_hmac_secret_present`, `test_sign_then_verify_falls_back_to_token_secret`, `test_verify_rejects_tampered_payload`
- E3-T1 (×5): `validate_rejects_missing_primary`, `validate_rejects_duplicate_versions`, `validate_accepts_minimal_valid_set`, `lookup_returns_some`, `lookup_returns_none_for_unknown`
- E3-T4 (×3): `test_kvr_to_string`, `test_kvr_try_from`, `test_kvr_serde_roundtrip`
- E3-T12 (×5): `signs_with_primary_then_verifies`, `verifies_non_primary_known_version`, `rejects_unknown_version`, `rejects_missing_kvr`, `rejects_tampered_kvr_anti_downgrade`

**Test Commands:**
```bash
cargo fmt --all -- --check
cargo build --workspace
cargo test --workspace --all
```
All green at `b2d4685f` (verified 2026-04-25).

**Deferred — E2-T4 (Postgres integration test for `rotate-kek`):** the repo has no Postgres integration-test scaffold yet. This task is explicitly deferred to roadmap M2 "Database Integration Tests" and tracked on the spec's status board. The migrator is exercised by unit tests of the helper layer; the round-trip + idempotence assertions on a live Postgres fixture will land with M2.

## Checklist

- [x] Tests added for new functionality
- [x] Existing tests pass
- [x] Code follows the project's style guidelines (`cargo fmt --all -- --check` clean)
- [x] Documentation has been updated (operator runbook + inventory updated)
- [x] No new warnings introduced
- [x] Breaking changes documented
- [x] Commits follow conventional commit format

## Additional Notes

- Spec, design, and tasks: `.claude/specs/features/hmac-key-rotation/{spec,design,tasks}.md` (at the **monorepo root**, not the submodule).
- Operator runbook: `docs/book/src/22-hmac-key-rotation.md`.
- Cross-link: depends on envelope encryption (`feat/envelope-encryption`, merged via #149) for the v2 cipher format.
