### PR TITLE
feat: expose public app config and replace hardcoded brand name in templates

### DIFF
--- a/ports/api/src/main.rs
+++ b/ports/api/src/main.rs
@@ -72,7 +72,7 @@ use reqwest::header::{
     ACCESS_CONTROL_ALLOW_ORIGIN, CONTENT_LENGTH, CONTENT_TYPE,
 };
 use rest::{
-    index::heath_check_endpoints,
+    index::{app_public_config_endpoints, heath_check_endpoints},
     manager::{
         account_endpoints as manager_account_endpoints,
         guest_role_endpoints as manager_guest_role_endpoints,
@@ -365,6 +365,10 @@ pub async fn main() -> std::io::Result<()> {
             .service(
                 web::scope("/health")
                     .configure(heath_check_endpoints::configure),
+            )
+            .service(
+                web::scope("/app-config")
+                    .configure(app_public_config_endpoints::configure),
             )
             //
             // The well known openid configuration path

--- a/ports/api/src/rest/index/app_public_config_endpoints.rs
+++ b/ports/api/src/rest/index/app_public_config_endpoints.rs
@@ -1,0 +1,77 @@
+use actix_web::{get, web, HttpResponse, Responder};
+use myc_core::models::AccountLifeCycle;
+use serde::Serialize;
+use utoipa::{ToResponse, ToSchema};
+
+// ? ---------------------------------------------------------------------------
+// ? Configure application
+// ? ---------------------------------------------------------------------------
+
+pub fn configure(config: &mut web::ServiceConfig) {
+    config.service(get_app_public_config_url);
+}
+
+// ? ---------------------------------------------------------------------------
+// ? Define API structs
+// ? ---------------------------------------------------------------------------
+
+#[derive(Serialize, ToSchema, ToResponse)]
+#[serde(rename_all = "camelCase")]
+pub struct AppPublicConfigResponse {
+    pub domain_name: String,
+    pub domain_url: Option<String>,
+    pub locale: Option<String>,
+}
+
+// ? ---------------------------------------------------------------------------
+// ? Define API paths
+// ? ---------------------------------------------------------------------------
+
+/// Get public application configuration
+///
+/// Returns the application's public branding and locale settings:
+/// domain name, optional domain URL, and optional default locale.
+/// No authentication required.
+#[utoipa::path(
+    get,
+    operation_id = "get_app_public_config",
+    context_path = "/app-config",
+    responses(
+        (
+            status = 200,
+            description = "Application public configuration.",
+            body = AppPublicConfigResponse,
+        ),
+        (
+            status = 500,
+            description = "Configuration resolution failed.",
+        ),
+    ),
+    security(()),
+)]
+#[get("")]
+pub async fn get_app_public_config_url(
+    life_cycle_settings: web::Data<AccountLifeCycle>,
+) -> impl Responder {
+    let domain_name =
+        match life_cycle_settings.domain_name.async_get_or_error().await {
+            Ok(name) => name,
+            Err(_) => return HttpResponse::InternalServerError().finish(),
+        };
+
+    let domain_url = match &life_cycle_settings.domain_url {
+        Some(resolver) => resolver.async_get_or_error().await.ok(),
+        None => None,
+    };
+
+    let locale = match &life_cycle_settings.locale {
+        Some(resolver) => resolver.async_get_or_error().await.ok(),
+        None => None,
+    };
+
+    HttpResponse::Ok().json(AppPublicConfigResponse {
+        domain_name,
+        domain_url,
+        locale,
+    })
+}

--- a/ports/api/src/rest/index/mod.rs
+++ b/ports/api/src/rest/index/mod.rs
@@ -1,1 +1,2 @@
+pub(crate) mod app_public_config_endpoints;
 pub(crate) mod heath_check_endpoints;

--- a/ports/api/src/rest/role_scoped/beginners/user_endpoints.rs
+++ b/ports/api/src/rest/role_scoped/beginners/user_endpoints.rs
@@ -1050,12 +1050,19 @@ pub async fn request_magic_link_url(
 #[get("/magic-link/display")]
 pub async fn display_magic_link_url(
     query: web::Query<MagicLinkDisplayParams>,
+    life_cycle_settings: web::Data<AccountLifeCycle>,
     sql_app_module: web::Data<SqlAppModule>,
 ) -> impl Responder {
+    let domain_name = life_cycle_settings
+        .domain_name
+        .async_get_or_error()
+        .await
+        .unwrap_or_default();
+
     let email = match Email::from_string(query.email.to_owned()) {
         Err(err) => {
             warn!("Invalid email in magic link display: {}", err);
-            return render_magic_link_error_page();
+            return render_magic_link_error_page(&domain_name);
         }
         Ok(email) => email,
     };
@@ -1066,12 +1073,12 @@ pub async fn display_magic_link_url(
         .await
     {
         Ok(FetchResponseKind::Found(code)) => code,
-        _ => return render_magic_link_error_page(),
+        _ => return render_magic_link_error_page(&domain_name),
     };
 
     let mut context = TeraContext::new();
     context.insert("code", &code);
-    context.insert("app_name", "Mycelium");
+    context.insert("domain_name", &domain_name);
     context.insert("expires_in_minutes", &15u32);
 
     match TEMPLATES.render("web/magic-link-display.html", &context) {
@@ -1085,9 +1092,9 @@ pub async fn display_magic_link_url(
     }
 }
 
-fn render_magic_link_error_page() -> HttpResponse {
+fn render_magic_link_error_page(domain_name: &str) -> HttpResponse {
     let mut context = TeraContext::new();
-    context.insert("app_name", "Mycelium");
+    context.insert("domain_name", domain_name);
 
     match TEMPLATES.render("web/magic-link-display-error.html", &context) {
         Ok(html) => HttpResponse::Unauthorized()

--- a/ports/api/src/rpc/dispatchers/beginners.rs
+++ b/ports/api/src/rpc/dispatchers/beginners.rs
@@ -644,6 +644,34 @@ pub async fn dispatch_beginners(
                 }
             })
         }
+        method_names::BEGINNERS_APP_CONFIG_GET_PUBLIC_INFO => {
+            let life_cycle = life_cycle_settings
+                .ok_or_else(|| invalid_params("Life cycle config required"))?
+                .get_ref();
+            let domain_name = life_cycle
+                .domain_name
+                .async_get_or_error()
+                .await
+                .map_err(mapped_errors_to_jsonrpc_error)?;
+            let domain_url = match &life_cycle.domain_url {
+                Some(r) => r.async_get_or_error().await.ok(),
+                None => None,
+            };
+            let locale = match &life_cycle.locale {
+                Some(r) => r.async_get_or_error().await.ok(),
+                None => None,
+            };
+            serde_json::to_value(serde_json::json!({
+                "domainName": domain_name,
+                "domainUrl": domain_url,
+                "locale": locale,
+            }))
+            .map_err(|e| JsonRpcError {
+                code: types::codes::INTERNAL_ERROR,
+                message: e.to_string(),
+                data: None,
+            })
+        }
         _ => Err(JsonRpcError {
             code: types::codes::METHOD_NOT_FOUND,
             message: format!("Method not found: {}", method),

--- a/ports/api/src/rpc/method_names.rs
+++ b/ports/api/src/rpc/method_names.rs
@@ -28,6 +28,8 @@ pub const GATEWAY_MANAGER_SERVICES_LIST: &str = "gatewayManager.services.list";
 pub const GATEWAY_MANAGER_TOOLS_LIST: &str = "gatewayManager.tools.list";
 
 // Beginners
+pub const BEGINNERS_APP_CONFIG_GET_PUBLIC_INFO: &str =
+    "beginners.appConfig.getPublicInfo";
 pub const BEGINNERS_ACCOUNTS_CREATE: &str = "beginners.accounts.create";
 pub const BEGINNERS_ACCOUNTS_GET: &str = "beginners.accounts.get";
 pub const BEGINNERS_ACCOUNTS_UPDATE_NAME: &str =

--- a/ports/api/src/rpc/openrpc/methods/beginners.rs
+++ b/ports/api/src/rpc/openrpc/methods/beginners.rs
@@ -49,6 +49,27 @@ pub fn methods() -> Vec<serde_json::Value> {
 
     vec![
         serde_json::json!({
+            "name": method_names::BEGINNERS_APP_CONFIG_GET_PUBLIC_INFO,
+            "summary": "Get public application configuration",
+            "description": "Returns the application's public branding and locale settings (domainName, domainUrl, locale). No authentication required.",
+            "tags": [{ "name": "beginners" }, { "name": "appConfig" }],
+            "params": [],
+            "result": {
+                "name": "result",
+                "description": "Public config with domainName, domainUrl and locale",
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "domainName": { "type": "string" },
+                        "domainUrl": { "type": ["string", "null"] },
+                        "locale": { "type": ["string", "null"] }
+                    },
+                    "required": ["domainName"]
+                }
+            },
+            "errors": [{ "code": -32603, "message": "Internal error" }]
+        }),
+        serde_json::json!({
             "name": method_names::BEGINNERS_ACCOUNTS_CREATE,
             "summary": "Create a user-related account",
             "description": "Creates an account for a physical person. Uses credentials from the request (multi-identity provider).",

--- a/templates/en-us/email/base.jinja
+++ b/templates/en-us/email/base.jinja
@@ -39,7 +39,7 @@
                 <!-- Wordmark -->
                 <td style="padding: 24px 32px;">
                   <span
-                    style="font-family: Georgia, 'Times New Roman', Times, serif; font-size: 22px; font-weight: bold; color: #ffffff; letter-spacing: -0.02em;">Mycelium</span>
+                    style="font-family: Georgia, 'Times New Roman', Times, serif; font-size: 22px; font-weight: bold; color: #ffffff; letter-spacing: -0.02em;">{{ domain_name }}</span>
                 </td>
               </tr>
             </table>

--- a/templates/es/email/base.jinja
+++ b/templates/es/email/base.jinja
@@ -39,7 +39,7 @@
                 <!-- Wordmark -->
                 <td style="padding: 24px 32px;">
                   <span
-                    style="font-family: Georgia, 'Times New Roman', Times, serif; font-size: 22px; font-weight: bold; color: #ffffff; letter-spacing: -0.02em;">Mycelium</span>
+                    style="font-family: Georgia, 'Times New Roman', Times, serif; font-size: 22px; font-weight: bold; color: #ffffff; letter-spacing: -0.02em;">{{ domain_name }}</span>
                 </td>
               </tr>
             </table>

--- a/templates/pt-br/email/base.jinja
+++ b/templates/pt-br/email/base.jinja
@@ -39,7 +39,7 @@
                 <!-- Wordmark -->
                 <td style="padding: 24px 32px;">
                   <span
-                    style="font-family: Georgia, 'Times New Roman', Times, serif; font-size: 22px; font-weight: bold; color: #ffffff; letter-spacing: -0.02em;">Mycelium</span>
+                    style="font-family: Georgia, 'Times New Roman', Times, serif; font-size: 22px; font-weight: bold; color: #ffffff; letter-spacing: -0.02em;">{{ domain_name }}</span>
                 </td>
               </tr>
             </table>

--- a/templates/web/magic-link-display-error.html
+++ b/templates/web/magic-link-display-error.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>{{ app_name }} — Invalid Link</title>
+  <title>{{ domain_name }} — Invalid Link</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;700&display=swap" rel="stylesheet" />
@@ -48,11 +48,11 @@
 </head>
 <body>
   <div class="card">
-    <div class="brand">Mycelium</div>
+    <div class="brand">{{ domain_name }}</div>
     <h1>Link Invalid or Expired</h1>
     <p>
       This login link is invalid, has already been used, or has expired.<br/><br/>
-      Please return to {{ app_name }} and request a new login link.
+      Please return to {{ domain_name }} and request a new login link.
     </p>
   </div>
 </body>

--- a/templates/web/magic-link-display.html
+++ b/templates/web/magic-link-display.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>{{ app_name }} — Login Code</title>
+  <title>{{ domain_name }} — Login Code</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;700&display=swap" rel="stylesheet" />
@@ -65,8 +65,8 @@
 </head>
 <body>
   <div class="card">
-    <div class="brand">Mycelium</div>
-    <h1>Your {{ app_name }} Login Code</h1>
+    <div class="brand">{{ domain_name }}</div>
+    <h1>Your {{ domain_name }} Login Code</h1>
     <p>
       Enter the code below in the app to complete your login.<br/>
       This code expires in {{ expires_in_minutes }} minutes and can only be used once.


### PR DESCRIPTION
## Summary

- Add `GET /app-config` public REST endpoint and `beginners.appConfig.getPublicInfo` JSON-RPC method to expose `domainName`, `domainUrl`, and `locale` from `AccountLifeCycle` config — no auth required, no database involved
- Replace hardcoded `Mycelium` wordmark in all three email `base.jinja` templates (en-us, pt-br, es) with `{{ domain_name }}`
- Replace hardcoded `Mycelium` and `{{ app_name }}` in both magic-link web HTML templates with `{{ domain_name }}` for consistency with email templates
- Inject `AccountLifeCycle` into `display_magic_link_url` so `domain_name` is resolved from config at runtime instead of being hardcoded

## Test plan

- [ ] `GET /app-config` returns `{ domainName, domainUrl, locale }` from config with no auth token
- [ ] `beginners.appConfig.getPublicInfo` RPC returns same payload
- [ ] `rpc.discover` includes `beginners.appConfig.getPublicInfo` in the method list
- [ ] Magic link email header shows configured domain name instead of "Mycelium"
- [ ] Magic link display page (success and error) shows configured domain name instead of "Mycelium"

🤖 Generated with [Claude Code](https://claude.com/claude-code)