### PR TITLE
ci(docker): add workflow_dispatch trigger for manual builds

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - '*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Tag to build (e.g. 8.3.1-rc.2)
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -25,7 +31,7 @@ jobs:
       - name: Classify tag
         id: tag
         run: |
-          TAG="${GITHUB_REF_NAME}"
+          TAG="${{ inputs.tag || github.ref_name }}"
           echo "version=${TAG}" >> $GITHUB_OUTPUT
           if echo "${TAG}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-'; then
             echo "prerelease=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Adds a `workflow_dispatch` input to `docker-release.yml` so the image
can be built manually when a tag push does not fire the webhook
(e.g. after delete + recreate of a tag).

After merging, trigger with:
```
gh workflow run docker-release.yml --ref main -f tag=8.3.1-rc.2
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)