### PR TITLE
feat(release): harden pipeline — crates.io OIDC, auto GitHub Releases, signed images

### DIFF
--- a/.claude/specs/features/release-pipeline-hardening/design.md
+++ b/.claude/specs/features/release-pipeline-hardening/design.md
@@ -1,0 +1,405 @@
+# Design: Release Pipeline Hardening
+
+**Feature:** release-pipeline-hardening
+**Spec:** `./spec.md`
+**Status:** Design
+**Created:** 2026-07-11
+
+Implements REL-01..15 from `spec.md`, plus two follow-ups raised directly by the user in this
+round (tracked as REL-16/REL-17 below): a crates.io publish retry/backoff story, and the 9.0.0
+major-bump-via-RCs process.
+
+---
+
+## 1. Current state (verified by reading the actual workflow files)
+
+| File | Current behavior | Problem |
+|---|---|---|
+| `release-prerelease.yml` / `release-stable.yml` | Single `cargo release <level> --execute --no-confirm` step. `CARGO_REGISTRY_TOKEN` from a repo secret. | Publish, tag, and push all happen inside one opaque command. If publish fails partway (crates.io throttling), the version-bump commit was made locally but never pushed (job is ephemeral) — a retry re-runs the whole command from the original base version, re-bumping to a *different* version and stranding the partially-published crates at an orphaned, never-tagged version. |
+| `docker-release.yml` | Triggers on tag push or `workflow_dispatch` with a `tag` input. Computes `steps.tag.outputs.version` from `inputs.tag \|\| github.ref_name`, but the `actions/checkout@v4` step has **no `ref:`** — it always checks out whatever ref triggered the workflow (for `workflow_dispatch`, that's the branch the dispatch was run from, not the tag). | REL-09/REL-10: a manual rebuild of an old tag builds from the current default branch, so the image's `VERSION` label and its actual content disagree. |
+| *(no workflow)* | Nothing ever creates a GitHub Release. | REL-01..04: Releases (`v8.2.1` GA, a stale `8.3.1-rc.2` Draft) are stuck behind the images/crates that already moved to `8.3.1-rc.5`. |
+| `docker-release.yml` | No provenance, no signing. | REL-12/13: consumers can't verify image origin. |
+| `release.toml` | `tag-name = "{{version}}"` (no `v` prefix) — already the target convention. | REL-14/15: just needs documenting; no renaming of historical `v*` tags. |
+| `release.toml` | `[rate-limit] new-packages = 5 / existing-packages = 30` already present. | cargo-release *does* have a built-in rate-limiter (queries crates.io's own published-count API and paces publishes to stay under crates.io's documented limits). This existing config is correct and is kept — the gap is what happens when crates.io still throttles anyway (global account-wide limits, clock/window edge cases), which the current single-shot workflow has no graceful recovery from. |
+
+---
+
+## 2. Ordering principle (unchanged from spec.md — and from cargo-release's own default)
+
+```
+version bump ──▶ commit (local, not pushed) ──▶ publish (rate-limited) ──▶ tag ──▶ push
+                                                        │
+                                               success  │  failure
+                                                        ▼         ╲
+                                              (continues above)    ╲──▶ job fails here.
+                                                                        Nothing was ever
+                                                                        pushed (tag or
+                                                                        branch) -- remote
+                                                                        state is untouched,
+                                                                        exactly as if the
+                                                                        run never happened.
+```
+
+**Revised from an earlier draft of this doc** (caught in review): the first version of this design
+pushed the bump commit to `develop`/`main` immediately after bump, *before* publish, reasoning
+that it would make a failed publish resumable without re-bumping. That trades away a property the
+*current* single-command flow already has for free — cargo-release's own default order is
+version → commit → publish → tag → **push last** — so today, if publish fails, the branch is
+never touched at all. Pushing early would mean a failed publish leaves `develop` carrying a
+"Release 9.0.0-rc.1" commit for a version that was never actually released (no tag, not fully on
+crates.io) — anyone branching off `develop` in that window sees a lie. Keeping this repo's design.
+below preserves push-last.
+
+Splitting `cargo release` into separate step invocations (bump+commit → publish → tag+push) inside
+the **same job** (same checkout, same working directory, no push in between) still lets us slot the
+OIDC auth step in between bump and publish, without ever pushing before publish succeeds — the job
+simply fails and ends before reaching the tag/push steps if publish fails, same as today.
+
+**Recovery after a failed publish depends on the bump kind:**
+- **Fixed-target bumps** (`major`, `minor`, `patch`, `release`): the target version is deterministic
+  regardless of how many times you compute it. Simply **re-dispatch the same workflow** — it
+  recomputes the identical target version, and `cargo release publish` already skips crates that
+  got published in the previous (failed) attempt, so the retry only publishes what's left, then
+  proceeds to tag+push normally. No manual intervention beyond re-running the workflow.
+- **Relative bumps** (`rc`, `beta`): re-dispatching increments again (`rc.1` → `rc.2`), it does not
+  retry `rc.1`. The simplest safe recovery is to **abandon the failed rc/beta attempt** — the
+  handful of crates that did publish at that orphaned version stay on crates.io (harmless; version
+  numbers aren't reused, nothing references that untagged version) — and just cut the next rc/beta
+  number, which starts clean. This needs no special tooling, only documenting (§8).
+
+---
+
+## 3. `release-prerelease.yml` / `release-stable.yml` — staged steps
+
+Both files get the same shape (only the `release_type` choices and the `if: github.ref` branch
+differ, as today). Replace the single "Run release" step with:
+
+```yaml
+    permissions:
+      contents: write
+      id-token: write   # REL-05: OIDC token for crates-io-auth-action
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}   # unchanged — must cascade to tag-triggered workflows
+          fetch-depth: 0
+      # ... (Rust toolchain, rust-cache, cargo-release, git-cliff install — unchanged) ...
+
+      - name: Configure git identity
+        run: |
+          git config user.name "Samuel Galvão Elias"
+          git config user.email "sgelias@outlook.com"
+
+      # release-prerelease.yml only: a `custom_version` input overrides
+      # release_type, for the one bump cargo-release's LEVEL keywords can't
+      # express (the first RC of a new major -- see §9). Both are exported
+      # as env vars and resolved to $TARGET via a shell step, never
+      # interpolated directly into a `run:` block (workflow-injection
+      # hardening, flagged by this repo's own security hook).
+      - name: Bump version, changelog, commit (dry run)
+        if: inputs.dry_run == true
+        run: cargo release "$TARGET" --no-publish --no-tag --no-push
+
+      - name: Bump version, changelog, commit (no publish/tag/push yet)
+        if: inputs.dry_run == false
+        run: |
+          cargo release "$TARGET" --execute --no-confirm --no-publish --no-tag --no-push
+
+      # REL-05/06: short-lived OIDC token, not a stored secret
+      - name: Authenticate to crates.io (Trusted Publishing)
+        if: inputs.dry_run == false
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+
+      - name: Publish crates (rate-limited by release.toml's [rate-limit])
+        if: inputs.dry_run == false
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo release publish --execute --no-confirm
+        # If this step fails partway (crates.io still throttling despite
+        # [rate-limit]), nothing has been pushed -- the bump commit only
+        # exists in this ephemeral runner's working tree, exactly like
+        # today's single-command flow. See docs/book/src/08-release-process.md
+        # for the recovery procedure (differs for fixed vs. rc/beta bumps).
+
+      - name: Tag and push
+        if: inputs.dry_run == false
+        run: cargo release tag --execute --no-confirm && cargo release push --execute --no-confirm
+```
+
+Notes:
+- `--no-publish --no-tag --no-push` on the bump step, then a dedicated `publish` step, then a
+  dedicated `tag`+`push` step, all in the *same job* with no push in between: these map 1:1 onto
+  cargo-release's own documented sub-steps (`version`, `commit`, `publish`, `tag`, `push` —
+  confirmed via `cargo release --help`) and preserve the exact same "nothing pushed if publish
+  fails" property the current single-command flow already has — the only thing that changes is
+  where the OIDC auth step slots in.
+- `rust-lang/crates-io-auth-action@v1` (REL-05/06) exchanges the job's OIDC token for a
+  short-lived (≤30 min) crates.io token, exported as `steps.auth.outputs.token`. This is fed to
+  `CARGO_REGISTRY_TOKEN` for just the publish step — never a repo secret.
+- **External prerequisite (cannot be done from this repo's code):** each of the 15 publishable
+  crates must have **Trusted Publishing** configured on its own crates.io settings page (Owner →
+  Publishing → GitHub Actions), pointing at this repo + the `release-prerelease.yml`/
+  `release-stable.yml` workflow filenames. This is a **manual, one-time, per-crate,
+  crates.io-account-owner action** — flagged clearly in tasks.md, not something I can automate.
+  Until it's done for a crate, that crate's publish step will fail auth; keep
+  `CARGO_REGISTRY_TOKEN` (the secret) as a fallback in `publish-crates.yml` (see below) until all
+  15 crates have Trusted Publishing configured, then remove the secret (REL-07).
+
+---
+
+## 4. `publish-crates.yml` — kept as manual OIDC-first fallback
+
+Per spec.md's Recommended Approach ("Keep `publish-crates.yml` as a manual OIDC-based fallback
+only"): same OIDC auth step added, `CARGO_REGISTRY_TOKEN` env now sourced from
+`steps.auth.outputs.token`. This is also the **documented manual-retry entry point** — an operator
+can run this workflow with `workflow_dispatch` (dry_run=false) any time after a partial publish
+failure; `cargo release publish` skips already-published crates automatically.
+
+---
+
+## 5. `docker-release.yml` — ref fix, provenance, signing, split into two jobs
+
+```yaml
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  image:
+    permissions:
+      contents: read
+      packages: write
+      id-token: write        # REL-13: cosign keyless
+      attestations: write     # REL-12: build provenance
+    outputs:
+      version: ${{ steps.tag.outputs.version }}
+      prerelease: ${{ steps.tag.outputs.prerelease }}
+      prerelease_type: ${{ steps.tag.outputs.prerelease_type }}
+      digest: ${{ steps.push.outputs.digest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}   # REL-09/10: THE FIX -- was missing entirely
+
+      - name: Classify tag
+        id: tag
+        run: |
+          TAG="${{ inputs.tag || github.ref_name }}"
+          # ... unchanged classification logic ...
+
+      # `github.repository` is case-preserved ("LepistaBioinformatics/mycelium").
+      # docker/metadata-action lowercases internally (why builds work today),
+      # but cosign and attest-build-provenance below do NOT -- GHCR/OCI image
+      # refs must be all-lowercase or both steps fail. Compute it once, reuse
+      # everywhere.
+      - name: Lowercase image name
+        id: image
+        run: echo "name=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.image.outputs.name }}
+          # ... tags: unchanged (same 3-line type=raw block as today) ...
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with: { registry: ghcr.io, username: ${{ github.actor }}, password: ${{ secrets.GITHUB_TOKEN }} }
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: VERSION=${{ steps.tag.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # REL-12
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ steps.image.outputs.name }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+      # REL-13
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign image (keyless)
+        run: |
+          cosign sign --yes \
+            ${{ steps.image.outputs.name }}@${{ steps.push.outputs.digest }}
+
+  github-release:
+    needs: image
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}
+          fetch-depth: 0   # git-cliff needs history
+
+      - name: Install git-cliff
+        run: cargo install git-cliff --locked
+
+      - name: Generate release notes
+        id: notes
+        run: |
+          git-cliff --latest --strip header -o /tmp/notes.md
+          echo "path=/tmp/notes.md" >> "$GITHUB_OUTPUT"
+
+      # REL-01..04: idempotent -- gh release create errors if the tag already
+      # has a Release, so fall back to `edit` in that case instead of failing
+      # the job (re-runs, e.g. workflow_dispatch replays, stay safe).
+      - name: Create or update GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ needs.image.outputs.version }}"
+          PRERELEASE_FLAG=""
+          if [ "${{ needs.image.outputs.prerelease }}" = "true" ]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" --notes-file "${{ steps.notes.outputs.path }}" $PRERELEASE_FLAG
+          else
+            gh release create "$TAG" --title "$TAG" --notes-file "${{ steps.notes.outputs.path }}" $PRERELEASE_FLAG
+          fi
+```
+
+Two jobs instead of one so a `github-release` failure (e.g. `git-cliff` hiccup) doesn't need a
+full image rebuild+resign to retry — `needs: image` still lets `workflow_dispatch` re-run the
+whole workflow for a tag when needed (idempotent either way, since publish/sign target the same
+digest and Release creation checks for an existing Release first).
+
+`gh release create/edit` uses `github.token` (the built-in `GITHUB_TOKEN`), not the same PAT used
+for the release-bump workflows -- creating a Release doesn't need to *cascade* to another
+workflow, unlike the tag push, so the default token's non-cascading behavior is fine here and
+keeps permissions minimal (`contents: write` only, no PAT needed for this job).
+
+---
+
+## 6. Cross-cutting hardening
+
+- **Least-privilege `permissions:`**: every job above now declares only what it uses (shown
+  inline). Top-level workflow `permissions:` stays `contents: read` where a job doesn't need
+  more; each job overrides as needed (GitHub Actions job-level `permissions:` takes precedence).
+- **Pin third-party actions to full commit SHA**: `docker/metadata-action`, `docker/login-action`,
+  `docker/setup-buildx-action`, `docker/build-push-action`, `actions/attest-build-provenance`,
+  `sigstore/cosign-installer`, `rust-lang/crates-io-auth-action`, `dtolnay/rust-toolchain`,
+  `Swatinem/rust-cache` — pin each to the SHA of the tag currently referenced (recorded with a
+  `# vX.Y.Z` trailing comment per GitHub's own recommended convention). Exact SHAs resolved at
+  implementation time via `gh api repos/<owner>/<repo>/git/refs/tags/<tag>`.
+- **GitHub Environment `release`**: `release-stable.yml`, `release-prerelease.yml`, and
+  `publish-crates.yml`'s jobs gain `environment: release`. **External prerequisite:** the
+  `release` Environment plus its required-reviewers rule must be created in the repo's Settings →
+  Environments UI — not something expressible in workflow YAML alone. Flagged in tasks.md.
+- **Removing `CARGO_REGISTRY_TOKEN`** (REL-07): only after every crate has Trusted Publishing
+  configured AND at least one full release cycle (an RC) has succeeded end-to-end using OIDC.
+  Sequenced last in tasks.md, deliberately not bundled with the workflow-file edits.
+
+---
+
+## 7. Naming convention documentation (REL-14/15)
+
+No code change (`tag-name = "{{version}}"` in `release.toml` is already the target, no `v`
+prefix). Add a short section to `.claude/specs/project/STATE.md` (or a new
+`docs/book/src/08-release-process.md`, see below) recording: tags are `X.Y.Z` /
+`X.Y.Z-beta.N` / `X.Y.Z-rc.N`, no `v` prefix; historical `v*` tags (pre-8.3.0) are left as-is,
+never renamed; image tags mirror this (`:X.Y.Z`+`:latest` stable, `:X.Y.Z-rc.N`+`:rc`, etc.,
+already implemented in `docker-release.yml`'s tag classification step).
+
+---
+
+## 8. REL-16 (new) — crates.io publish retry runbook
+
+Not a code change beyond the staged workflow steps in §3 — a **documented runbook** (new
+`docs/book/src/08-release-process.md`) covering:
+
+1. Normal flow: dispatch `release-prerelease.yml` (or `-stable.yml`) with `dry_run: true` first,
+   review the bump diff, then re-dispatch with `dry_run: false`.
+2. If the **publish** step fails (crates.io throttling despite `release.toml`'s `[rate-limit]`,
+   network blip, or a specific crate's own issue): per §2, **nothing has been pushed** — the
+   partial run's local commit died with the runner. Recovery depends on what kind of bump it was:
+   - **`major`/`minor`/`patch`/`release`** (deterministic target version): just **re-dispatch the
+     same workflow**. It recomputes the identical target version; `cargo release publish` skips
+     the crates that already succeeded in the previous attempt and only publishes what's left.
+   - **`rc`/`beta`** (relative bump): do **not** re-dispatch — it would produce `rc.N+1`, not retry
+     `rc.N`. Instead, treat the partial `rc.N`/`beta.N` as abandoned (the handful of crates that
+     did publish at that version are harmless orphans on crates.io — untagged, unreferenced,
+     nothing depends on that exact version existing) and dispatch the workflow again for the
+     **next** rc/beta number. This needs no special tooling.
+   - `publish-crates.yml` (manual, OIDC-based) is also available any time as a standalone
+     re-publish pass — useful if you want to retry *only* the publish step without touching
+     bump/tag/push at all (e.g. crates.io was down when a `major`/`minor` bump's publish step
+     failed, and you don't want to re-run the whole bump workflow for unrelated reasons).
+
+---
+
+## 9. REL-17 (new) — 9.0.0 major bump via RCs
+
+Per the user: routine major bump, no known breaking API changes — the "manual adjustment" concern
+was general caution, not a specific known blocker. Process (uses existing `cargo release` levels,
+no new tooling):
+
+1. From `develop`, dispatch `release-prerelease.yml` with `release_type: rc` — but `rc` **bumps
+   the rc *pre-version***, it does not jump to a new major. To go from the current `8.3.1-rc.N`
+   line to `9.0.0-rc.1`, cargo-release's `LEVEL` keywords can't compose "major" + "rc" in one call
+   (and `--metadata`/`-m` is semver *build* metadata after a `+`, e.g. `9.0.0+rc.1` — **not** a
+   pre-release identifier; verified against cargo-release's own docs, this was wrong in an earlier
+   draft of this section). The correct approach is cargo-release's other accepted form of its
+   `[LEVEL|VERSION]` argument: an **explicit target version string**, which must be valid semver
+   and greater than the current version:
+   ```
+   cargo release 9.0.0-rc.1 --execute --no-confirm --no-publish --no-tag --no-push
+   ```
+   `release-prerelease.yml` now has a `custom_version` input specifically for this (overrides
+   `release_type` when set) — dispatch it with `custom_version: 9.0.0-rc.1`, `release_type` left
+   blank. Every subsequent RC in the 9.0.0 line uses the normal `release_type: rc` dropdown again
+   (`9.0.0-rc.1` → `rc` level → `9.0.0-rc.2`, etc. — verify via a `dry_run: true` dispatch before
+   executing for real, same as any other bump).
+2. Each RC goes through the full staged pipeline (§2): bump (local) → publish → tag+push → image
+   (signed+attested) → GitHub prerelease. Verify end-to-end (install the RC crate, boot the RC
+   image) before cutting the next RC or promoting to stable.
+3. Promote to stable with `cargo release release` (cargo-release's dedicated level that strips
+   the pre-release suffix, `9.0.0-rc.N` → `9.0.0`) via `release-stable.yml`.
+4. This is also the **first real end-to-end exercise of OIDC Trusted Publishing** (§3) — do the
+   crates.io Trusted Publishing setup (external prerequisite) before cutting `9.0.0-rc.1`, and keep
+   `CARGO_REGISTRY_TOKEN` as a fallback until this cycle proves it works, per §6.
+
+---
+
+## 10. Verification plan
+
+No `actionlint`/`yamllint` available locally — verification instead:
+- `python3 -c "import yaml; yaml.safe_load(open(f))"` against every edited workflow file (catches
+  YAML syntax errors, not GitHub Actions semantic errors).
+- Manual review of every `${{ }}` expression and `needs:`/`outputs:` wiring against GitHub Actions
+  documented syntax.
+- Confirm the lowercase-image-name step actually lowercases `LepistaBioinformatics/mycelium`
+  (test the `tr` one-liner locally) and that both `attest-build-provenance` and `cosign sign`
+  reference `steps.image.outputs.name`, never a raw `${{ github.repository }}` interpolation.
+- `dry_run: true` dispatch of `release-prerelease.yml` (safe -- `--no-publish --no-tag`, nothing
+  irreversible) as the actual functional test once pushed, run by the user (I cannot dispatch
+  `workflow_dispatch` runs against the real repo from here in a way that's meaningfully safer than
+  the user doing it themselves, and doing so would be taking a real CI action on their behalf
+  without being asked).
+- Full gate (`cargo fmt`, `cargo build --workspace`, `cargo test --workspace --all`) — unaffected
+  by this feature (CI/docs only), run anyway to confirm no accidental source changes.

--- a/.claude/specs/features/release-pipeline-hardening/spec.md
+++ b/.claude/specs/features/release-pipeline-hardening/spec.md
@@ -1,0 +1,232 @@
+# Release Pipeline Hardening Specification
+
+## Problem Statement
+
+The release cycle produces git tags (via `cargo release`) that build & push Docker images to
+GHCR automatically, but **no workflow ever creates a GitHub Release**. As a result the GHCR
+images are out of sync with GitHub Releases: images exist up to `8.3.1-rc.5` while the newest
+*published* Release is still `v8.2.1` (plus a stale `8.3.1-rc.2` Draft). On top of the missing
+release step, the pipeline relies on a long-lived `CARGO_REGISTRY_TOKEN` secret, produces no
+supply-chain provenance/signatures for images, and has a `workflow_dispatch` bug that builds an
+image from the wrong source ref. This feature makes tag → crates.io publish → GitHub Release →
+signed GHCR image a single, atomic, secure, and reproducible flow.
+
+## Goals
+
+- [ ] Every published tag results in a **GitHub Release** (pre-release flag for `beta`/`rc`),
+      with notes generated from `git-cliff`/`CHANGELOG.md` — zero manual release steps.
+- [ ] Every published tag results in **exactly one GHCR image built from that tag's source**,
+      tagged consistently, with no `workflow_dispatch` ref drift.
+- [ ] crates.io publishing uses **Trusted Publishing (OIDC)** — no long-lived
+      `CARGO_REGISTRY_TOKEN` secret stored in the repo.
+- [ ] GHCR images carry **build provenance attestation** and are **signed (cosign keyless)**,
+      so downstream consumers can verify origin (SLSA-aligned).
+- [ ] Tag/version/image naming is **consistent and documented** (resolve the `v`-prefix drift).
+- [ ] A failure at any stage leaves a **recoverable, non-contradictory state** (re-runnable on
+      the tag), and the irreversible step (crates.io publish) runs **before** the tag is pushed.
+
+## Out of Scope
+
+| Feature | Reason |
+| --- | --- |
+| Webapp (`mycelium-webapp`) release/deploy pipeline | Separate module; this spec is gateway-only |
+| SDK-py (`mycelium-sdk-py`) PyPI publishing | Separate module & registry; different flow |
+| Dokploy / production deploy automation | Deployment consumes images; out of the release-artifact scope |
+| Retroactively creating Releases for pre-`8.3.1` tags | One-off cleanup, tracked as a manual todo — not pipeline logic |
+| Yanking / republishing already-published crates | crates.io publish is irreversible; recovery is operational, not automated |
+| Multi-arch (arm64) image builds | Current images are single-arch; can be a later P3 enhancement |
+
+---
+
+## User Stories
+
+### P1: Automated GitHub Release on every tag ⭐ MVP
+
+**User Story**: As a maintainer, I want a GitHub Release created automatically for every release
+tag so that Releases stay in sync with tags and GHCR images.
+
+**Why P1**: This is the direct cause of the observed desync — the missing piece.
+
+**Acceptance Criteria**:
+
+1. WHEN a version tag (`X.Y.Z` or `X.Y.Z-beta.N` / `X.Y.Z-rc.N`) is pushed THEN the pipeline
+   SHALL create a GitHub Release for that tag.
+2. WHEN the tag is a pre-release (`-beta.` / `-rc.`) THEN the Release SHALL be flagged
+   `prerelease = true`; WHEN it is a stable `X.Y.Z` tag THEN it SHALL be flagged as the latest
+   stable Release.
+3. WHEN the Release is created THEN its body SHALL be populated from `git-cliff` /
+   `CHANGELOG.md` notes for that version.
+4. WHEN a Release for that tag already exists THEN the step SHALL be idempotent (update or no-op,
+   never fail the pipeline nor duplicate).
+
+**Independent Test**: Push a throwaway `0.0.0-rc.1` tag on a test branch → a pre-release GitHub
+Release appears with changelog notes; re-running the workflow does not duplicate it.
+
+---
+
+### P2: Trusted Publishing for crates.io (OIDC, no stored token)
+
+**User Story**: As a maintainer, I want crates.io publishing to authenticate via GitHub OIDC so
+that no long-lived registry token is stored in repository secrets.
+
+**Why P2**: Removes the highest-value standing secret; short-lived (≤30 min) scoped tokens.
+
+**Acceptance Criteria**:
+
+1. WHEN the publish job runs THEN it SHALL obtain a short-lived crates.io token via
+   `rust-lang/crates-io-auth-action@v1` using `permissions: id-token: write`.
+2. WHEN publishing THEN `cargo release publish` (or `cargo publish`) SHALL consume the token via
+   `CARGO_REGISTRY_TOKEN` from the action output, not from a repository secret.
+3. WHEN crates.io Trusted Publishing is configured THEN the stored `CARGO_REGISTRY_TOKEN` secret
+   SHALL be removed from the repository.
+4. WHEN the crates.io publish fails THEN the tag SHALL NOT be pushed (publish runs before tag),
+   leaving no orphan tag/image/release.
+
+**Independent Test**: Run the release in dry-run → auth step exchanges OIDC successfully; confirm
+no `CARGO_REGISTRY_TOKEN` remains under repo secrets after cutover.
+
+---
+
+### P2: Reproducible, correctly-sourced GHCR image
+
+**User Story**: As a maintainer, I want the image to always be built from the exact tagged
+commit so that the image content matches its version label.
+
+**Why P2**: The current `workflow_dispatch` path checks out the default branch, not `inputs.tag`.
+
+**Acceptance Criteria**:
+
+1. WHEN the image workflow is triggered by tag push THEN it SHALL check out the tag ref.
+2. WHEN the image workflow is triggered via `workflow_dispatch` with a `tag` input THEN it SHALL
+   check out that tag ref (`ref: ${{ inputs.tag || github.ref_name }}`), never the default branch.
+3. WHEN building THEN it SHALL pass `build-args: VERSION=<tag>` and produce image tags per the
+   documented tagging strategy (`:X.Y.Z` + `:latest` for stable; `:X.Y.Z-rc.N` + `:rc`; etc.).
+4. WHEN the same tag is built twice THEN the resulting image SHALL be reproducible from identical
+   source (no drift).
+
+**Independent Test**: `workflow_dispatch` for an existing older tag → the pushed image's embedded
+`VERSION` and source match that tag, not `main`.
+
+---
+
+### P2: Supply-chain provenance & signing for images
+
+**User Story**: As a downstream operator, I want to verify that a GHCR image was built by this
+repo's release workflow so that I can trust its origin.
+
+**Why P2**: "Most secure" requirement; enables SLSA-style verification.
+
+**Acceptance Criteria**:
+
+1. WHEN an image is pushed THEN a build provenance attestation SHALL be generated via
+   `actions/attest-build-provenance` for the image digest.
+2. WHEN an image is pushed THEN it SHALL be signed keyless via cosign (Sigstore/Fulcio) using
+   `permissions: id-token: write`, bound to the workflow's OIDC identity.
+3. WHEN a consumer runs `cosign verify` with the expected identity/issuer THEN verification SHALL
+   succeed for released images.
+
+**Independent Test**: `cosign verify --certificate-identity-regexp ... --certificate-oidc-issuer https://token.actions.githubusercontent.com ghcr.io/.../mycelium:<tag>` succeeds.
+
+---
+
+### P3: Consistent, documented version/tag/image naming
+
+**User Story**: As a maintainer, I want one documented naming convention so that tags, images,
+and Releases line up predictably.
+
+**Why P3**: Cleanup of historical `v`-prefix drift (`v8.2.1` vs `8.3.0`); important but not blocking.
+
+**Acceptance Criteria**:
+
+1. WHEN a decision is recorded THEN either `tag-name = "{{version}}"` (no `v`) or
+   `tag-name = "v{{version}}"` SHALL be applied consistently in `release.toml` **and** Cargo.toml
+   `[workspace.metadata.release]`.
+2. WHEN the convention changes THEN `docker-release.yml` tag classification regex and any
+   downstream references SHALL be updated to match.
+3. WHEN documented THEN the convention SHALL be recorded in STATE.md / codebase docs.
+
+---
+
+## Edge Cases
+
+- WHEN `git-cliff` produces empty notes for a version THEN the Release SHALL still be created
+  with a minimal auto-generated body (never fail).
+- WHEN the tag push webhook is missed (as happened for `8.3.1-rc.2`) THEN `workflow_dispatch`
+  with the tag SHALL fully reproduce crates publish (if needed) + image + Release.
+- WHEN a stable tag is pushed THEN `:latest` SHALL move to it; WHEN a pre-release tag is pushed
+  THEN `:latest` SHALL NOT move.
+- WHEN crates.io reports "already published" for a crate (retry after partial publish) THEN the
+  publish step SHALL treat it as success/skip, not hard-fail the pipeline.
+- WHEN the image build succeeds but signing/attestation fails THEN the pipeline SHALL fail
+  visibly (no silently-unsigned released image) and be safely re-runnable on the tag.
+- WHEN two release workflows race THEN concurrency groups SHALL serialize them.
+
+---
+
+## Recommended Approach (secure target architecture)
+
+Recorded here per request; concrete YAML belongs in `design.md`.
+
+**Ordering principle:** the irreversible step (crates.io publish) runs **inside the bump job,
+before the tag is pushed** — `cargo release`'s native order is bump → commit → publish → tag →
+push. If publish fails, no tag exists and nothing downstream fires. Recoverable steps (image,
+Release) run **after**, triggered by the tag, and are re-runnable.
+
+1. **Release bump job** (`release-stable.yml` / `release-prerelease.yml`, `workflow_dispatch`):
+   - `permissions: { contents: write, id-token: write }`.
+   - `rust-lang/crates-io-auth-action@v1` → export `CARGO_REGISTRY_TOKEN` (OIDC, short-lived).
+   - `cargo release <type> --execute --no-confirm` (bump + changelog + publish + tag + push).
+   - Push uses `RELEASE_TOKEN` (PAT/App) so the tag push **cascades** to tag-triggered workflows
+     (the built-in `GITHUB_TOKEN` would NOT cascade).
+
+2. **Tag-triggered artifact workflow** (`docker-release.yml`, extended — on `push: tags`):
+   - Job `image`: `permissions: { contents: read, packages: write, id-token: write,
+     attestations: write }`; checkout the tag ref; build from `Dockerfile`; push to GHCR;
+     `actions/attest-build-provenance`; cosign keyless sign.
+   - Job `github-release` (`needs: image`): `permissions: { contents: write }`; create/update
+     the GitHub Release from `git-cliff` notes; `--prerelease` for `beta`/`rc`.
+
+3. **Cross-cutting hardening:**
+   - Least-privilege `permissions:` per job (default read).
+   - Pin third-party actions to full commit SHA.
+   - Optional GitHub `Environment: release` with required reviewers gating publish.
+   - Remove `CARGO_REGISTRY_TOKEN` repo secret after Trusted Publishing cutover.
+   - Keep `publish-crates.yml` as a manual OIDC-based fallback only.
+
+---
+
+## Requirement Traceability
+
+| Requirement ID | Story | Phase | Status |
+| --- | --- | --- | --- |
+| REL-01 | P1: Auto GitHub Release | Design | Pending |
+| REL-02 | P1: pre-release vs stable flagging | Design | Pending |
+| REL-03 | P1: changelog notes in Release | Design | Pending |
+| REL-04 | P1: idempotent Release creation | Design | Pending |
+| REL-05 | P2: OIDC Trusted Publishing auth | Design | Pending |
+| REL-06 | P2: token from action, not secret | Design | Pending |
+| REL-07 | P2: remove stored CARGO_REGISTRY_TOKEN | Design | Pending |
+| REL-08 | P2: publish-before-tag ordering | Design | Pending |
+| REL-09 | P2: image built from correct tag ref | Design | Pending |
+| REL-10 | P2: workflow_dispatch ref fix | Design | Pending |
+| REL-11 | P2: documented image tag strategy | Design | Pending |
+| REL-12 | P2: build provenance attestation | Design | Pending |
+| REL-13 | P2: cosign keyless signing | Design | Pending |
+| REL-14 | P3: consistent tag/version naming | Design | Pending |
+| REL-15 | P3: naming documented in STATE/docs | Design | Pending |
+
+**ID format:** `REL-[NUMBER]`
+**Status values:** Pending → In Design → In Tasks → Implementing → Verified
+**Coverage:** 15 total, 0 mapped to tasks, 15 unmapped ⚠️ (Tasks phase pending)
+
+---
+
+## Success Criteria
+
+- [ ] For a full `beta → rc → stable` cycle, each pushed tag has: a matching GitHub Release, a
+      matching signed GHCR image built from that tag, and (for the bump) published crates.
+- [ ] No `CARGO_REGISTRY_TOKEN` secret exists in the repository; publishing still works via OIDC.
+- [ ] `cosign verify` succeeds against a released image with the expected workflow identity.
+- [ ] A deliberately failed publish leaves no orphan tag/image/Release.
+- [ ] `workflow_dispatch` rebuild of an old tag produces an image whose source matches that tag.
+- [ ] Tag/image/Release naming convention is single and documented.

--- a/.claude/specs/features/release-pipeline-hardening/spec.md
+++ b/.claude/specs/features/release-pipeline-hardening/spec.md
@@ -199,25 +199,29 @@ Release) run **after**, triggered by the tag, and are re-runnable.
 
 | Requirement ID | Story | Phase | Status |
 | --- | --- | --- | --- |
-| REL-01 | P1: Auto GitHub Release | Design | Pending |
-| REL-02 | P1: pre-release vs stable flagging | Design | Pending |
-| REL-03 | P1: changelog notes in Release | Design | Pending |
-| REL-04 | P1: idempotent Release creation | Design | Pending |
-| REL-05 | P2: OIDC Trusted Publishing auth | Design | Pending |
-| REL-06 | P2: token from action, not secret | Design | Pending |
-| REL-07 | P2: remove stored CARGO_REGISTRY_TOKEN | Design | Pending |
-| REL-08 | P2: publish-before-tag ordering | Design | Pending |
-| REL-09 | P2: image built from correct tag ref | Design | Pending |
-| REL-10 | P2: workflow_dispatch ref fix | Design | Pending |
-| REL-11 | P2: documented image tag strategy | Design | Pending |
-| REL-12 | P2: build provenance attestation | Design | Pending |
-| REL-13 | P2: cosign keyless signing | Design | Pending |
-| REL-14 | P3: consistent tag/version naming | Design | Pending |
-| REL-15 | P3: naming documented in STATE/docs | Design | Pending |
+| REL-01 | P1: Auto GitHub Release | Tasks | Implemented (`docker-release.yml` `github-release` job) |
+| REL-02 | P1: pre-release vs stable flagging | Tasks | Implemented |
+| REL-03 | P1: changelog notes in Release | Tasks | Implemented (`git-cliff --latest`) |
+| REL-04 | P1: idempotent Release creation | Tasks | Implemented (`gh release view` → `edit`/`create`) |
+| REL-05 | P2: OIDC Trusted Publishing auth | Tasks | Implemented in workflow; **blocked** on REL-T11 (crates.io UI, external) |
+| REL-06 | P2: token from action, not secret | Tasks | Implemented (`CARGO_REGISTRY_TOKEN` falls back to the secret until REL-T11) |
+| REL-07 | P2: remove stored CARGO_REGISTRY_TOKEN | Tasks | Not yet — deliberately sequenced last, after an RC proves OIDC works (REL-T13) |
+| REL-08 | P2: publish-before-tag ordering | Tasks | Implemented (already cargo-release's default; preserved, not changed) |
+| REL-09 | P2: image built from correct tag ref | Tasks | Implemented (`ref:` was missing entirely — real bug, now fixed) |
+| REL-10 | P2: workflow_dispatch ref fix | Tasks | Implemented (same fix as REL-09) |
+| REL-11 | P2: documented image tag strategy | Tasks | Implemented (`docs/book/src/08-release-process.md`) |
+| REL-12 | P2: build provenance attestation | Tasks | Implemented (`actions/attest-build-provenance`) |
+| REL-13 | P2: cosign keyless signing | Tasks | Implemented (`sigstore/cosign-installer` + `cosign sign`) |
+| REL-14 | P3: consistent tag/version naming | Tasks | Implemented — no code change needed, already the convention |
+| REL-15 | P3: naming documented in STATE/docs | Tasks | Implemented (`STATE.md`, `08-release-process.md`) |
+| REL-16 | (new) crates.io publish retry/backoff runbook | Tasks | Implemented (staged workflow + documented recovery per bump kind) |
+| REL-17 | (new) 9.0.0 major bump via RCs | Tasks | Implemented (`custom_version` input + runbook); cutting the actual RC is REL-T14 |
 
 **ID format:** `REL-[NUMBER]`
 **Status values:** Pending → In Design → In Tasks → Implementing → Verified
-**Coverage:** 15 total, 0 mapped to tasks, 15 unmapped ⚠️ (Tasks phase pending)
+**Coverage:** 17 total (15 original + 2 user-driven additions), 17 mapped to tasks, 13 code-complete,
+2 blocked on external/manual prerequisites (REL-05/06 pending REL-T11), 1 deliberately deferred
+(REL-07 pending a proven OIDC cycle). See `tasks.md` for the full breakdown.
 
 ---
 

--- a/.claude/specs/features/release-pipeline-hardening/tasks.md
+++ b/.claude/specs/features/release-pipeline-hardening/tasks.md
@@ -1,0 +1,45 @@
+# Tasks: Release Pipeline Hardening
+
+**Feature:** release-pipeline-hardening
+**Design:** `./design.md`
+**Status:** Code done (REL-T1..T10) — pending manual prerequisites (REL-T11..T14) and final review
+
+Legend: 🤖 = I implement this. 🧑 = requires you to act outside this repo (crates.io UI, GitHub
+Settings UI) — I cannot do these; flagged clearly so nothing silently blocks.
+
+- [x] REL-T1 🤖 — Pin every third-party action referenced by the 4 release/publish workflows to a
+      full commit SHA (resolve via `gh api repos/<owner>/<repo>/git/refs/tags/<tag>`).
+- [x] REL-T2 🤖 — `release-prerelease.yml` + `release-stable.yml`: split the single `cargo release`
+      step into bump (`--no-publish --no-tag --no-push`) → OIDC auth → publish → tag+push, all in
+      the same job with no push in between (REL-05, REL-06, REL-08, REL-16). Also added a
+      `custom_version` input to `release-prerelease.yml` for the 9.0.0 edge case (REL-17).
+- [x] REL-T3 🤖 — `publish-crates.yml`: add the same OIDC auth step; keep as the documented manual
+      retry entry point (REL-16).
+- [x] REL-T4 🤖 — `docker-release.yml`: fix the missing `ref:` on checkout (REL-09, REL-10).
+- [x] REL-T5 🤖 — `docker-release.yml`: add build provenance attestation + cosign keyless signing,
+      split into `image` + `github-release` jobs (REL-12, REL-13).
+- [x] REL-T6 🤖 — `docker-release.yml`'s new `github-release` job: create/update a GitHub Release
+      per tag from `git-cliff` notes, idempotent, `prerelease` flag from the existing tag
+      classification (REL-01..04).
+- [x] REL-T7 🤖 — Document the naming convention (no `v` prefix, historical tags untouched) in
+      STATE.md (REL-14, REL-15).
+- [x] REL-T8 🤖 — Write `docs/book/src/08-release-process.md`: normal flow, publish-failure retry
+      procedure (`--unpublished`), and the 9.0.0 RC→stable process (REL-16, REL-17).
+- [x] REL-T9 🤖 — Least-privilege `permissions:` review across all 4 workflow files; confirm no job
+      has broader scope than it uses.
+- [x] REL-T10 🤖 — YAML-syntax-validate every edited workflow file (`python3 -c "import yaml; ..."`);
+      full gate (`cargo fmt`, `cargo build --workspace`, `cargo test --workspace --all`).
+- [ ] REL-T11 🧑 — Configure crates.io **Trusted Publishing** for all 15 publishable crates
+      (crates.io → each crate → Settings → Publishing → add GitHub Actions config pointing at this
+      repo + `release-prerelease.yml`/`release-stable.yml`/`publish-crates.yml`). Blocks REL-05/06
+      actually working; `CARGO_REGISTRY_TOKEN` secret stays as fallback until this is done.
+- [ ] REL-T12 🧑 — Create the GitHub **Environment `release`** (Settings → Environments) with
+      required reviewers, and reference it (`environment: release`) in the 3 publish/bump jobs —
+      the environment itself can't be created via workflow YAML.
+- [ ] REL-T13 🧑 — After REL-T11 is confirmed working end-to-end on a real RC (see REL-T14),
+      remove the `CARGO_REGISTRY_TOKEN` repository secret (REL-07).
+- [ ] REL-T14 🧑 — Cut `9.0.0-rc.1` by dispatching `release-prerelease.yml` with
+      `custom_version: 9.0.0-rc.1` (REL-17) — this is a real release action against the live
+      repo/registry; I've documented the exact process in design.md §9 and
+      `docs/book/src/08-release-process.md`, but will not dispatch it myself without your explicit
+      go-ahead on the day you want to cut it.

--- a/.claude/specs/project/STATE.md
+++ b/.claude/specs/project/STATE.md
@@ -684,11 +684,18 @@ All 13 workspace crates confirmed to exist on crates.io (no name conflicts). Wor
 | `8.3.2-rc.1` | `:8.3.2-rc.1`, `:rc` |
 | `8.3.2-beta.1` | `:8.3.2-beta.1`, `:beta` |
 
+### Tag/version naming convention (REL-14/15, 2026-07-11)
+
+Git tags and image tags use **no `v` prefix** (`8.3.2`, not `v8.3.2`) — this is what
+`release.toml`'s `tag-name = "{{version}}"` and every current image tag already produce; this
+section just makes the convention explicit. Historical `v*` tags/Releases (pre-`8.3.0`) are left
+as-is, never renamed. See `docs/book/src/08-release-process.md` for the full release process.
+
 ---
 
 ## Todos
 
-- **Release pipeline hardening** — spec at `features/release-pipeline-hardening/spec.md` (2026-07-06). Root cause of GHCR↔GitHub-Release desync: no workflow creates GitHub Releases (only tags). Spec also covers crates.io Trusted Publishing (OIDC, drop long-lived `CARGO_REGISTRY_TOKEN`), image provenance + cosign signing, `workflow_dispatch` ref bug, and `v`-prefix naming drift. Next: Design → Tasks.
+- **Release pipeline hardening** — spec/design/tasks at `features/release-pipeline-hardening/` (2026-07-06, design 2026-07-11). Workflow YAML implemented: GitHub Release automation (`docker-release.yml`'s new `github-release` job), OIDC Trusted Publishing wiring (`rust-lang/crates-io-auth-action`, `CARGO_REGISTRY_TOKEN` kept as fallback), the `workflow_dispatch` ref bug (`docker-release.yml` checkout had no `ref:` at all), build provenance attestation + cosign keyless signing, third-party actions pinned to commit SHA, and a `custom_version` input on `release-prerelease.yml` for the 9.0.0-rc.1 major-bump edge case cargo-release's LEVEL keywords can't express. **Still open (external, can't be done from code):** configure crates.io Trusted Publishing per-crate (15 crates), create the GitHub `release` Environment with required reviewers, remove `CARGO_REGISTRY_TOKEN` only after an RC proves OIDC works end-to-end. See `tasks.md` for the full 🤖/🧑 split.
 - Retroactively create GitHub Releases for `8.3.0`+ tags and publish/discard the stale `8.3.1-rc.2` Draft.
 
 ---

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -13,57 +13,91 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 concurrency:
   group: docker-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:
-  docker:
+  image:
     name: Build and push ${{ github.ref_name }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write # REL-13: cosign keyless signing
+      attestations: write # REL-12: build provenance
+    outputs:
+      version: ${{ steps.tag.outputs.version }}
+      prerelease: ${{ steps.tag.outputs.prerelease }}
+    env:
+      # workflow_dispatch's `tag` input is operator-provided free text --
+      # routed through an env var instead of interpolated directly into a
+      # `run:` block (workflow-injection hardening).
+      INPUT_TAG: ${{ inputs.tag }}
 
     steps:
+      # Defense in depth: workflow_dispatch's `tag` is operator-typed free
+      # text (requires repo write access to trigger, but validate the shape
+      # anyway before it's used as a checkout `ref:`).
+      - name: Validate tag input
+        if: inputs.tag != ''
+        run: |
+          if ! echo "$INPUT_TAG" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+\.[0-9]+)?$'; then
+            echo "::error::tag input '$INPUT_TAG' doesn't look like a release version (X.Y.Z or X.Y.Z-stage.N)."
+            exit 1
+          fi
+
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.tag || github.ref_name }} # REL-09/10: THE FIX -- was missing entirely, workflow_dispatch built from whatever branch triggered it
 
       - name: Classify tag
         id: tag
         run: |
-          TAG="${{ inputs.tag || github.ref_name }}"
-          echo "version=${TAG}" >> $GITHUB_OUTPUT
+          TAG="${INPUT_TAG:-$GITHUB_REF_NAME}"
+          echo "version=${TAG}" >> "$GITHUB_OUTPUT"
           if echo "${TAG}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-'; then
-            echo "prerelease=true" >> $GITHUB_OUTPUT
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
             TYPE=$(echo "${TAG}" | sed -E 's/^[0-9]+\.[0-9]+\.[0-9]+-([a-z]+)\..*/\1/')
-            echo "prerelease_type=${TYPE}" >> $GITHUB_OUTPUT
+            echo "prerelease_type=${TYPE}" >> "$GITHUB_OUTPUT"
           else
-            echo "prerelease=false" >> $GITHUB_OUTPUT
-            echo "prerelease_type=" >> $GITHUB_OUTPUT
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "prerelease_type=" >> "$GITHUB_OUTPUT"
           fi
+
+      # `github.repository` is case-preserved ("LepistaBioinformatics/mycelium").
+      # docker/metadata-action lowercases internally (why builds work today),
+      # but cosign and attest-build-provenance below do NOT -- GHCR/OCI image
+      # refs must be all-lowercase or both steps fail. Compute it once here.
+      - name: Lowercase image name
+        id: image
+        run: echo "name=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ${{ steps.image.outputs.name }}
           tags: |
             type=raw,value=${{ steps.tag.outputs.version }}
             type=raw,value=latest,enable=${{ steps.tag.outputs.prerelease == 'false' }}
             type=raw,value=${{ steps.tag.outputs.prerelease_type }},enable=${{ steps.tag.outputs.prerelease == 'true' }}
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        id: push
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile
@@ -73,3 +107,67 @@ jobs:
           build-args: VERSION=${{ steps.tag.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # REL-12
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@92c65d2898f1f53cfdc910b962cecff86e7f8fcc # v1
+        with:
+          subject-name: ${{ steps.image.outputs.name }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+      # REL-13
+      - name: Install cosign
+        uses: sigstore/cosign-installer@f713795cb21599bc4e5c4b58cbad1da852d7eeb9 # v3
+
+      - name: Sign image (keyless)
+        run: cosign sign --yes "${{ steps.image.outputs.name }}@${{ steps.push.outputs.digest }}"
+
+  github-release:
+    name: Create GitHub Release for ${{ needs.image.outputs.version }}
+    needs: image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      TAG: ${{ needs.image.outputs.version }}
+      IS_PRERELEASE: ${{ needs.image.outputs.prerelease }}
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.image.outputs.version }}
+          fetch-depth: 0 # git-cliff needs full history to generate notes
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+
+      - name: Install git-cliff
+        run: cargo install git-cliff --locked
+
+      - name: Generate release notes
+        run: |
+          git-cliff --latest --strip header -o /tmp/notes.md
+          # git-cliff can legitimately produce an empty file for a version
+          # with no conventional-commit-tagged changes -- never fail the
+          # Release for that, ship a minimal body instead (REL-01 edge case).
+          if [ ! -s /tmp/notes.md ]; then
+            echo "Release ${TAG}." > /tmp/notes.md
+          fi
+
+      # REL-01..04: idempotent -- `gh release create` errors if the tag
+      # already has a Release, so fall back to `edit` instead of failing the
+      # job (safe to re-run this workflow for the same tag).
+      - name: Create or update GitHub Release
+        run: |
+          PRERELEASE_FLAG=""
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" --notes-file /tmp/notes.md $PRERELEASE_FLAG
+          else
+            gh release create "$TAG" --title "$TAG" --notes-file /tmp/notes.md $PRERELEASE_FLAG
+          fi

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -8,6 +8,14 @@ on:
         required: false
         type: boolean
         default: true
+      unpublished_only:
+        description: >-
+          Only process packages whose current version isn't on crates.io yet
+          (cargo release --unpublished). Useful for retrying after a partial
+          publish failure -- see docs/book/src/08-release-process.md.
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: publish-crates
@@ -17,30 +25,45 @@ jobs:
   publish:
     name: Publish workspace crates
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      id-token: write # REL-05: OIDC token for crates-io-auth-action
     env:
-      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      UNPUBLISHED_FLAG: ${{ inputs.unpublished_only == true && '--unpublished' || '' }}
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       - name: Install cargo-release
         run: cargo install cargo-release --locked
 
+      # REL-05/06: short-lived OIDC token, not a stored secret. Falls back to
+      # CARGO_REGISTRY_TOKEN until every crate has Trusted Publishing set up
+      # on crates.io (see docs/book/src/08-release-process.md).
+      - name: Authenticate to crates.io (Trusted Publishing)
+        id: auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+
       - name: Publish (dry run)
         if: inputs.dry_run == true
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token || secrets.CARGO_REGISTRY_TOKEN }}
         run: |
-          cargo release publish --no-confirm
+          cargo release publish --no-confirm $UNPUBLISHED_FLAG
           echo "Dry-run complete — no crates were published."
 
       - name: Publish
         if: inputs.dry_run == false
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token || secrets.CARGO_REGISTRY_TOKEN }}
         run: |
-          cargo release publish --execute --no-confirm
+          cargo release publish --execute --no-confirm $UNPUBLISHED_FLAG
           echo "Publish complete."

--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -4,12 +4,20 @@ on:
   workflow_dispatch:
     inputs:
       release_type:
-        description: Pre-release stage
-        required: true
+        description: Pre-release stage (ignored if custom_version is set)
+        required: false
         type: choice
         options:
           - beta
           - rc
+      custom_version:
+        description: >-
+          Explicit target version, overrides release_type. Only needed for a
+          version cargo-release's LEVEL keywords can't express directly, e.g.
+          the first RC of a new major (9.0.0-rc.1 from 8.3.1) -- see
+          docs/book/src/08-release-process.md.
+        required: false
+        type: string
       dry_run:
         description: Dry run (no changes committed or pushed)
         required: false
@@ -25,21 +33,26 @@ jobs:
     name: Bump ${{ inputs.release_type }}
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/develop'
+    environment: release
+    permissions:
+      contents: write
+      id-token: write # REL-05: OIDC token for crates-io-auth-action
     env:
-      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      RELEASE_TYPE: ${{ inputs.release_type }}
+      CUSTOM_VERSION: ${{ inputs.custom_version }}
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ secrets.RELEASE_TOKEN }}
           fetch-depth: 0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       - name: Install cargo-release
         run: cargo install cargo-release --locked --force
@@ -52,14 +65,51 @@ jobs:
           git config user.name "Samuel Galvão Elias"
           git config user.email "sgelias@outlook.com"
 
-      - name: Run release (dry run)
+      - name: Resolve target level/version
+        run: |
+          if [ -z "$CUSTOM_VERSION" ] && [ -z "$RELEASE_TYPE" ]; then
+            echo "::error::Either release_type or custom_version must be set."
+            exit 1
+          fi
+          echo "TARGET=${CUSTOM_VERSION:-$RELEASE_TYPE}" >> "$GITHUB_ENV"
+
+      - name: Bump version, changelog, commit (dry run)
         if: inputs.dry_run == true
         run: |
-          cargo release ${{ inputs.release_type }} --no-publish
+          cargo release "$TARGET" --no-publish --no-tag --no-push
           echo "Dry-run complete — no changes were committed or pushed."
 
-      - name: Run release
+      - name: Bump version, changelog, commit (no publish/tag/push yet)
+        if: inputs.dry_run == false
+        run: cargo release "$TARGET" --execute --no-confirm --no-publish --no-tag --no-push
+
+      # REL-05/06: short-lived OIDC token, not a stored secret. Requires
+      # Trusted Publishing configured on crates.io for every crate first
+      # (see docs/book/src/08-release-process.md) -- until then this step
+      # fails and CARGO_REGISTRY_TOKEN below is the fallback.
+      - name: Authenticate to crates.io (Trusted Publishing)
+        if: inputs.dry_run == false
+        id: auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+
+      - name: Publish crates
+        if: inputs.dry_run == false
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token || secrets.CARGO_REGISTRY_TOKEN }}
+        # release.toml's [rate-limit] paces publishes to stay under crates.io's
+        # documented limits. If this step still fails partway (crates.io
+        # throttling, network blip): nothing has been pushed yet (see design
+        # doc §2) -- re-dispatching this same workflow is safe for a fixed
+        # bump, but NOT for rc/beta (it would bump again instead of retrying).
+        # See docs/book/src/08-release-process.md for the full recovery
+        # procedure.
+        run: |
+          cargo release publish --execute --no-confirm
+          echo "Publish complete."
+
+      - name: Tag and push
         if: inputs.dry_run == false
         run: |
-          cargo release ${{ inputs.release_type }} --execute --no-confirm
+          cargo release tag --execute --no-confirm
+          cargo release push --execute --no-confirm
           echo "Release complete."

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -26,21 +26,25 @@ jobs:
     name: Bump ${{ inputs.release_type }}
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
+    environment: release
+    permissions:
+      contents: write
+      id-token: write # REL-05: OIDC token for crates-io-auth-action
     env:
-      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      RELEASE_TYPE: ${{ inputs.release_type }}
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ secrets.RELEASE_TOKEN }}
           fetch-depth: 0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
       - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       - name: Install cargo-release
         run: cargo install cargo-release --locked --force
@@ -53,14 +57,43 @@ jobs:
           git config user.name "Samuel Galvão Elias"
           git config user.email "sgelias@outlook.com"
 
-      - name: Run release (dry run)
+      - name: Bump version, changelog, commit (dry run)
         if: inputs.dry_run == true
         run: |
-          cargo release ${{ inputs.release_type }} --no-publish
+          cargo release "$RELEASE_TYPE" --no-publish --no-tag --no-push
           echo "Dry-run complete — no changes were committed or pushed."
 
-      - name: Run release
+      - name: Bump version, changelog, commit (no publish/tag/push yet)
+        if: inputs.dry_run == false
+        run: cargo release "$RELEASE_TYPE" --execute --no-confirm --no-publish --no-tag --no-push
+
+      # REL-05/06: short-lived OIDC token, not a stored secret. Requires
+      # Trusted Publishing configured on crates.io for every crate first
+      # (see docs/book/src/08-release-process.md) -- until then this step
+      # fails and CARGO_REGISTRY_TOKEN below is the fallback.
+      - name: Authenticate to crates.io (Trusted Publishing)
+        if: inputs.dry_run == false
+        id: auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+
+      - name: Publish crates
+        if: inputs.dry_run == false
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token || secrets.CARGO_REGISTRY_TOKEN }}
+        # release.toml's [rate-limit] paces publishes to stay under crates.io's
+        # documented limits. If this step still fails partway (crates.io
+        # throttling, network blip): nothing has been pushed yet (see design
+        # doc §2) -- re-dispatching this same workflow is safe (patch/minor/
+        # major are deterministic bumps; publish skips already-done crates).
+        # See docs/book/src/08-release-process.md for the full recovery
+        # procedure.
+        run: |
+          cargo release publish --execute --no-confirm
+          echo "Publish complete."
+
+      - name: Tag and push
         if: inputs.dry_run == false
         run: |
-          cargo release ${{ inputs.release_type }} --execute --no-confirm
+          cargo release tag --execute --no-confirm
+          cargo release push --execute --no-confirm
           echo "Release complete."

--- a/docs/book/po/pt-BR.po
+++ b/docs/book/po/pt-BR.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Mycelium API Gateway Documentation\n"
-"POT-Creation-Date: 2026-07-08T23:07:06-03:00\n"
+"POT-Creation-Date: 2026-07-11T18:34:58-03:00\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -353,8 +353,7 @@ msgstr ""
 "Escolha o método de instalação que melhor se adapta ao seu fluxo de trabalho."
 
 #: src/02-installation.md:8 src/10-alternative-idps.md:94 src/13-mcp.md:23
-#: src/21-envelope-encryption-migration.md:22 src/08-release-process.md:12
-#: src/09-log-cache-tests.md:16
+#: src/21-envelope-encryption-migration.md:22 src/09-log-cache-tests.md:16
 msgid "Prerequisites"
 msgstr "Pré-requisitos"
 
@@ -488,7 +487,7 @@ msgstr ""
 #: src/02-installation.md:90 src/03-quick-start.md:139
 #: src/05-deploy-locally.md:105 src/06-downstream-apis.md:280
 #: src/10-alternative-idps.md:469 src/07-running-tests.md:73
-#: src/08-release-process.md:363 src/09-log-cache-tests.md:175
+#: src/08-release-process.md:266 src/09-log-cache-tests.md:175
 msgid "Troubleshooting"
 msgstr "Solução de problemas"
 
@@ -857,7 +856,7 @@ msgstr "Campo"
 #: src/14-json-rpc.md:275 src/14-json-rpc.md:287 src/14-json-rpc.md:294
 #: src/14-json-rpc.md:301 src/14-json-rpc.md:308 src/14-json-rpc.md:321
 #: src/14-json-rpc.md:336 src/14-json-rpc.md:346 src/18-cli.md:52
-#: src/20-encryption-inventory.md:34 src/08-release-process.md:195
+#: src/20-encryption-inventory.md:34 src/08-release-process.md:150
 msgid "Description"
 msgstr "Descrição"
 
@@ -5252,7 +5251,7 @@ msgid "Reference — callback fields"
 msgstr "Referência — campos de callback"
 
 #: src/12-response-callbacks.md:187 src/20-encryption-inventory.md:34
-#: src/08-release-process.md:195
+#: src/08-release-process.md:150
 msgid "Type"
 msgstr ""
 
@@ -7984,7 +7983,7 @@ msgstr "A versão resumida"
 msgid "Version"
 msgstr "Tipo de Versão"
 
-#: src/20-encryption-inventory.md:58 src/08-release-process.md:25
+#: src/20-encryption-inventory.md:58 src/08-release-process.md:28
 msgid "Format"
 msgstr ""
 
@@ -8205,7 +8204,7 @@ msgid ""
 "tenant)."
 msgstr ""
 
-#: src/21-envelope-encryption-migration.md:8 src/08-release-process.md:5
+#: src/21-envelope-encryption-migration.md:8 src/08-release-process.md:6
 #: src/09-log-cache-tests.md:5
 msgid "Overview"
 msgstr ""
@@ -8894,424 +8893,344 @@ msgstr ""
 "contêineres Docker nas mesmas portas."
 
 #: src/08-release-process.md:3
+#, fuzzy
 msgid ""
-"This guide explains how to create and manage releases for Mycelium using "
-"`cargo-release` and `git-cliff`."
+"This guide explains how Mycelium releases are cut, using `cargo-release` and "
+"`git-cliff`, orchestrated by GitHub Actions."
 msgstr ""
 "Este guia explica como criar e gerenciar lançamentos do Mycelium usando "
 "`cargo-release` e `git-cliff`."
 
-#: src/08-release-process.md:7
+#: src/08-release-process.md:8
 msgid ""
-"Mycelium follows [Semantic Versioning](https://semver.org/) and uses "
-"automated tools to manage releases:"
+"Mycelium follows [Semantic Versioning](https://semver.org/). Releases are "
+"**not** run by hand locally — they run through GitHub Actions "
+"`workflow_dispatch` jobs, because two pieces of the pipeline only work "
+"inside CI:"
 msgstr ""
-"O Mycelium segue o [Versionamento Semântico](https://semver.org/) e usa "
-"ferramentas automatizadas para gerenciar lançamentos:"
 
-#: src/08-release-process.md:9
-msgid "**cargo-release**: Manages version bumping, tagging, and publishing"
-msgstr "**cargo-release**: Gerencia incremento de versão, tagging e publicação"
-
-#: src/08-release-process.md:10
-msgid "**git-cliff**: Generates changelogs from conventional commits"
-msgstr "**git-cliff**: Gera changelogs a partir de commits convencionais"
+#: src/08-release-process.md:12
+msgid ""
+"**`RELEASE_TOKEN`** (a PAT/App token) is what makes a pushed tag _cascade_ "
+"to the tag-triggered `docker-release.yml` workflow — the built-in "
+"`GITHUB_TOKEN` would not."
+msgstr ""
 
 #: src/08-release-process.md:14
-msgid "Install the required tools:"
-msgstr "Instale as ferramentas necessárias:"
+msgid ""
+"**crates.io Trusted Publishing (OIDC)** — the short-lived crates.io token is "
+"exchanged via GitHub's OIDC identity, which only exists inside an Actions "
+"run."
+msgstr ""
+
+#: src/08-release-process.md:17
+msgid ""
+"A local `cargo release <level>` (no `--execute`) dry-run is still the right "
+"way to preview a bump before dispatching the real workflow — it needs no "
+"credentials and touches nothing."
+msgstr ""
+
+#: src/08-release-process.md:20
+msgid "Tools involved:"
+msgstr ""
 
 #: src/08-release-process.md:21
+#, fuzzy
+msgid ""
+"**cargo-release**: version bumping, changelog hook, tagging, publishing."
+msgstr "**cargo-release**: Gerencia incremento de versão, tagging e publicação"
+
+#: src/08-release-process.md:22
+msgid ""
+"**git-cliff**: generates changelog notes from conventional commits — used "
+"both for `CHANGELOG.md` and as the body of the GitHub Release `docker-"
+"release.yml`'s `github-release` job creates for every tag."
+msgstr ""
+
+#: src/08-release-process.md:26
 msgid "Version Semantics"
 msgstr "Semântica de Versão"
 
-#: src/08-release-process.md:23
-msgid "Mycelium follows Semantic Versioning (SemVer):"
-msgstr "O Mycelium segue o Versionamento Semântico (SemVer):"
-
-#: src/08-release-process.md:25
+#: src/08-release-process.md:28
 msgid "Version Type"
 msgstr "Tipo de Versão"
 
-#: src/08-release-process.md:25
+#: src/08-release-process.md:28
 msgid "When to Use"
 msgstr "Quando Usar"
 
-#: src/08-release-process.md:25
+#: src/08-release-process.md:28
 msgid "Example"
 msgstr ""
 
-#: src/08-release-process.md:27
+#: src/08-release-process.md:30
 msgid "**MAJOR**"
 msgstr "**MAJOR**"
 
-#: src/08-release-process.md:27
+#: src/08-release-process.md:30
 msgid "`X.0.0`"
 msgstr ""
 
-#: src/08-release-process.md:27
+#: src/08-release-process.md:30
 msgid "Breaking changes or incompatible API changes"
 msgstr ""
 "Mudanças incompatíveis ou alterações de API que quebram compatibilidade"
 
-#: src/08-release-process.md:27
+#: src/08-release-process.md:30
 msgid "`8.0.0` → `9.0.0`"
 msgstr ""
 
-#: src/08-release-process.md:28
+#: src/08-release-process.md:31
 msgid "**MINOR**"
 msgstr "**MINOR**"
 
-#: src/08-release-process.md:28
+#: src/08-release-process.md:31
 msgid "`x.Y.0`"
 msgstr ""
 
-#: src/08-release-process.md:28
+#: src/08-release-process.md:31
 msgid "New features (backward-compatible)"
 msgstr "Novas funcionalidades (compatíveis com versões anteriores)"
 
-#: src/08-release-process.md:28
+#: src/08-release-process.md:31
 msgid "`8.3.0` → `8.4.0`"
 msgstr ""
 
-#: src/08-release-process.md:29
+#: src/08-release-process.md:32
 msgid "**PATCH**"
 msgstr "**PATCH**"
 
-#: src/08-release-process.md:29
+#: src/08-release-process.md:32
 msgid "`x.y.Z`"
 msgstr ""
 
-#: src/08-release-process.md:29
+#: src/08-release-process.md:32
 msgid "Bug fixes (backward-compatible)"
 msgstr "Correções de bugs (compatíveis com versões anteriores)"
 
-#: src/08-release-process.md:29
+#: src/08-release-process.md:32
 msgid "`8.3.0` → `8.3.1`"
 msgstr ""
 
-#: src/08-release-process.md:31
-msgid "Pre-release Workflow"
-msgstr "Fluxo de Pré-lançamento"
-
-#: src/08-release-process.md:33
-msgid "Pre-releases follow a specific progression through stages:"
-msgstr "Os pré-lançamentos seguem uma progressão específica por estágios:"
-
-#: src/08-release-process.md:35
-#, fuzzy
-msgid "1. Alpha Stage"
-msgstr "Estágio Alpha"
+#: src/08-release-process.md:34
+msgid ""
+"**Tag naming:** no `v` prefix — tags and image tags are `8.3.1`, `8.3.1-"
+"rc.1`, never `v8.3.1`. Historical `v*` tags (pre-`8.3.0`) are left as-is, "
+"never renamed."
+msgstr ""
 
 #: src/08-release-process.md:37
-msgid "**Purpose**: Early development and testing"
-msgstr "**Objetivo**: Desenvolvimento inicial e testes"
+msgid "The Automated Pipeline"
+msgstr ""
 
-#: src/08-release-process.md:39 src/08-release-process.md:60
-#: src/08-release-process.md:82
-msgid "**Characteristics**:"
-msgstr "**Características**:"
+#: src/08-release-process.md:39
+msgid ""
+"Dispatching `release-prerelease.yml` (from `develop`) or `release-stable."
+"yml` (from `main`) runs, in one job: **bump → commit (local) → publish "
+"(OIDC, rate-limited) → tag → push.** Nothing is pushed to the branch or to "
+"crates.io until the step that does it succeeds; if `publish` fails, the job "
+"simply ends and the remote is untouched — see [Publish Failures & Retry]"
+"(#publish-failures--retry) below."
+msgstr ""
 
-#: src/08-release-process.md:40
-msgid "Unstable, frequent changes"
-msgstr "Instável, mudanças frequentes"
+#: src/08-release-process.md:45
+msgid "Once the tag is pushed, `docker-release.yml` fires automatically:"
+msgstr ""
 
-#: src/08-release-process.md:41
-msgid "Used for initial feature testing"
-msgstr "Usado para testes iniciais de funcionalidades"
-
-#: src/08-release-process.md:42
-msgid "Not recommended for production"
-msgstr "Não recomendado para produção"
-
-#: src/08-release-process.md:44
-msgid "**Creating an alpha release**:"
-msgstr "**Criando um lançamento alpha**:"
-
-#: src/08-release-process.md:47
-msgid "# First alpha\n"
+#: src/08-release-process.md:46
+msgid ""
+"**`image` job** — builds from that exact tag (fixed ref bug, see below), "
+"pushes to GHCR, attests build provenance, and signs the image keylessly with "
+"cosign."
 msgstr ""
 
 #: src/08-release-process.md:48
-msgid "# Creates x.y.z-alpha.1\n"
-msgstr ""
-
-#: src/08-release-process.md:49
-msgid "# Subsequent alphas\n"
+msgid ""
+"**`github-release` job** — creates (or updates, idempotently) a GitHub "
+"Release for the tag, with `git-cliff` notes and the correct `prerelease` "
+"flag."
 msgstr ""
 
 #: src/08-release-process.md:51
-msgid "# Creates x.y.z-alpha.2, etc.\n"
-msgstr ""
-
-#: src/08-release-process.md:54
 msgid ""
-"**Example progression**: `8.3.0-alpha.1` → `8.3.0-alpha.2` → `8.3.0-alpha.3`"
+"You can also trigger `docker-release.yml` manually via `workflow_dispatch` "
+"with a `tag` input — for example to rebuild an older tag. It checks out that "
+"exact tag's source (not whatever branch the dispatch happened to run from), "
+"so the rebuilt image's content always matches its version label."
 msgstr ""
-"**Exemplo de progressão**: `8.3.0-alpha.1` → `8.3.0-alpha.2` → `8.3.0-"
-"alpha.3`"
 
-#: src/08-release-process.md:56
-#, fuzzy
-msgid "2. Beta Stage"
-msgstr "Estágio Beta"
+#: src/08-release-process.md:55
+msgid "Pre-release Workflow"
+msgstr "Fluxo de Pré-lançamento"
 
-#: src/08-release-process.md:58
-msgid "**Purpose**: Feature-complete version ready for broader testing"
+#: src/08-release-process.md:57
+msgid ""
+"Pre-releases progress through `beta` → `rc` stages (dispatch `release-"
+"prerelease.yml` from `develop`, choosing `release_type`). `cargo-release` "
+"also supports an `alpha` level, but it isn't wired into either workflow's "
+"dropdown today — use `custom_version` (see below) if you ever need it."
 msgstr ""
-"**Objetivo**: Versão com funcionalidades completas, pronta para testes mais "
-"amplos"
 
 #: src/08-release-process.md:61
-msgid "Features are complete"
-msgstr "Funcionalidades completas"
-
-#: src/08-release-process.md:62
-msgid "API should be relatively stable"
-msgstr "API deve estar relativamente estável"
-
-#: src/08-release-process.md:63
-msgid "May still have bugs"
-msgstr "Pode ainda ter bugs"
-
-#: src/08-release-process.md:64
-msgid "Used for wider testing and feedback"
-msgstr "Usado para testes mais abrangentes e feedback"
-
-#: src/08-release-process.md:66
-msgid "**Moving to beta**:"
-msgstr "**Avançando para beta**:"
-
-#: src/08-release-process.md:69
-msgid "# First beta\n"
-msgstr ""
-
-#: src/08-release-process.md:70
-msgid "# Creates x.y.z-beta.1\n"
-msgstr ""
-
-#: src/08-release-process.md:71
-msgid "# Subsequent betas\n"
-msgstr ""
-
-#: src/08-release-process.md:73
-msgid "# Creates x.y.z-beta.2, etc.\n"
-msgstr ""
-
-#: src/08-release-process.md:76
+#, fuzzy
 msgid ""
-"**Example progression**: `8.3.0-beta.1` → `8.3.0-beta.2` → `8.3.0-beta.3`"
+"**Example progression**: `8.3.0-beta.1` → `8.3.0-beta.2` → `8.3.0-rc.1` → "
+"`8.3.0-rc.2`"
 msgstr ""
 "**Exemplo de progressão**: `8.3.0-beta.1` → `8.3.0-beta.2` → `8.3.0-beta.3`"
 
-#: src/08-release-process.md:78
-#, fuzzy
-msgid "3. Release Candidate (RC) Stage"
-msgstr "Estágio Release Candidate (RC)"
+#: src/08-release-process.md:63
+msgid "Promoting to stable"
+msgstr ""
+
+#: src/08-release-process.md:65
+msgid ""
+"Dispatch `release-stable.yml` from `main` with `release_type: patch|minor|"
+"major` — cargo-release's `release` level (`X.Y.Z-rc.N` → `X.Y.Z`, dropping "
+"the pre-release suffix) is available locally for a dry-run preview, but "
+"isn't exposed as a `release-stable.yml` dropdown option; the stable workflow "
+"always bumps from `main`'s current version, so merge the release branch into "
+"`main` first, then dispatch with the level matching what the pre-release "
+"cycle was for (a `9.0.0-rc.N` line promotes via `major` from the last stable "
+"tag once `main` is on the rc's commit — see the 9.0.0 walkthrough below for "
+"the concrete case)."
+msgstr ""
+
+#: src/08-release-process.md:73
+msgid "Publish Failures & Retry"
+msgstr ""
+
+#: src/08-release-process.md:75
+msgid ""
+"If the **publish** step fails partway (crates.io throttling despite `release."
+"toml`'s `[rate-limit]`, a network blip, or a single crate's own issue), "
+"recovery depends on what kind of bump it was — nothing was pushed, so the "
+"remote branch and tags are exactly as they were before you dispatched:"
+msgstr ""
 
 #: src/08-release-process.md:80
-msgid "**Purpose**: Production-ready candidate for final validation"
-msgstr "**Objetivo**: Candidato pronto para produção e validação final"
-
-#: src/08-release-process.md:83
-msgid "Final testing before stable release"
-msgstr "Testes finais antes do lançamento estável"
+msgid ""
+"**`patch` / `minor` / `major` / `release`** (deterministic target version): "
+"just **re-dispatch the same workflow**. It recomputes the identical target "
+"version, and `cargo release publish` already skips crates that succeeded in "
+"the previous attempt — the retry only publishes what's left, then proceeds "
+"to tag+push normally."
+msgstr ""
 
 #: src/08-release-process.md:84
-msgid "Only critical bug fixes allowed"
-msgstr "Apenas correções críticas de bugs permitidas"
-
-#: src/08-release-process.md:85
-msgid "Ready for production testing"
-msgstr "Pronto para testes em produção"
-
-#: src/08-release-process.md:86
-msgid "Last chance to catch issues"
-msgstr "Última chance de encontrar problemas"
-
-#: src/08-release-process.md:88
-msgid "**Creating release candidates**:"
-msgstr "**Criando release candidates**:"
-
-#: src/08-release-process.md:91
-msgid "# First RC\n"
+msgid ""
+"**`beta` / `rc`** (relative bump): re-dispatching increments again (`rc.1` → "
+"`rc.2`), it does **not** retry `rc.1`. Treat the partial `rc.N`/`beta.N` as "
+"abandoned — the handful of crates that did publish at that version are "
+"harmless orphans on crates.io (untagged, unreferenced, nothing depends on "
+"that exact version existing) — and dispatch the workflow again for the "
+"**next** rc/beta number."
 msgstr ""
 
-#: src/08-release-process.md:92
-msgid "# Creates x.y.z-rc.1\n"
+#: src/08-release-process.md:89
+msgid ""
+"**`publish-crates.yml`** is also available any time as a standalone re-"
+"publish pass (same OIDC auth), with an `unpublished_only` input (`cargo "
+"release publish --unpublished`) to scope it to just the packages not yet "
+"published at their current `Cargo.toml` version — useful if you want to "
+"retry only the publish step without touching bump/tag/push."
 msgstr ""
 
-#: src/08-release-process.md:93
-msgid "# Subsequent RCs (if needed)\n"
+#: src/08-release-process.md:94
+msgid "Major Version Bump via Release Candidates (9.0.0 walkthrough)"
 msgstr ""
 
-#: src/08-release-process.md:95
-msgid "# Creates x.y.z-rc.2, etc.\n"
+#: src/08-release-process.md:96
+msgid ""
+"Going from the `8.3.x` line to `9.0.0` is a routine major bump with no "
+"breaking changes planned — release it as a series of RCs first, same as any "
+"other release, with one wrinkle: cargo-release's `major` LEVEL alone jumps "
+"straight to a **stable** `9.0.0`, and its `--metadata`/`-m` flag sets semver "
+"_build_ metadata after a `+` (e.g. `9.0.0+rc.1`), **not** a pre-release "
+"identifier — neither composes \"major\" with \"rc\" the way you'd want. The "
+"fix is `release-prerelease.yml`'s `custom_version` input, which accepts an "
+"explicit target version string (cargo-release's other accepted form of its "
+"`[LEVEL|VERSION]` argument):"
 msgstr ""
-
-#: src/08-release-process.md:98
-msgid "**Example progression**: `8.3.0-rc.1` → `8.3.0-rc.2`"
-msgstr "**Exemplo de progressão**: `8.3.0-rc.1` → `8.3.0-rc.2`"
-
-#: src/08-release-process.md:100
-#, fuzzy
-msgid "4. Stable Release"
-msgstr "Lançamento Estável"
-
-#: src/08-release-process.md:102
-msgid "**Purpose**: Production-ready version"
-msgstr "**Objetivo**: Versão pronta para produção"
 
 #: src/08-release-process.md:104
-msgid "**Creating the stable release**:"
-msgstr "**Criando o lançamento estável**:"
-
-#: src/08-release-process.md:107
-msgid "# Creates x.y.z\n"
+msgid ""
+"Dispatch `release-prerelease.yml` from `develop` with `custom_version: 9.0.0-"
+"rc.1` (leave `release_type` blank). Do a `dry_run: true` pass first and "
+"review the diff."
 msgstr ""
 
-#: src/08-release-process.md:110
-msgid "**Example**: `8.3.0-rc.2` → `8.3.0`"
-msgstr "**Exemplo**: `8.3.0-rc.2` → `8.3.0`"
+#: src/08-release-process.md:106
+msgid ""
+"Every subsequent RC uses the normal `release_type: rc` dropdown again — "
+"`9.0.0-rc.1` → `rc` → `9.0.0-rc.2`, etc. Verify each RC end-to-end (install "
+"the RC crate, boot the RC image) before cutting the next one."
+msgstr ""
+
+#: src/08-release-process.md:109
+msgid ""
+"Before cutting `9.0.0-rc.1`, make sure crates.io Trusted Publishing is "
+"configured for every workspace crate (see below) — this is the first real "
+"end-to-end exercise of OIDC publishing; keep `CARGO_REGISTRY_TOKEN` as a "
+"fallback until this cycle proves it works."
+msgstr ""
 
 #: src/08-release-process.md:112
-msgid "Version Increment Commands"
-msgstr "Comandos de Incremento de Versão"
-
-#: src/08-release-process.md:114
-msgid "Patch Release"
-msgstr "Lançamento de Patch"
-
-#: src/08-release-process.md:116
-msgid "For bug fixes on existing stable releases:"
-msgstr "Para correções de bugs em lançamentos estáveis existentes:"
-
-#: src/08-release-process.md:122
-msgid "**Example**: `8.3.0` → `8.3.1`"
-msgstr "**Exemplo**: `8.3.0` → `8.3.1`"
-
-#: src/08-release-process.md:124
-msgid "Minor Release"
-msgstr "Lançamento Minor"
-
-#: src/08-release-process.md:126
-msgid "For new features (backward-compatible):"
-msgstr "Para novas funcionalidades (compatíveis com versões anteriores):"
-
-#: src/08-release-process.md:132
-msgid "**Example**: `8.3.1` → `8.4.0`"
-msgstr "**Exemplo**: `8.3.1` → `8.4.0`"
-
-#: src/08-release-process.md:134
-msgid "Major Release"
-msgstr "Lançamento Major"
-
-#: src/08-release-process.md:136
-msgid "For breaking changes:"
-msgstr "Para mudanças que quebram compatibilidade:"
-
-#: src/08-release-process.md:142
-msgid "**Example**: `8.4.0` → `9.0.0`"
-msgstr "**Exemplo**: `8.4.0` → `9.0.0`"
-
-#: src/08-release-process.md:144
-msgid "Complete Release Cycle Example"
-msgstr "Exemplo de Ciclo de Lançamento Completo"
-
-#: src/08-release-process.md:146
-msgid "Here's a complete example of releasing version 8.3.0:"
-msgstr "Aqui está um exemplo completo do lançamento da versão 8.3.0:"
-
-#: src/08-release-process.md:149
-msgid "# Alpha stage - initial testing\n"
+msgid ""
+"Once satisfied, merge to `main` and dispatch `release-stable.yml` with "
+"`release_type: major` to drop the `-rc.N` suffix and cut `9.0.0` stable."
 msgstr ""
 
-#: src/08-release-process.md:150
-msgid "# 8.3.0-alpha.1\n"
+#: src/08-release-process.md:115
+msgid "crates.io Trusted Publishing setup (one-time, per crate)"
 msgstr ""
 
-#: src/08-release-process.md:152
-msgid "# 8.3.0-alpha.2\n"
+#: src/08-release-process.md:117
+msgid ""
+"OIDC-based publishing (no long-lived `CARGO_REGISTRY_TOKEN`) requires "
+"configuring **Trusted Publishing** individually for each of this workspace's "
+"~15 published crates, on crates.io itself — this can't be done from workflow "
+"YAML:"
 msgstr ""
 
-#: src/08-release-process.md:154
-msgid "# 8.3.0-alpha.3\n"
+#: src/08-release-process.md:121
+msgid ""
+"For each crate: crates.io → the crate's page → Settings → Publishing → add a "
+"GitHub Actions trusted publisher pointing at `LepistaBioinformatics/"
+"mycelium` and the workflow filename (`release-prerelease.yml`, `release-"
+"stable.yml`, or `publish-crates.yml` — add all three, since any of them may "
+"run the publish step)."
 msgstr ""
 
-#: src/08-release-process.md:155
-#, fuzzy
-msgid "# Beta stage - features complete\n"
-msgstr "Funcionalidades completas"
-
-#: src/08-release-process.md:157
-msgid "# 8.3.0-beta.1\n"
+#: src/08-release-process.md:125
+msgid ""
+"Until every crate has this configured, publish steps fall back to the "
+"`CARGO_REGISTRY_TOKEN` repository secret automatically."
 msgstr ""
 
-#: src/08-release-process.md:159
-msgid "# 8.3.0-beta.2\n"
+#: src/08-release-process.md:127
+msgid ""
+"Once every crate is confirmed working via OIDC (ideally proven by a full RC "
+"cycle), remove the `CARGO_REGISTRY_TOKEN` secret from the repository."
 msgstr ""
 
-#: src/08-release-process.md:160
-#, fuzzy
-msgid "# Release candidate - final validation\n"
-msgstr "**Objetivo**: Candidato pronto para produção e validação final"
-
-#: src/08-release-process.md:162
-msgid "# 8.3.0-rc.1\n"
-msgstr ""
-
-#: src/08-release-process.md:164
-msgid "# 8.3.0-rc.2\n"
-msgstr ""
-
-#: src/08-release-process.md:165
-#, fuzzy
-msgid "# Stable release\n"
-msgstr "Lançamento Estável"
-
-#: src/08-release-process.md:167
-msgid "# 8.3.0\n"
-msgstr ""
-
-#: src/08-release-process.md:168
-#, fuzzy
-msgid "# Later patch releases\n"
-msgstr "Lançamento de Patch"
-
-#: src/08-release-process.md:170
-msgid "# 8.3.1\n"
-msgstr ""
-
-#: src/08-release-process.md:171
-msgid "# 8.3.2\n"
-msgstr ""
-
-#: src/08-release-process.md:172
-#, fuzzy
-msgid "# Next minor release\n"
-msgstr "Lançamento Minor"
-
-#: src/08-release-process.md:174 src/08-release-process.md:360
-msgid "# 8.4.0\n"
-msgstr ""
-
-#: src/08-release-process.md:177
+#: src/08-release-process.md:130
 msgid "Changelog Management"
 msgstr "Gerenciamento de Changelog"
 
-#: src/08-release-process.md:179
+#: src/08-release-process.md:132
 msgid ""
 "Mycelium uses `git-cliff` to automatically generate changelogs from "
-"conventional commits."
+"conventional commits — both `CHANGELOG.md` (via `release.toml`'s `pre-"
+"release-hook`) and each tag's GitHub Release body (via `docker-release."
+"yml`'s `github-release` job)."
 msgstr ""
-"O Mycelium usa o `git-cliff` para gerar changelogs automaticamente a partir "
-"de commits convencionais."
 
-#: src/08-release-process.md:181
+#: src/08-release-process.md:136
 msgid "Conventional Commit Format"
 msgstr "Formato de Commit Convencional"
 
-#: src/08-release-process.md:183
+#: src/08-release-process.md:138
 msgid ""
 "All commits should follow the [Conventional Commits](https://www."
 "conventionalcommits.org/) specification:"
@@ -9319,120 +9238,120 @@ msgstr ""
 "Todos os commits devem seguir a especificação [Conventional Commits](https://"
 "www.conventionalcommits.org/):"
 
-#: src/08-release-process.md:193
+#: src/08-release-process.md:148
 msgid "**Supported types**:"
 msgstr "**Tipos suportados**:"
 
-#: src/08-release-process.md:195
+#: src/08-release-process.md:150
 msgid "Changelog Section"
 msgstr "Seção do Changelog"
 
-#: src/08-release-process.md:197
+#: src/08-release-process.md:152
 msgid "`feat`"
 msgstr ""
 
-#: src/08-release-process.md:197
+#: src/08-release-process.md:152
 msgid "New feature"
 msgstr "Nova funcionalidade"
 
-#: src/08-release-process.md:197
+#: src/08-release-process.md:152
 msgid "🚀 Features"
 msgstr "🚀 Features"
 
-#: src/08-release-process.md:198
+#: src/08-release-process.md:153
 msgid "`fix`"
 msgstr ""
 
-#: src/08-release-process.md:198
+#: src/08-release-process.md:153
 msgid "Bug fix"
 msgstr "Correção de bug"
 
-#: src/08-release-process.md:198
+#: src/08-release-process.md:153
 msgid "🐛 Bug Fixes"
 msgstr "🐛 Bug Fixes"
 
-#: src/08-release-process.md:199
+#: src/08-release-process.md:154
 msgid "`docs`"
 msgstr ""
 
-#: src/08-release-process.md:199
+#: src/08-release-process.md:154
 msgid "Documentation"
 msgstr ""
 
-#: src/08-release-process.md:199
+#: src/08-release-process.md:154
 msgid "📚 Documentation"
 msgstr "📚 Documentation"
 
-#: src/08-release-process.md:200
+#: src/08-release-process.md:155
 msgid "`perf`"
 msgstr ""
 
-#: src/08-release-process.md:200
+#: src/08-release-process.md:155
 msgid "Performance improvement"
 msgstr "Melhoria de desempenho"
 
-#: src/08-release-process.md:200
+#: src/08-release-process.md:155
 msgid "⚡ Performance"
 msgstr "⚡ Performance"
 
-#: src/08-release-process.md:201
+#: src/08-release-process.md:156
 msgid "`refactor`"
 msgstr ""
 
-#: src/08-release-process.md:201
+#: src/08-release-process.md:156
 msgid "Code refactoring"
 msgstr "Refatoração de código"
 
-#: src/08-release-process.md:201
+#: src/08-release-process.md:156
 msgid "🚜 Refactor"
 msgstr "🚜 Refactor"
 
-#: src/08-release-process.md:202
+#: src/08-release-process.md:157
 msgid "`style`"
 msgstr ""
 
-#: src/08-release-process.md:202
+#: src/08-release-process.md:157
 msgid "Code style changes"
 msgstr "Mudanças de estilo de código"
 
-#: src/08-release-process.md:202
+#: src/08-release-process.md:157
 msgid "🎨 Styling"
 msgstr "🎨 Styling"
 
-#: src/08-release-process.md:203
+#: src/08-release-process.md:158
 msgid "`test`"
 msgstr ""
 
-#: src/08-release-process.md:203
+#: src/08-release-process.md:158
 msgid "Test changes"
 msgstr "Mudanças em testes"
 
-#: src/08-release-process.md:203
+#: src/08-release-process.md:158
 msgid "🧪 Testing"
 msgstr "🧪 Testing"
 
-#: src/08-release-process.md:204
+#: src/08-release-process.md:159
 msgid "`chore`"
 msgstr ""
 
-#: src/08-release-process.md:204
+#: src/08-release-process.md:159
 msgid "Maintenance tasks"
 msgstr "Tarefas de manutenção"
 
-#: src/08-release-process.md:204
+#: src/08-release-process.md:159
 msgid "⚙️ Miscellaneous Tasks"
 msgstr "⚙️ Miscellaneous Tasks"
 
-#: src/08-release-process.md:206
+#: src/08-release-process.md:161
 msgid "**Examples**:"
 msgstr "**Exemplos**:"
 
-#: src/08-release-process.md:209
+#: src/08-release-process.md:164
 #, fuzzy
 msgid "# Feature commit\n"
 msgstr "Funcionalidades completas"
 
-#: src/08-release-process.md:210
+#: src/08-release-process.md:165
 msgid ""
 "\"feat(auth): add passwordless authentication\n"
 "\n"
@@ -9442,23 +9361,23 @@ msgid ""
 "Fixes #110\""
 msgstr ""
 
-#: src/08-release-process.md:216
+#: src/08-release-process.md:171
 msgid "# Bug fix commit\n"
 msgstr ""
 
-#: src/08-release-process.md:218
+#: src/08-release-process.md:173
 msgid ""
 "\"fix(api): resolve null pointer in user endpoint\n"
 "\n"
 "Fixes #123\""
 msgstr ""
 
-#: src/08-release-process.md:221
+#: src/08-release-process.md:176
 #, fuzzy
 msgid "# Breaking change\n"
 msgstr "Para mudanças que quebram compatibilidade:"
 
-#: src/08-release-process.md:223
+#: src/08-release-process.md:178
 msgid ""
 "\"feat(core): redesign authentication API\n"
 "\n"
@@ -9468,31 +9387,33 @@ msgid ""
 "Fixes #150\""
 msgstr ""
 
-#: src/08-release-process.md:231
-msgid "Generating Changelogs"
+#: src/08-release-process.md:186
+#, fuzzy
+msgid "Previewing changelogs locally"
 msgstr "Gerando Changelogs"
 
-#: src/08-release-process.md:233
-msgid "Before creating a release, update the changelog:"
-msgstr "Antes de criar um lançamento, atualize o changelog:"
-
-#: src/08-release-process.md:236
+#: src/08-release-process.md:189
 msgid "# Preview unreleased changes\n"
 msgstr ""
 
-#: src/08-release-process.md:238
-msgid "# Update CHANGELOG.md with unreleased changes\n"
+#: src/08-release-process.md:191
+msgid ""
+"# Notes for a specific already-tagged version (what the GitHub Release job "
+"runs)\n"
 msgstr ""
 
-#: src/08-release-process.md:241
-msgid "# Generate changelog for a specific version\n"
+#: src/08-release-process.md:196
+msgid ""
+"`CHANGELOG.md` itself is updated automatically by `release.toml`'s `pre-"
+"release-hook` as part of the bump step — you don't need to run this by hand "
+"as part of a normal release."
 msgstr ""
 
-#: src/08-release-process.md:246
+#: src/08-release-process.md:199
 msgid "Changelog Configuration"
 msgstr "Configuração do Changelog"
 
-#: src/08-release-process.md:248
+#: src/08-release-process.md:201
 msgid ""
 "The changelog format is configured in `cliff.toml` at the repository root. "
 "This file defines:"
@@ -9500,104 +9421,108 @@ msgstr ""
 "O formato do changelog é configurado em `cliff.toml` na raiz do repositório. "
 "Este arquivo define:"
 
-#: src/08-release-process.md:249
+#: src/08-release-process.md:202
 msgid "Commit parsing rules"
 msgstr "Regras de análise de commits"
 
-#: src/08-release-process.md:250
+#: src/08-release-process.md:203
 msgid "Grouping and sorting"
 msgstr "Agrupamento e ordenação"
 
-#: src/08-release-process.md:251
+#: src/08-release-process.md:204
 msgid "Output format"
 msgstr "Formato de saída"
 
-#: src/08-release-process.md:252
+#: src/08-release-process.md:205
 msgid "Template customization"
 msgstr "Personalização de template"
 
-#: src/08-release-process.md:254
+#: src/08-release-process.md:207
 msgid "Dry Run (Recommended)"
 msgstr "Simulação (Recomendado)"
 
-#: src/08-release-process.md:256
-msgid "Always preview release changes before executing:"
+#: src/08-release-process.md:209
+#, fuzzy
+msgid "Always preview a release locally before dispatching the real workflow:"
 msgstr "Sempre pré-visualize as mudanças do lançamento antes de executar:"
 
-#: src/08-release-process.md:259
-msgid "# Dry run (default - no --execute flag)\n"
+#: src/08-release-process.md:212
+msgid ""
+"# Dry run (default -- no --execute flag). Needs no credentials, touches "
+"nothing.\n"
 msgstr ""
 
-#: src/08-release-process.md:261
+#: src/08-release-process.md:214
 msgid "# Review the output carefully:\n"
 msgstr ""
 
-#: src/08-release-process.md:263
+#: src/08-release-process.md:216
 msgid "# - Files that will be modified\n"
 msgstr ""
 
-#: src/08-release-process.md:265
+#: src/08-release-process.md:218
 msgid "# - Tags that will be created\n"
 msgstr ""
 
-#: src/08-release-process.md:267
-msgid "# If everything looks correct, execute\n"
+#: src/08-release-process.md:222
+msgid ""
+"Every release workflow also has its own `dry_run` input (`--no-publish --no-"
+"tag --no-push`) for the same preview, run inside CI."
 msgstr ""
 
-#: src/08-release-process.md:272
+#: src/08-release-process.md:225
 msgid "Release Checklist"
 msgstr "Checklist de Lançamento"
 
-#: src/08-release-process.md:274
-msgid "Use this checklist before creating a stable release:"
+#: src/08-release-process.md:227
+#, fuzzy
+msgid "Use this checklist before dispatching a stable release:"
 msgstr "Use este checklist antes de criar um lançamento estável:"
 
-#: src/08-release-process.md:276
-msgid "All tests pass: `cargo test`"
+#: src/08-release-process.md:229
+#, fuzzy
+msgid "All tests pass: `cargo test --workspace --all`"
 msgstr "Todos os testes passam: `cargo test`"
 
-#: src/08-release-process.md:277
-msgid "Code is properly formatted: `cargo fmt`"
+#: src/08-release-process.md:230
+#, fuzzy
+msgid "Code is properly formatted: `cargo fmt --all -- --check`"
 msgstr "Código está devidamente formatado: `cargo fmt`"
 
-#: src/08-release-process.md:278
+#: src/08-release-process.md:231
 msgid "No security vulnerabilities: `cargo audit`"
 msgstr "Sem vulnerabilidades de segurança: `cargo audit`"
 
-#: src/08-release-process.md:279
+#: src/08-release-process.md:232
 msgid "Documentation is up-to-date"
 msgstr "Documentação está atualizada"
 
-#: src/08-release-process.md:280
+#: src/08-release-process.md:233
 msgid "All commits follow conventional commit format"
 msgstr "Todos os commits seguem o formato de commit convencional"
 
-#: src/08-release-process.md:281
-msgid "Changelog is updated: `git-cliff --unreleased --prepend CHANGELOG.md`"
+#: src/08-release-process.md:234
+msgid "All CI checks pass on the branch being released"
 msgstr ""
-"Changelog está atualizado: `git-cliff --unreleased --prepend CHANGELOG.md`"
 
-#: src/08-release-process.md:282
-msgid "All CI checks pass"
-msgstr "Todas as verificações de CI passam"
-
-#: src/08-release-process.md:283
+#: src/08-release-process.md:235
 msgid "Team review is complete (for major/minor releases)"
 msgstr "Revisão do time está completa (para lançamentos major/minor)"
 
-#: src/08-release-process.md:284
-msgid "Release notes are prepared"
-msgstr "Notas de lançamento estão preparadas"
-
-#: src/08-release-process.md:285
-msgid "Dry run reviewed: `cargo release <level>`"
+#: src/08-release-process.md:236
+#, fuzzy
+msgid "Local dry run reviewed: `cargo release <level>`"
 msgstr "Simulação revisada: `cargo release <level>`"
 
-#: src/08-release-process.md:287
+#: src/08-release-process.md:237
+msgid "Workflow `dry_run: true` dispatch reviewed"
+msgstr ""
+
+#: src/08-release-process.md:239
 msgid "Release Configuration"
 msgstr "Configuração de Lançamento"
 
-#: src/08-release-process.md:289
+#: src/08-release-process.md:241
 msgid ""
 "The project's release behavior is configured in `release.toml` at the "
 "repository root."
@@ -9605,247 +9530,189 @@ msgstr ""
 "O comportamento de lançamento do projeto é configurado em `release.toml` na "
 "raiz do repositório."
 
-#: src/08-release-process.md:291
+#: src/08-release-process.md:243
 msgid "Key configurations include:"
 msgstr "As principais configurações incluem:"
 
-#: src/08-release-process.md:292
-msgid "**Pre-release hooks**: Run tests and builds before releasing"
+#: src/08-release-process.md:244
+#, fuzzy
+msgid ""
+"**Pre-release hooks**: regenerate `CHANGELOG.md` via `git-cliff` before "
+"tagging"
 msgstr "**Hooks pré-lançamento**: Executa testes e builds antes do lançamento"
 
-#: src/08-release-process.md:293
-msgid "**Version bumping**: Control how versions are incremented"
-msgstr "**Incremento de versão**: Controla como as versões são incrementadas"
+#: src/08-release-process.md:245
+msgid ""
+"**`[rate-limit]`**: paces crates.io publishes (`new-packages`/`existing-"
+"packages`) to stay under crates.io's documented limits — see [Publish "
+"Failures & Retry](#publish-failures--retry) for what happens if it still "
+"isn't enough"
+msgstr ""
 
-#: src/08-release-process.md:294
-msgid "**Git operations**: Tag format, commit messages"
+#: src/08-release-process.md:248
+msgid ""
+"**Version bumping**: `shared-version = true` — all workspace crates move "
+"together"
+msgstr ""
+
+#: src/08-release-process.md:249
+#, fuzzy
+msgid ""
+"**Git operations**: `tag-name = \"{{version}}\"` (no `v` prefix), commit/tag "
+"message templates"
 msgstr "**Operações Git**: Formato de tag, mensagens de commit"
 
-#: src/08-release-process.md:295
+#: src/08-release-process.md:250
 msgid ""
-"**Changelog integration**: Automatic changelog generation with git-cliff"
+"**Publishing**: `publish = true`, consumed by the `publish` step of the "
+"staged pipeline"
 msgstr ""
-"**Integração de changelog**: Geração automática de changelog com git-cliff"
 
-#: src/08-release-process.md:296
-msgid "**Publishing**: Control what gets published and where"
-msgstr "**Publicação**: Controla o que é publicado e onde"
-
-#: src/08-release-process.md:298
+#: src/08-release-process.md:252
 msgid "Best Practices"
 msgstr "Boas Práticas"
 
-#: src/08-release-process.md:300
-msgid "**Test thoroughly**: Run full test suite before any release"
+#: src/08-release-process.md:254
+#, fuzzy
+msgid "**Test thoroughly**: run the full test suite before any release."
 msgstr ""
 "**Teste completamente**: Execute o conjunto completo de testes antes de "
 "qualquer lançamento"
 
-#: src/08-release-process.md:301
-msgid "**Use dry runs**: Always preview changes before executing"
-msgstr "**Use simulações**: Sempre pré-visualize as mudanças antes de executar"
-
-#: src/08-release-process.md:302
+#: src/08-release-process.md:255
 msgid ""
-"**Follow the progression**: Don't skip stages (alpha → beta → rc → release)"
+"**Use dry runs**: both the local `cargo release <level>` preview and each "
+"workflow's `dry_run` input."
+msgstr ""
+
+#: src/08-release-process.md:257
+#, fuzzy
+msgid ""
+"**Follow the progression**: don't skip stages (beta → rc → stable) for "
+"anything but a hotfix patch."
 msgstr "**Siga a progressão**: Não pule estágios (alpha → beta → rc → release)"
 
-#: src/08-release-process.md:303
+#: src/08-release-process.md:259
+#, fuzzy
 msgid ""
-"**Write good commits**: Use conventional commits for automatic changelog "
-"generation"
+"**Write good commits**: use conventional commits — they drive both "
+"`CHANGELOG.md` and every tag's GitHub Release notes."
 msgstr ""
 "**Escreva bons commits**: Use commits convencionais para geração automática "
 "de changelog"
 
-#: src/08-release-process.md:304
-msgid "**Update changelog**: Generate changelog before each release"
-msgstr "**Atualize o changelog**: Gere o changelog antes de cada lançamento"
-
-#: src/08-release-process.md:305
-msgid "**Coordinate releases**: Communicate with team for major/minor releases"
+#: src/08-release-process.md:261
+#, fuzzy
+msgid ""
+"**Coordinate releases**: communicate with the team for major/minor releases."
 msgstr ""
 "**Coordene lançamentos**: Comunique-se com o time para lançamentos major/"
 "minor"
 
-#: src/08-release-process.md:306
-msgid "**Tag properly**: Let cargo-release handle tagging automatically"
-msgstr ""
-"**Faça tags corretamente**: Deixe o cargo-release gerenciar as tags "
-"automaticamente"
-
-#: src/08-release-process.md:307
-msgid "**Document changes**: Include migration guides for breaking changes"
-msgstr ""
-"**Documente mudanças**: Inclua guias de migração para mudanças que quebram "
-"compatibilidade"
-
-#: src/08-release-process.md:309
-msgid "Common Workflows"
-msgstr "Fluxos de Trabalho Comuns"
-
-#: src/08-release-process.md:311
-msgid "Hotfix Release"
-msgstr "Lançamento de Hotfix"
-
-#: src/08-release-process.md:313
-msgid "For urgent bug fixes on a stable release:"
-msgstr "Para correções urgentes de bugs em um lançamento estável:"
-
-#: src/08-release-process.md:316
-msgid "# On main branch with stable release 8.3.0\n"
+#: src/08-release-process.md:262
+msgid ""
+"**Never publish crates.io by hand**: always go through a workflow (OIDC "
+"token only exists in CI); a stray local `cargo publish` bypasses the "
+"pipeline entirely and won't produce a tag, image, or Release."
 msgstr ""
 
-#: src/08-release-process.md:317
-msgid "# ... fix the bug ...\n"
+#: src/08-release-process.md:268
+msgid "Workflow fails: \"Either release_type or custom_version must be set\""
 msgstr ""
 
-#: src/08-release-process.md:319
-msgid "\"fix: resolve critical security issue\""
+#: src/08-release-process.md:270
+msgid ""
+"`release-prerelease.yml` requires one of the two — leave `release_type` on "
+"its default `beta`/`rc` choice unless you specifically need `custom_version` "
+"(see the 9.0.0 walkthrough above)."
 msgstr ""
 
-#: src/08-release-process.md:320
-msgid "# Merge to main\n"
-msgstr ""
-
-#: src/08-release-process.md:324
-#, fuzzy
-msgid "# Create patch release\n"
-msgstr "Criar um papel de convidado"
-
-#: src/08-release-process.md:328
-msgid "\"docs: update changelog for 8.3.1\""
-msgstr ""
-
-#: src/08-release-process.md:329
-#, fuzzy
-msgid "# 8.3.0 → 8.3.1\n"
-msgstr "**Exemplo**: `8.3.0` → `8.3.1`"
-
-#: src/08-release-process.md:332
-msgid "Feature Release"
-msgstr "Lançamento de Funcionalidade"
-
-#: src/08-release-process.md:334
-msgid "For a new feature release:"
-msgstr "Para um lançamento de nova funcionalidade:"
-
-#: src/08-release-process.md:337
-msgid "# On develop branch\n"
-msgstr ""
-
-#: src/08-release-process.md:338
-msgid "# ... implement feature ...\n"
-msgstr ""
-
-#: src/08-release-process.md:340
-msgid "\"feat: add new capability\""
-msgstr ""
-
-#: src/08-release-process.md:341
-msgid "# Merge to develop\n"
-msgstr ""
-
-#: src/08-release-process.md:345
-msgid "# Start pre-release cycle\n"
-msgstr ""
-
-#: src/08-release-process.md:347
-msgid "# 8.4.0-alpha.1\n"
-msgstr ""
-
-#: src/08-release-process.md:349
-msgid "# 8.4.0-beta.1\n"
-msgstr ""
-
-#: src/08-release-process.md:351
-msgid "# 8.4.0-rc.1\n"
-msgstr ""
-
-#: src/08-release-process.md:353
-msgid "# Merge to main and release\n"
-msgstr ""
-
-#: src/08-release-process.md:359
-msgid "\"docs: update changelog for 8.4.0\""
-msgstr ""
-
-#: src/08-release-process.md:365
-msgid "Release fails due to uncommitted changes"
-msgstr "Lançamento falha devido a mudanças não confirmadas"
-
-#: src/08-release-process.md:368
-msgid "# Ensure working directory is clean\n"
-msgstr ""
-
-#: src/08-release-process.md:370
-msgid "# Commit or stash changes\n"
-msgstr ""
-
-#: src/08-release-process.md:373
-msgid "\"chore: prepare for release\""
-msgstr ""
-
-#: src/08-release-process.md:376
+#: src/08-release-process.md:273
 msgid "Changelog not generating correctly"
 msgstr "Changelog não está sendo gerado corretamente"
 
-#: src/08-release-process.md:379
+#: src/08-release-process.md:276
 #, fuzzy
 msgid "# Verify conventional commit format\n"
 msgstr "Formato de Commit Convencional"
 
-#: src/08-release-process.md:381
+#: src/08-release-process.md:278
 #, fuzzy
 msgid "# Test cliff configuration\n"
 msgstr "Configuração por tenant"
 
-#: src/08-release-process.md:384
+#: src/08-release-process.md:281
 #, fuzzy
 msgid "# Check cliff.toml configuration\n"
 msgstr "Configuração do Changelog"
 
-#: src/08-release-process.md:389
+#: src/08-release-process.md:286
+msgid "A GitHub Release didn't get created for a tag"
+msgstr ""
+
+#: src/08-release-process.md:288
+msgid ""
+"`docker-release.yml`'s `github-release` job depends on the `image` job "
+"succeeding first (`needs: image`) — check the `image` job's logs (build, "
+"provenance attestation, cosign signing) for the actual failure; the Release "
+"step itself is idempotent and safe to re-run via `workflow_dispatch` with "
+"that tag once the underlying issue is fixed."
+msgstr ""
+
+#: src/08-release-process.md:293
 msgid "Wrong version incremented"
 msgstr "Versão errada incrementada"
 
-#: src/08-release-process.md:392
-msgid "# Use dry run first to verify\n"
+#: src/08-release-process.md:296
+#, fuzzy
+msgid "# Use a local dry run first to verify: cargo release <level>\n"
+msgstr "Simulação revisada: `cargo release <level>`"
+
+#: src/08-release-process.md:297
+msgid ""
+"# (publish failed before tag+push), just re-dispatch with the correct level "
+"--\n"
 msgstr ""
 
-#: src/08-release-process.md:395
-msgid "# Edit Cargo.toml files\n"
+#: src/08-release-process.md:299
+msgid ""
+"# If it DID reach the remote (tag pushed), coordinate a fix manually --\n"
 msgstr ""
 
-#: src/08-release-process.md:397
-msgid "# Try again with correct level\n"
+#: src/08-release-process.md:301
+msgid "# without understanding the full blast radius first.\n"
 msgstr ""
 
-#: src/08-release-process.md:401
+#: src/08-release-process.md:305
 msgid "Additional Resources"
 msgstr "Recursos Adicionais"
 
-#: src/08-release-process.md:403
+#: src/08-release-process.md:307
 msgid "[Semantic Versioning Specification](https://semver.org/)"
 msgstr "[Especificação de Versionamento Semântico](https://semver.org/)"
 
-#: src/08-release-process.md:404
+#: src/08-release-process.md:308
 msgid ""
 "[Conventional Commits Specification](https://www.conventionalcommits.org/)"
 msgstr ""
 "[Especificação de Conventional Commits](https://www.conventionalcommits.org/)"
 
-#: src/08-release-process.md:405
+#: src/08-release-process.md:309
 msgid ""
 "[cargo-release Documentation](https://github.com/crate-ci/cargo-release)"
 msgstr ""
 "[Documentação do cargo-release](https://github.com/crate-ci/cargo-release)"
 
-#: src/08-release-process.md:406
+#: src/08-release-process.md:310
 msgid "[git-cliff Documentation](https://git-cliff.org/)"
 msgstr "[Documentação do git-cliff](https://git-cliff.org/)"
 
-#: src/08-release-process.md:407
+#: src/08-release-process.md:311
+msgid ""
+"[crates.io Trusted Publishing](https://crates.io/docs/trusted-publishing)"
+msgstr ""
+
+#: src/08-release-process.md:312
 msgid "[Contributing Guide](../../CONTRIBUTING.md#release-process)"
 msgstr "[Guia de Contribuição](../../CONTRIBUTING.md#release-process)"
 
@@ -10361,3 +10228,245 @@ msgstr ""
 "ciclo é o fluxo de identidade/perfil de uma requisição; use-os para comparar "
 "a primeira requisição (geralmente mais `resolved`) vs. requisições "
 "posteriores (geralmente mais `from_cache`)."
+
+#~ msgid ""
+#~ "Mycelium follows [Semantic Versioning](https://semver.org/) and uses "
+#~ "automated tools to manage releases:"
+#~ msgstr ""
+#~ "O Mycelium segue o [Versionamento Semântico](https://semver.org/) e usa "
+#~ "ferramentas automatizadas para gerenciar lançamentos:"
+
+#~ msgid "**git-cliff**: Generates changelogs from conventional commits"
+#~ msgstr "**git-cliff**: Gera changelogs a partir de commits convencionais"
+
+#~ msgid "Install the required tools:"
+#~ msgstr "Instale as ferramentas necessárias:"
+
+#~ msgid "Mycelium follows Semantic Versioning (SemVer):"
+#~ msgstr "O Mycelium segue o Versionamento Semântico (SemVer):"
+
+#~ msgid "Pre-releases follow a specific progression through stages:"
+#~ msgstr "Os pré-lançamentos seguem uma progressão específica por estágios:"
+
+#, fuzzy
+#~ msgid "1. Alpha Stage"
+#~ msgstr "Estágio Alpha"
+
+#~ msgid "**Purpose**: Early development and testing"
+#~ msgstr "**Objetivo**: Desenvolvimento inicial e testes"
+
+#~ msgid "**Characteristics**:"
+#~ msgstr "**Características**:"
+
+#~ msgid "Unstable, frequent changes"
+#~ msgstr "Instável, mudanças frequentes"
+
+#~ msgid "Used for initial feature testing"
+#~ msgstr "Usado para testes iniciais de funcionalidades"
+
+#~ msgid "Not recommended for production"
+#~ msgstr "Não recomendado para produção"
+
+#~ msgid "**Creating an alpha release**:"
+#~ msgstr "**Criando um lançamento alpha**:"
+
+#~ msgid ""
+#~ "**Example progression**: `8.3.0-alpha.1` → `8.3.0-alpha.2` → `8.3.0-"
+#~ "alpha.3`"
+#~ msgstr ""
+#~ "**Exemplo de progressão**: `8.3.0-alpha.1` → `8.3.0-alpha.2` → `8.3.0-"
+#~ "alpha.3`"
+
+#, fuzzy
+#~ msgid "2. Beta Stage"
+#~ msgstr "Estágio Beta"
+
+#~ msgid "**Purpose**: Feature-complete version ready for broader testing"
+#~ msgstr ""
+#~ "**Objetivo**: Versão com funcionalidades completas, pronta para testes "
+#~ "mais amplos"
+
+#~ msgid "Features are complete"
+#~ msgstr "Funcionalidades completas"
+
+#~ msgid "API should be relatively stable"
+#~ msgstr "API deve estar relativamente estável"
+
+#~ msgid "May still have bugs"
+#~ msgstr "Pode ainda ter bugs"
+
+#~ msgid "Used for wider testing and feedback"
+#~ msgstr "Usado para testes mais abrangentes e feedback"
+
+#~ msgid "**Moving to beta**:"
+#~ msgstr "**Avançando para beta**:"
+
+#, fuzzy
+#~ msgid "3. Release Candidate (RC) Stage"
+#~ msgstr "Estágio Release Candidate (RC)"
+
+#~ msgid "**Purpose**: Production-ready candidate for final validation"
+#~ msgstr "**Objetivo**: Candidato pronto para produção e validação final"
+
+#~ msgid "Final testing before stable release"
+#~ msgstr "Testes finais antes do lançamento estável"
+
+#~ msgid "Only critical bug fixes allowed"
+#~ msgstr "Apenas correções críticas de bugs permitidas"
+
+#~ msgid "Ready for production testing"
+#~ msgstr "Pronto para testes em produção"
+
+#~ msgid "Last chance to catch issues"
+#~ msgstr "Última chance de encontrar problemas"
+
+#~ msgid "**Creating release candidates**:"
+#~ msgstr "**Criando release candidates**:"
+
+#~ msgid "**Example progression**: `8.3.0-rc.1` → `8.3.0-rc.2`"
+#~ msgstr "**Exemplo de progressão**: `8.3.0-rc.1` → `8.3.0-rc.2`"
+
+#, fuzzy
+#~ msgid "4. Stable Release"
+#~ msgstr "Lançamento Estável"
+
+#~ msgid "**Purpose**: Production-ready version"
+#~ msgstr "**Objetivo**: Versão pronta para produção"
+
+#~ msgid "**Creating the stable release**:"
+#~ msgstr "**Criando o lançamento estável**:"
+
+#~ msgid "**Example**: `8.3.0-rc.2` → `8.3.0`"
+#~ msgstr "**Exemplo**: `8.3.0-rc.2` → `8.3.0`"
+
+#~ msgid "Version Increment Commands"
+#~ msgstr "Comandos de Incremento de Versão"
+
+#~ msgid "Patch Release"
+#~ msgstr "Lançamento de Patch"
+
+#~ msgid "For bug fixes on existing stable releases:"
+#~ msgstr "Para correções de bugs em lançamentos estáveis existentes:"
+
+#~ msgid "**Example**: `8.3.0` → `8.3.1`"
+#~ msgstr "**Exemplo**: `8.3.0` → `8.3.1`"
+
+#~ msgid "Minor Release"
+#~ msgstr "Lançamento Minor"
+
+#~ msgid "For new features (backward-compatible):"
+#~ msgstr "Para novas funcionalidades (compatíveis com versões anteriores):"
+
+#~ msgid "**Example**: `8.3.1` → `8.4.0`"
+#~ msgstr "**Exemplo**: `8.3.1` → `8.4.0`"
+
+#~ msgid "Major Release"
+#~ msgstr "Lançamento Major"
+
+#~ msgid "For breaking changes:"
+#~ msgstr "Para mudanças que quebram compatibilidade:"
+
+#~ msgid "**Example**: `8.4.0` → `9.0.0`"
+#~ msgstr "**Exemplo**: `8.4.0` → `9.0.0`"
+
+#~ msgid "Complete Release Cycle Example"
+#~ msgstr "Exemplo de Ciclo de Lançamento Completo"
+
+#~ msgid "Here's a complete example of releasing version 8.3.0:"
+#~ msgstr "Aqui está um exemplo completo do lançamento da versão 8.3.0:"
+
+#, fuzzy
+#~ msgid "# Beta stage - features complete\n"
+#~ msgstr "Funcionalidades completas"
+
+#, fuzzy
+#~ msgid "# Release candidate - final validation\n"
+#~ msgstr "**Objetivo**: Candidato pronto para produção e validação final"
+
+#, fuzzy
+#~ msgid "# Stable release\n"
+#~ msgstr "Lançamento Estável"
+
+#, fuzzy
+#~ msgid "# Later patch releases\n"
+#~ msgstr "Lançamento de Patch"
+
+#, fuzzy
+#~ msgid "# Next minor release\n"
+#~ msgstr "Lançamento Minor"
+
+#~ msgid ""
+#~ "Mycelium uses `git-cliff` to automatically generate changelogs from "
+#~ "conventional commits."
+#~ msgstr ""
+#~ "O Mycelium usa o `git-cliff` para gerar changelogs automaticamente a "
+#~ "partir de commits convencionais."
+
+#~ msgid "Before creating a release, update the changelog:"
+#~ msgstr "Antes de criar um lançamento, atualize o changelog:"
+
+#~ msgid ""
+#~ "Changelog is updated: `git-cliff --unreleased --prepend CHANGELOG.md`"
+#~ msgstr ""
+#~ "Changelog está atualizado: `git-cliff --unreleased --prepend CHANGELOG.md`"
+
+#~ msgid "All CI checks pass"
+#~ msgstr "Todas as verificações de CI passam"
+
+#~ msgid "Release notes are prepared"
+#~ msgstr "Notas de lançamento estão preparadas"
+
+#~ msgid "**Version bumping**: Control how versions are incremented"
+#~ msgstr ""
+#~ "**Incremento de versão**: Controla como as versões são incrementadas"
+
+#~ msgid ""
+#~ "**Changelog integration**: Automatic changelog generation with git-cliff"
+#~ msgstr ""
+#~ "**Integração de changelog**: Geração automática de changelog com git-cliff"
+
+#~ msgid "**Publishing**: Control what gets published and where"
+#~ msgstr "**Publicação**: Controla o que é publicado e onde"
+
+#~ msgid "**Use dry runs**: Always preview changes before executing"
+#~ msgstr ""
+#~ "**Use simulações**: Sempre pré-visualize as mudanças antes de executar"
+
+#~ msgid "**Update changelog**: Generate changelog before each release"
+#~ msgstr "**Atualize o changelog**: Gere o changelog antes de cada lançamento"
+
+#~ msgid "**Tag properly**: Let cargo-release handle tagging automatically"
+#~ msgstr ""
+#~ "**Faça tags corretamente**: Deixe o cargo-release gerenciar as tags "
+#~ "automaticamente"
+
+#~ msgid "**Document changes**: Include migration guides for breaking changes"
+#~ msgstr ""
+#~ "**Documente mudanças**: Inclua guias de migração para mudanças que "
+#~ "quebram compatibilidade"
+
+#~ msgid "Common Workflows"
+#~ msgstr "Fluxos de Trabalho Comuns"
+
+#~ msgid "Hotfix Release"
+#~ msgstr "Lançamento de Hotfix"
+
+#~ msgid "For urgent bug fixes on a stable release:"
+#~ msgstr "Para correções urgentes de bugs em um lançamento estável:"
+
+#, fuzzy
+#~ msgid "# Create patch release\n"
+#~ msgstr "Criar um papel de convidado"
+
+#, fuzzy
+#~ msgid "# 8.3.0 → 8.3.1\n"
+#~ msgstr "**Exemplo**: `8.3.0` → `8.3.1`"
+
+#~ msgid "Feature Release"
+#~ msgstr "Lançamento de Funcionalidade"
+
+#~ msgid "For a new feature release:"
+#~ msgstr "Para um lançamento de nova funcionalidade:"
+
+#~ msgid "Release fails due to uncommitted changes"
+#~ msgstr "Lançamento falha devido a mudanças não confirmadas"

--- a/docs/book/src/08-release-process.md
+++ b/docs/book/src/08-release-process.md
@@ -1,26 +1,29 @@
 # Release Process
 
-This guide explains how to create and manage releases for Mycelium using `cargo-release` and `git-cliff`.
+This guide explains how Mycelium releases are cut, using `cargo-release` and `git-cliff`,
+orchestrated by GitHub Actions.
 
 ## Overview
 
-Mycelium follows [Semantic Versioning](https://semver.org/) and uses automated tools to manage releases:
+Mycelium follows [Semantic Versioning](https://semver.org/). Releases are **not** run by hand
+locally — they run through GitHub Actions `workflow_dispatch` jobs, because two pieces of the
+pipeline only work inside CI:
 
-- **cargo-release**: Manages version bumping, tagging, and publishing
-- **git-cliff**: Generates changelogs from conventional commits
+- **`RELEASE_TOKEN`** (a PAT/App token) is what makes a pushed tag *cascade* to the
+  tag-triggered `docker-release.yml` workflow — the built-in `GITHUB_TOKEN` would not.
+- **crates.io Trusted Publishing (OIDC)** — the short-lived crates.io token is exchanged via
+  GitHub's OIDC identity, which only exists inside an Actions run.
 
-## Prerequisites
+A local `cargo release <level>` (no `--execute`) dry-run is still the right way to preview a bump
+before dispatching the real workflow — it needs no credentials and touches nothing.
 
-Install the required tools:
-
-```bash
-cargo install cargo-release
-cargo install git-cliff
-```
+Tools involved:
+- **cargo-release**: version bumping, changelog hook, tagging, publishing.
+- **git-cliff**: generates changelog notes from conventional commits — used both for
+  `CHANGELOG.md` and as the body of the GitHub Release `docker-release.yml`'s `github-release`
+  job creates for every tag.
 
 ## Version Semantics
-
-Mycelium follows Semantic Versioning (SemVer):
 
 | Version Type | Format | When to Use | Example |
 |--------------|--------|-------------|---------|
@@ -28,155 +31,107 @@ Mycelium follows Semantic Versioning (SemVer):
 | **MINOR** | `x.Y.0` | New features (backward-compatible) | `8.3.0` → `8.4.0` |
 | **PATCH** | `x.y.Z` | Bug fixes (backward-compatible) | `8.3.0` → `8.3.1` |
 
+**Tag naming:** no `v` prefix — tags and image tags are `8.3.1`, `8.3.1-rc.1`, never `v8.3.1`.
+Historical `v*` tags (pre-`8.3.0`) are left as-is, never renamed.
+
+## The Automated Pipeline
+
+Dispatching `release-prerelease.yml` (from `develop`) or `release-stable.yml` (from `main`) runs,
+in one job: **bump → commit (local) → publish (OIDC, rate-limited) → tag → push.** Nothing is
+pushed to the branch or to crates.io until the step that does it succeeds; if `publish` fails, the
+job simply ends and the remote is untouched — see [Publish Failures & Retry](#publish-failures--retry)
+below.
+
+Once the tag is pushed, `docker-release.yml` fires automatically:
+1. **`image` job** — builds from that exact tag (fixed ref bug, see below), pushes to GHCR, attests
+   build provenance, and signs the image keylessly with cosign.
+2. **`github-release` job** — creates (or updates, idempotently) a GitHub Release for the tag, with
+   `git-cliff` notes and the correct `prerelease` flag.
+
+You can also trigger `docker-release.yml` manually via `workflow_dispatch` with a `tag` input — for
+example to rebuild an older tag. It checks out that exact tag's source (not whatever branch the
+dispatch happened to run from), so the rebuilt image's content always matches its version label.
+
 ## Pre-release Workflow
 
-Pre-releases follow a specific progression through stages:
+Pre-releases progress through `beta` → `rc` stages (dispatch `release-prerelease.yml` from
+`develop`, choosing `release_type`). `cargo-release` also supports an `alpha` level, but it isn't
+wired into either workflow's dropdown today — use `custom_version` (see below) if you ever need it.
 
-### 1. Alpha Stage
+**Example progression**: `8.3.0-beta.1` → `8.3.0-beta.2` → `8.3.0-rc.1` → `8.3.0-rc.2`
 
-**Purpose**: Early development and testing
+### Promoting to stable
 
-**Characteristics**:
-- Unstable, frequent changes
-- Used for initial feature testing
-- Not recommended for production
+Dispatch `release-stable.yml` from `main` with `release_type: patch|minor|major` — cargo-release's
+`release` level (`X.Y.Z-rc.N` → `X.Y.Z`, dropping the pre-release suffix) is available locally for
+a dry-run preview, but isn't exposed as a `release-stable.yml` dropdown option; the stable workflow
+always bumps from `main`'s current version, so merge the release branch into `main` first, then
+dispatch with the level matching what the pre-release cycle was for (a `9.0.0-rc.N` line promotes
+via `major` from the last stable tag once `main` is on the rc's commit — see the 9.0.0 walkthrough
+below for the concrete case).
 
-**Creating an alpha release**:
+## Publish Failures & Retry
 
-```bash
-# First alpha
-cargo release alpha --execute  # Creates x.y.z-alpha.1
+If the **publish** step fails partway (crates.io throttling despite `release.toml`'s
+`[rate-limit]`, a network blip, or a single crate's own issue), recovery depends on what kind of
+bump it was — nothing was pushed, so the remote branch and tags are exactly as they were before
+you dispatched:
 
-# Subsequent alphas
-cargo release alpha --execute  # Creates x.y.z-alpha.2, etc.
-```
+- **`patch` / `minor` / `major` / `release`** (deterministic target version): just **re-dispatch
+  the same workflow**. It recomputes the identical target version, and `cargo release publish`
+  already skips crates that succeeded in the previous attempt — the retry only publishes what's
+  left, then proceeds to tag+push normally.
+- **`beta` / `rc`** (relative bump): re-dispatching increments again (`rc.1` → `rc.2`), it does
+  **not** retry `rc.1`. Treat the partial `rc.N`/`beta.N` as abandoned — the handful of crates that
+  did publish at that version are harmless orphans on crates.io (untagged, unreferenced, nothing
+  depends on that exact version existing) — and dispatch the workflow again for the **next**
+  rc/beta number.
+- **`publish-crates.yml`** is also available any time as a standalone re-publish pass (same OIDC
+  auth), with an `unpublished_only` input (`cargo release publish --unpublished`) to scope it to
+  just the packages not yet published at their current `Cargo.toml` version — useful if you want to
+  retry only the publish step without touching bump/tag/push.
 
-**Example progression**: `8.3.0-alpha.1` → `8.3.0-alpha.2` → `8.3.0-alpha.3`
+## Major Version Bump via Release Candidates (9.0.0 walkthrough)
 
-### 2. Beta Stage
+Going from the `8.3.x` line to `9.0.0` is a routine major bump with no breaking changes planned —
+release it as a series of RCs first, same as any other release, with one wrinkle: cargo-release's
+`major` LEVEL alone jumps straight to a **stable** `9.0.0`, and its `--metadata`/`-m` flag sets
+semver *build* metadata after a `+` (e.g. `9.0.0+rc.1`), **not** a pre-release identifier — neither
+composes "major" with "rc" the way you'd want. The fix is `release-prerelease.yml`'s
+`custom_version` input, which accepts an explicit target version string (cargo-release's other
+accepted form of its `[LEVEL|VERSION]` argument):
 
-**Purpose**: Feature-complete version ready for broader testing
+1. Dispatch `release-prerelease.yml` from `develop` with `custom_version: 9.0.0-rc.1` (leave
+   `release_type` blank). Do a `dry_run: true` pass first and review the diff.
+2. Every subsequent RC uses the normal `release_type: rc` dropdown again — `9.0.0-rc.1` → `rc` →
+   `9.0.0-rc.2`, etc. Verify each RC end-to-end (install the RC crate, boot the RC image) before
+   cutting the next one.
+3. Before cutting `9.0.0-rc.1`, make sure crates.io Trusted Publishing is configured for every
+   workspace crate (see below) — this is the first real end-to-end exercise of OIDC publishing;
+   keep `CARGO_REGISTRY_TOKEN` as a fallback until this cycle proves it works.
+4. Once satisfied, merge to `main` and dispatch `release-stable.yml` with `release_type: major` to
+   drop the `-rc.N` suffix and cut `9.0.0` stable.
 
-**Characteristics**:
-- Features are complete
-- API should be relatively stable
-- May still have bugs
-- Used for wider testing and feedback
+## crates.io Trusted Publishing setup (one-time, per crate)
 
-**Moving to beta**:
+OIDC-based publishing (no long-lived `CARGO_REGISTRY_TOKEN`) requires configuring **Trusted
+Publishing** individually for each of this workspace's ~15 published crates, on crates.io itself —
+this can't be done from workflow YAML:
 
-```bash
-# First beta
-cargo release beta --execute   # Creates x.y.z-beta.1
-
-# Subsequent betas
-cargo release beta --execute   # Creates x.y.z-beta.2, etc.
-```
-
-**Example progression**: `8.3.0-beta.1` → `8.3.0-beta.2` → `8.3.0-beta.3`
-
-### 3. Release Candidate (RC) Stage
-
-**Purpose**: Production-ready candidate for final validation
-
-**Characteristics**:
-- Final testing before stable release
-- Only critical bug fixes allowed
-- Ready for production testing
-- Last chance to catch issues
-
-**Creating release candidates**:
-
-```bash
-# First RC
-cargo release rc --execute     # Creates x.y.z-rc.1
-
-# Subsequent RCs (if needed)
-cargo release rc --execute     # Creates x.y.z-rc.2, etc.
-```
-
-**Example progression**: `8.3.0-rc.1` → `8.3.0-rc.2`
-
-### 4. Stable Release
-
-**Purpose**: Production-ready version
-
-**Creating the stable release**:
-
-```bash
-cargo release release --execute  # Creates x.y.z
-```
-
-**Example**: `8.3.0-rc.2` → `8.3.0`
-
-## Version Increment Commands
-
-### Patch Release
-
-For bug fixes on existing stable releases:
-
-```bash
-cargo release patch --execute
-```
-
-**Example**: `8.3.0` → `8.3.1`
-
-### Minor Release
-
-For new features (backward-compatible):
-
-```bash
-cargo release minor --execute
-```
-
-**Example**: `8.3.1` → `8.4.0`
-
-### Major Release
-
-For breaking changes:
-
-```bash
-cargo release major --execute
-```
-
-**Example**: `8.4.0` → `9.0.0`
-
-## Complete Release Cycle Example
-
-Here's a complete example of releasing version 8.3.0:
-
-```bash
-# Alpha stage - initial testing
-cargo release alpha --execute        # 8.3.0-alpha.1
-# ... make changes, test ...
-cargo release alpha --execute        # 8.3.0-alpha.2
-# ... more changes, testing ...
-cargo release alpha --execute        # 8.3.0-alpha.3
-
-# Beta stage - features complete
-cargo release beta --execute         # 8.3.0-beta.1
-# ... wider testing, bug fixes ...
-cargo release beta --execute         # 8.3.0-beta.2
-
-# Release candidate - final validation
-cargo release rc --execute           # 8.3.0-rc.1
-# ... production testing ...
-cargo release rc --execute           # 8.3.0-rc.2
-
-# Stable release
-cargo release release --execute      # 8.3.0
-
-# Later patch releases
-cargo release patch --execute        # 8.3.1
-cargo release patch --execute        # 8.3.2
-
-# Next minor release
-cargo release minor --execute        # 8.4.0
-```
+1. For each crate: crates.io → the crate's page → Settings → Publishing → add a GitHub Actions
+   trusted publisher pointing at `LepistaBioinformatics/mycelium` and the workflow filename
+   (`release-prerelease.yml`, `release-stable.yml`, or `publish-crates.yml` — add all three, since
+   any of them may run the publish step).
+2. Until every crate has this configured, publish steps fall back to the `CARGO_REGISTRY_TOKEN`
+   repository secret automatically.
+3. Once every crate is confirmed working via OIDC (ideally proven by a full RC cycle), remove the
+   `CARGO_REGISTRY_TOKEN` secret from the repository.
 
 ## Changelog Management
 
-Mycelium uses `git-cliff` to automatically generate changelogs from conventional commits.
+Mycelium uses `git-cliff` to automatically generate changelogs from conventional commits — both
+`CHANGELOG.md` (via `release.toml`'s `pre-release-hook`) and each tag's GitHub Release body (via
+`docker-release.yml`'s `github-release` job).
 
 ### Conventional Commit Format
 
@@ -228,20 +183,18 @@ See migration guide for details.
 Fixes #150"
 ```
 
-### Generating Changelogs
-
-Before creating a release, update the changelog:
+### Previewing changelogs locally
 
 ```bash
 # Preview unreleased changes
 git-cliff --unreleased
 
-# Update CHANGELOG.md with unreleased changes
-git-cliff --unreleased --prepend CHANGELOG.md
-
-# Generate changelog for a specific version
-git-cliff --tag v8.3.0 --prepend CHANGELOG.md
+# Notes for a specific already-tagged version (what the GitHub Release job runs)
+git-cliff --latest --strip header
 ```
+
+`CHANGELOG.md` itself is updated automatically by `release.toml`'s `pre-release-hook` as part of
+the bump step — you don't need to run this by hand as part of a normal release.
 
 ### Changelog Configuration
 
@@ -253,125 +206,69 @@ The changelog format is configured in `cliff.toml` at the repository root. This 
 
 ## Dry Run (Recommended)
 
-Always preview release changes before executing:
+Always preview a release locally before dispatching the real workflow:
 
 ```bash
-# Dry run (default - no --execute flag)
-cargo release alpha
+# Dry run (default -- no --execute flag). Needs no credentials, touches nothing.
+cargo release rc
 
 # Review the output carefully:
 # - Version changes
 # - Files that will be modified
 # - Git commands that will run
 # - Tags that will be created
-
-# If everything looks correct, execute
-cargo release alpha --execute
 ```
+
+Every release workflow also has its own `dry_run` input (`--no-publish --no-tag --no-push`) for
+the same preview, run inside CI.
 
 ## Release Checklist
 
-Use this checklist before creating a stable release:
+Use this checklist before dispatching a stable release:
 
-- [ ] All tests pass: `cargo test`
-- [ ] Code is properly formatted: `cargo fmt`
+- [ ] All tests pass: `cargo test --workspace --all`
+- [ ] Code is properly formatted: `cargo fmt --all -- --check`
 - [ ] No security vulnerabilities: `cargo audit`
 - [ ] Documentation is up-to-date
 - [ ] All commits follow conventional commit format
-- [ ] Changelog is updated: `git-cliff --unreleased --prepend CHANGELOG.md`
-- [ ] All CI checks pass
+- [ ] All CI checks pass on the branch being released
 - [ ] Team review is complete (for major/minor releases)
-- [ ] Release notes are prepared
-- [ ] Dry run reviewed: `cargo release <level>`
+- [ ] Local dry run reviewed: `cargo release <level>`
+- [ ] Workflow `dry_run: true` dispatch reviewed
 
 ## Release Configuration
 
 The project's release behavior is configured in `release.toml` at the repository root.
 
 Key configurations include:
-- **Pre-release hooks**: Run tests and builds before releasing
-- **Version bumping**: Control how versions are incremented
-- **Git operations**: Tag format, commit messages
-- **Changelog integration**: Automatic changelog generation with git-cliff
-- **Publishing**: Control what gets published and where
+- **Pre-release hooks**: regenerate `CHANGELOG.md` via `git-cliff` before tagging
+- **`[rate-limit]`**: paces crates.io publishes (`new-packages`/`existing-packages`) to stay under
+  crates.io's documented limits — see [Publish Failures & Retry](#publish-failures--retry) for what
+  happens if it still isn't enough
+- **Version bumping**: `shared-version = true` — all workspace crates move together
+- **Git operations**: `tag-name = "{{version}}"` (no `v` prefix), commit/tag message templates
+- **Publishing**: `publish = true`, consumed by the `publish` step of the staged pipeline
 
 ## Best Practices
 
-1. **Test thoroughly**: Run full test suite before any release
-2. **Use dry runs**: Always preview changes before executing
-3. **Follow the progression**: Don't skip stages (alpha → beta → rc → release)
-4. **Write good commits**: Use conventional commits for automatic changelog generation
-5. **Update changelog**: Generate changelog before each release
-6. **Coordinate releases**: Communicate with team for major/minor releases
-7. **Tag properly**: Let cargo-release handle tagging automatically
-8. **Document changes**: Include migration guides for breaking changes
-
-## Common Workflows
-
-### Hotfix Release
-
-For urgent bug fixes on a stable release:
-
-```bash
-# On main branch with stable release 8.3.0
-git checkout -b hotfix/critical-bug
-# ... fix the bug ...
-git commit -m "fix: resolve critical security issue"
-
-# Merge to main
-git checkout main
-git merge hotfix/critical-bug
-
-# Create patch release
-git-cliff --unreleased --prepend CHANGELOG.md
-git add CHANGELOG.md
-git commit -m "docs: update changelog for 8.3.1"
-cargo release patch --execute  # 8.3.0 → 8.3.1
-```
-
-### Feature Release
-
-For a new feature release:
-
-```bash
-# On develop branch
-git checkout -b feature/new-capability
-# ... implement feature ...
-git commit -m "feat: add new capability"
-
-# Merge to develop
-git checkout develop
-git merge feature/new-capability
-
-# Start pre-release cycle
-cargo release alpha --execute    # 8.4.0-alpha.1
-# ... test, fix, repeat ...
-cargo release beta --execute     # 8.4.0-beta.1
-# ... wider testing ...
-cargo release rc --execute       # 8.4.0-rc.1
-# ... final validation ...
-
-# Merge to main and release
-git checkout main
-git merge develop
-git-cliff --unreleased --prepend CHANGELOG.md
-git add CHANGELOG.md
-git commit -m "docs: update changelog for 8.4.0"
-cargo release release --execute  # 8.4.0
-```
+1. **Test thoroughly**: run the full test suite before any release.
+2. **Use dry runs**: both the local `cargo release <level>` preview and each workflow's `dry_run`
+   input.
+3. **Follow the progression**: don't skip stages (beta → rc → stable) for anything but a hotfix
+   patch.
+4. **Write good commits**: use conventional commits — they drive both `CHANGELOG.md` and every
+   tag's GitHub Release notes.
+5. **Coordinate releases**: communicate with the team for major/minor releases.
+6. **Never publish crates.io by hand**: always go through a workflow (OIDC token only exists in
+   CI); a stray local `cargo publish` bypasses the pipeline entirely and won't produce a tag, image,
+   or Release.
 
 ## Troubleshooting
 
-### Release fails due to uncommitted changes
+### Workflow fails: "Either release_type or custom_version must be set"
 
-```bash
-# Ensure working directory is clean
-git status
-
-# Commit or stash changes
-git add .
-git commit -m "chore: prepare for release"
-```
+`release-prerelease.yml` requires one of the two — leave `release_type` on its default `beta`/`rc`
+choice unless you specifically need `custom_version` (see the 9.0.0 walkthrough above).
 
 ### Changelog not generating correctly
 
@@ -386,16 +283,23 @@ git-cliff --unreleased
 cat cliff.toml
 ```
 
+### A GitHub Release didn't get created for a tag
+
+`docker-release.yml`'s `github-release` job depends on the `image` job succeeding first
+(`needs: image`) — check the `image` job's logs (build, provenance attestation, cosign signing) for
+the actual failure; the Release step itself is idempotent and safe to re-run via `workflow_dispatch`
+with that tag once the underlying issue is fixed.
+
 ### Wrong version incremented
 
 ```bash
-# Use dry run first to verify
-cargo release <level>
-
-# If wrong level used, manually fix:
-# Edit Cargo.toml files
-# Delete incorrect git tag: git tag -d vX.Y.Z
-# Try again with correct level
+# Use a local dry run first to verify: cargo release <level>
+# If a workflow already ran with the wrong level and nothing was pushed yet
+# (publish failed before tag+push), just re-dispatch with the correct level --
+# no cleanup needed, nothing reached the remote.
+# If it DID reach the remote (tag pushed), coordinate a fix manually --
+# do not delete/force-push a tag that crates.io/GHCR/a Release already reference
+# without understanding the full blast radius first.
 ```
 
 ## Additional Resources
@@ -404,4 +308,5 @@ cargo release <level>
 - [Conventional Commits Specification](https://www.conventionalcommits.org/)
 - [cargo-release Documentation](https://github.com/crate-ci/cargo-release)
 - [git-cliff Documentation](https://git-cliff.org/)
+- [crates.io Trusted Publishing](https://crates.io/docs/trusted-publishing)
 - [Contributing Guide](../../CONTRIBUTING.md#release-process)


### PR DESCRIPTION
## Summary
Implements the release-pipeline-hardening draft issue (REL-01..15) plus two follow-ups requested directly: a crates.io publish retry/backoff story, and the 9.0.0 major-bump-via-RCs process.

- **`release-prerelease.yml` / `release-stable.yml`**: split the single `cargo release` step into bump (local, unpushed) → OIDC-authenticated publish → tag+push — preserves cargo-release's own safe default ordering (nothing pushed until publish succeeds). Added a `custom_version` input for the one bump cargo-release's LEVEL keywords can't express (the first RC of a new major, e.g. `9.0.0-rc.1`).
- **`publish-crates.yml`**: same OIDC auth, plus an `unpublished_only` input (`cargo release publish --unpublished`) for manual retry after a partial publish failure.
- **`docker-release.yml`**: fixed a real bug — checkout had **no `ref:` at all**, so a `workflow_dispatch` rebuild of an old tag silently built from whatever branch triggered it, not the tag. Added build provenance attestation + cosign keyless signing. Split into `image` + `github-release` jobs; the latter creates/updates a GitHub Release per tag idempotently from `git-cliff` notes.
- All third-party actions pinned to commit SHA. GHCR image name lowercased (case-preserved repo owner name breaks cosign/attest otherwise).
- Rewrote `docs/book/src/08-release-process.md` to match the actual CI-driven process instead of a stale manual-local flow that referenced a nonexistent `alpha` CI option and `v`-prefixed tags.

`CARGO_REGISTRY_TOKEN` stays as a fallback until crates.io Trusted Publishing is configured per-crate and an RC proves OIDC works end-to-end — both external, manual prerequisites (crates.io UI, GitHub Environment settings) tracked in `tasks.md`, not something expressible in workflow YAML.

## Test plan
- [x] YAML-validated all 4 edited workflow files
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace --all`
- [x] `docs/book` pt-BR translation catalog resynced (`mdbook` xgettext + `msgmerge`)
- [ ] `dry_run: true` dispatch of `release-prerelease.yml` from this branch, to confirm the new staged steps run correctly
- [ ] crates.io Trusted Publishing configured for all 15 crates (external, manual — see `tasks.md` REL-T11)
- [ ] `release` GitHub Environment confirmed to exist with required reviewers (REL-T12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)