### PR TITLE
chore: DeepSeek reviewer smoke test

### DIFF
--- a/.github/workflows/deepseek-pr-review.yml
+++ b/.github/workflows/deepseek-pr-review.yml
@@ -65,3 +65,4 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           gh pr comment "$PR_NUMBER" --body-file review_comment.md
+


### PR DESCRIPTION
Test PR to validate the DeepSeek PR review action. Can be closed after confirming the review comment appears.