### PR TITLE
fix(standalone-mode): apply busy_timeout to the SQLite migration connection

### DIFF
--- a/adapters/diesel_sqlite/src/migration.rs
+++ b/adapters/diesel_sqlite/src/migration.rs
@@ -1,4 +1,4 @@
-use diesel::{Connection, SqliteConnection};
+use diesel::{connection::SimpleConnection, Connection, SqliteConnection};
 use diesel_migrations::{
     embed_migrations, EmbeddedMigrations, MigrationHarness,
 };
@@ -42,6 +42,19 @@ pub fn provision_database(url: &str) -> Result<(), MappedErrors> {
             "Failed to establish SQLite connection at {url}: {err}"
         ))
     })?;
+
+    // This connection bypasses `DieselSqliteDbPoolProvider`'s pool
+    // customizer (`SqlitePragmas`), so `busy_timeout` defaults to 0 --
+    // `SQLITE_BUSY` ("database is locked") fails instantly with no retry.
+    // That matters here specifically: this runs on every boot, and a
+    // previous instance (container restart, Ctrl+C) can still be mid
+    // shutdown and briefly holding the file. Match the pool's timeout so
+    // this one-off connection retries too instead of failing the first
+    // time it races a still-exiting previous process.
+    conn.batch_execute("PRAGMA busy_timeout = 5000;")
+        .map_err(|err| {
+            creation_err(format!("Failed to set busy_timeout: {err}"))
+        })?;
 
     run_pending_migrations(&mut conn)
 }
@@ -102,6 +115,54 @@ mod tests {
         }
 
         let _ = std::fs::remove_file(&path);
+    }
+
+    /// Reproduces the real failure: `provision_database` runs on every boot,
+    /// including a restart that races a still-shutting-down previous
+    /// process. Holds an exclusive write lock on a background thread (a
+    /// stand-in for that lingering process) and asserts `provision_database`
+    /// retries and eventually succeeds instead of failing instantly with
+    /// `SQLITE_BUSY` ("database is locked") -- which it did before this
+    /// connection had `busy_timeout` set (default is 0, no retry).
+    #[test]
+    fn provision_database_retries_when_transiently_locked() {
+        let path = std::env::temp_dir().join(format!(
+            "myc_sqlite_provision_locked_{}_{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        let url = path.to_str().unwrap().to_string();
+
+        provision_database(&url).unwrap();
+
+        let holder_url = url.clone();
+        let holder = std::thread::spawn(move || {
+            let mut conn = SqliteConnection::establish(&holder_url).unwrap();
+            conn.batch_execute("BEGIN EXCLUSIVE;").unwrap();
+            std::thread::sleep(std::time::Duration::from_millis(1500));
+            conn.batch_execute("COMMIT;").unwrap();
+        });
+
+        // Give the holder thread time to acquire the exclusive lock first.
+        std::thread::sleep(std::time::Duration::from_millis(200));
+
+        let start = std::time::Instant::now();
+        provision_database(&url).unwrap();
+        let waited = start.elapsed();
+
+        holder.join().unwrap();
+
+        assert!(
+            waited >= std::time::Duration::from_millis(1000),
+            "expected provision_database to block on the held lock and \
+             retry via busy_timeout, but it returned after {waited:?} -- \
+             either the lock wasn't actually held, or busy_timeout isn't \
+             applied",
+        );
+
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(format!("{url}-wal"));
+        let _ = std::fs::remove_file(format!("{url}-shm"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to #160 (already merged) — found and fixed while helping the user debug a
"database is locked" error reported after stopping/restarting the standalone container
(also reproduced with a plain Ctrl+C).

`provision_database` runs on every boot and opens a raw `SqliteConnection::establish` to
check/run pending migrations, bypassing `DieselSqliteDbPoolProvider`'s pool customizer
entirely — so this connection had no `busy_timeout` (SQLite defaults to 0, no retry on
`SQLITE_BUSY`), unlike every other connection in the app.

Root cause confirmed empirically: the previous process can still be mid-shutdown and
briefly holding the database file when the new one's migration check runs, and with
`busy_timeout=0` that check fails instantly instead of waiting.

## Fix

Set the same `PRAGMA busy_timeout = 5000` used by the pool on this one-off connection.
Added a test that holds an exclusive lock on a background thread and asserts
`provision_database` blocks and retries instead of failing immediately — confirmed it
reproduces `"database is locked"` verbatim when run against the code without this fix,
and passes with it.

Also verified live: sent `SIGINT` to a running standalone process and booted a second one
immediately (0s gap, more aggressive than the reported scenario) — clean boot, no lock
error, where it failed before.

## Known follow-up (not fixed here)

The standalone process doesn't exit cleanly on `SIGINT` — it lingers through graceful
shutdown and background dispatchers, then aborts with a glibc heap corruption error
(`malloc_consolidate(): unaligned fastbin chunk detected`) instead of exiting normally.
This fix makes the app tolerant of that lingering window; it doesn't address why the
window exists. Worth a separate investigation.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace --all` (206 core tests + all other crates, 0 failed)
- [x] `cargo build -p mycelium-api --no-default-features --features standalone`
- [x] New regression test: `provision_database_retries_when_transiently_locked` (fails
      without the fix, passes with it — verified both ways)
- [x] `scripts/standalone-e2e-smoke.sh`
- [x] Live repro: SIGINT + immediate restart, no lock error