### PR TITLE
fix(http-secret): support field-level env/vault resolution for token

### DIFF
--- a/.claude/specs/features/http-secret-token-resolver/spec.md
+++ b/.claude/specs/features/http-secret-token-resolver/spec.md
@@ -1,0 +1,37 @@
+# Feature: Field-level env/vault resolution for HttpSecret.token
+
+Source: https://github.com/LepistaBioinformatics/mycelium/issues/165
+
+## Problem
+
+Docs (mag.lepista.io #downstream-apis) show `token = { env = "..." }` / `token = { vault = { path, key } }`
+on `HttpSecret::AuthorizationHeader` / `HttpSecret::QueryParameter`. The actual type declares
+`token: String`, so any config using the documented syntax fails to parse at boot
+(`data did not match any variant of untagged enum SecretResolver`).
+
+The `SecretResolver` pattern already works one level up, on the whole `HttpSecret` via
+`ServiceSecret.secret: SecretResolver<HttpSecret>` — but that forces the entire `HttpSecret`
+object (including non-sensitive `headerName`/`prefix`) to live inside the env var / vault secret,
+instead of just the token value, as SmtpConfig's `password: SecretResolver<String>` does today.
+
+## Requirements
+
+- R1: `HttpSecret::AuthorizationHeader.token` and `HttpSecret::QueryParameter.token` become
+  `SecretResolver<String>` instead of `String`, matching the docs and the `SmtpConfig` precedent.
+- R2: `HttpSecret::encrypt_me` / `decrypt_me` / `redact_token` only operate on
+  `SecretResolver::Value(_)` tokens (literal secrets stored at rest). `Env`/`Vault` tokens pass
+  through untouched — they never hold a plaintext secret at rest.
+- R3: The two call sites that build outgoing HTTP requests from a resolved `HttpSecret`
+  (`ports/api/src/router/inject_downstream_secret.rs`, `core/src/use_cases/support/dispatch_webhooks.rs`)
+  resolve `token` via `SecretResolver::async_get_or_error()` at point of use.
+- R4: Existing tests in `core/src/domain/dtos/route.rs` updated to construct
+  `token: SecretResolver::Value("...".to_string())`.
+- R5: No change to the outer `ServiceSecret.secret: SecretResolver<HttpSecret>` behavior — both
+  levels of resolution can now be used independently or together.
+
+## Out of scope
+
+- `adapters/diesel_postgres/src/migration/migrate_dek.rs` (`migrate_http_secret_json`) already only
+  handles literal (bare-string) tokens read from JSON — since `SecretResolver::Value(T)` is
+  `#[serde(untagged)]`, a literal token still serializes as a bare string, so this migration path is
+  unaffected. No change needed there.

--- a/core/src/domain/dtos/http_secret.rs
+++ b/core/src/domain/dtos/http_secret.rs
@@ -3,6 +3,7 @@ use crate::{
     models::AccountLifeCycle,
 };
 
+use myc_config::secret_resolver::SecretResolver;
 use mycelium_base::utils::errors::{dto_err, MappedErrors};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
@@ -39,7 +40,7 @@ pub enum HttpSecret {
         /// The token is the value of the header. For example, if the token is
         /// `1234`, the header will be `Authorization Bearer: 123
         ///
-        token: String,
+        token: SecretResolver<String>,
     },
 
     #[serde(rename_all = "camelCase")]
@@ -56,7 +57,7 @@ pub enum HttpSecret {
         /// The value of the query parameter. For example, if the value is `1234`,
         /// the query parameter will be `?token=1234`.
         ///
-        token: String,
+        token: SecretResolver<String>,
     },
 }
 
@@ -66,18 +67,27 @@ pub fn default_authorization_key() -> Option<String> {
 
 impl HttpSecret {
     /// Encrypt the token with the system DEK (v2 format).
+    ///
+    /// Only `SecretResolver::Value` tokens hold a plaintext secret at rest —
+    /// `Env`/`Vault` tokens are resolved externally on each use and pass
+    /// through untouched.
     #[tracing::instrument(name = "encrypt_me", skip_all)]
     pub(crate) fn encrypt_me(
         &self,
         dek: &[u8; 32],
         aad: &[u8],
     ) -> Result<Self, MappedErrors> {
-        let plain_token = match self {
-            Self::AuthorizationHeader { token, .. } => token.as_str(),
-            Self::QueryParameter { token, .. } => token.as_str(),
+        let token = match self {
+            Self::AuthorizationHeader { token, .. } => token,
+            Self::QueryParameter { token, .. } => token,
+        };
+
+        let SecretResolver::Value(plain_token) = token else {
+            return Ok(self.to_owned());
         };
 
         let encrypted_string = encrypt_with_dek(plain_token, dek, aad)?;
+        let token = SecretResolver::Value(encrypted_string);
 
         Ok(match self {
             Self::AuthorizationHeader {
@@ -85,12 +95,12 @@ impl HttpSecret {
                 prefix,
                 ..
             } => Self::AuthorizationHeader {
-                token: encrypted_string,
+                token,
                 header_name: header_name.to_owned(),
                 prefix: prefix.to_owned(),
             },
             Self::QueryParameter { name, .. } => Self::QueryParameter {
-                token: encrypted_string,
+                token,
                 name: name.to_owned(),
             },
         })
@@ -116,12 +126,17 @@ impl HttpSecret {
         aad: &[u8],
     ) -> Result<Self, MappedErrors> {
         let token = match self {
-            Self::AuthorizationHeader { token, .. } => token.as_str(),
-            Self::QueryParameter { token, .. } => token.as_str(),
+            Self::AuthorizationHeader { token, .. } => token,
+            Self::QueryParameter { token, .. } => token,
+        };
+
+        let SecretResolver::Value(encrypted_token) = token else {
+            return Ok(self.to_owned());
         };
 
         let decrypted_secret =
-            decrypt_string_with_dek(token, config, dek, aad).await?;
+            decrypt_string_with_dek(encrypted_token, config, dek, aad).await?;
+        let token = SecretResolver::Value(decrypted_secret);
 
         Ok(match self {
             Self::AuthorizationHeader {
@@ -129,12 +144,12 @@ impl HttpSecret {
                 prefix,
                 ..
             } => Self::AuthorizationHeader {
-                token: decrypted_secret,
+                token,
                 header_name: header_name.to_owned(),
                 prefix: prefix.to_owned(),
             },
             Self::QueryParameter { name, .. } => Self::QueryParameter {
-                token: decrypted_secret,
+                token,
                 name: name.to_owned(),
             },
         })
@@ -142,16 +157,16 @@ impl HttpSecret {
 
     #[tracing::instrument(name = "redact_token", skip_all)]
     pub(crate) fn redact_token(&mut self) {
-        let redacted_word = "REDACTED".to_string();
+        let token = match self {
+            Self::AuthorizationHeader { token, .. } => token,
+            Self::QueryParameter { token, .. } => token,
+        };
 
-        match self {
-            Self::AuthorizationHeader { token, .. } => {
-                *token = redacted_word;
-            }
-            Self::QueryParameter { token, .. } => {
-                *token = redacted_word;
-            }
-        }
+        let SecretResolver::Value(_) = token else {
+            return;
+        };
+
+        *token = SecretResolver::Value("REDACTED".to_string());
     }
 }
 
@@ -175,5 +190,99 @@ impl FromStr for HttpSecret {
         }
 
         dto_err("Failed to parse secret").as_error()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_authorization_header_token_env_variant_parses() {
+        let toml = r#"
+            authorizationHeader = { headerName = "Authorization", prefix = "Bearer", token = { env = "MY_TOKEN_VAR" } }
+        "#;
+
+        let secret: HttpSecret = toml::from_str(toml).unwrap();
+
+        match secret {
+            HttpSecret::AuthorizationHeader { token, .. } => {
+                assert_eq!(token, SecretResolver::Env("MY_TOKEN_VAR".into()));
+            }
+            other => panic!("Expected AuthorizationHeader, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_query_parameter_token_vault_variant_parses() {
+        let toml = r#"
+            queryParameter = { name = "token", token = { vault = { path = "myc/services/api", key = "token" } } }
+        "#;
+
+        let secret: HttpSecret = toml::from_str(toml).unwrap();
+
+        match secret {
+            HttpSecret::QueryParameter { token, .. } => {
+                assert_eq!(
+                    token,
+                    SecretResolver::Vault {
+                        path: "myc/services/api".into(),
+                        key: "token".into(),
+                    }
+                );
+            }
+            other => panic!("Expected QueryParameter, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_authorization_header_token_literal_parses_as_value() {
+        let toml = r#"
+            authorizationHeader = { headerName = "Authorization", prefix = "Bearer", token = "literal-token" }
+        "#;
+
+        let secret: HttpSecret = toml::from_str(toml).unwrap();
+
+        match secret {
+            HttpSecret::AuthorizationHeader { token, .. } => {
+                assert_eq!(
+                    token,
+                    SecretResolver::Value("literal-token".to_string())
+                );
+            }
+            other => panic!("Expected AuthorizationHeader, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_encrypt_me_passes_through_env_token_untouched() {
+        let secret = HttpSecret::AuthorizationHeader {
+            header_name: None,
+            prefix: None,
+            token: SecretResolver::Env("MY_TOKEN_VAR".to_string()),
+        };
+
+        let dek = [0u8; 32];
+        let aad = b"aad";
+        let encrypted = secret.encrypt_me(&dek, aad).unwrap();
+
+        assert_eq!(encrypted, secret);
+    }
+
+    #[test]
+    fn test_redact_token_ignores_env_token() {
+        let mut secret = HttpSecret::QueryParameter {
+            name: "token".to_string(),
+            token: SecretResolver::Env("MY_TOKEN_VAR".to_string()),
+        };
+
+        secret.redact_token();
+
+        match secret {
+            HttpSecret::QueryParameter { token, .. } => {
+                assert_eq!(token, SecretResolver::Env("MY_TOKEN_VAR".into()));
+            }
+            other => panic!("Expected QueryParameter, got {other:?}"),
+        }
     }
 }

--- a/core/src/domain/dtos/mod.rs
+++ b/core/src/domain/dtos/mod.rs
@@ -14,6 +14,7 @@ pub mod message;
 pub mod native_error_codes;
 pub mod profile;
 pub mod related_accounts;
+pub mod resolved_http_secret;
 pub mod route;
 pub mod security_group;
 pub mod service;

--- a/core/src/domain/dtos/resolved_http_secret.rs
+++ b/core/src/domain/dtos/resolved_http_secret.rs
@@ -1,0 +1,46 @@
+use crate::domain::dtos::http_secret::HttpSecret;
+
+use mycelium_base::utils::errors::MappedErrors;
+
+/// An `HttpSecret` with its `token` resolved to a plain string.
+///
+/// `HttpSecret.token` is a `SecretResolver<String>`, which may need an async
+/// env/vault lookup to reach a usable value. This type carries the resolved
+/// value so it can be read synchronously when building outgoing requests.
+///
+pub enum ResolvedHttpSecret {
+    AuthorizationHeader {
+        header_name: Option<String>,
+        prefix: Option<String>,
+        token: String,
+    },
+    QueryParameter {
+        name: String,
+        token: String,
+    },
+}
+
+impl ResolvedHttpSecret {
+    #[tracing::instrument(name = "resolve_http_secret", skip_all)]
+    pub async fn from_http_secret(
+        secret: HttpSecret,
+    ) -> Result<Self, MappedErrors> {
+        Ok(match secret {
+            HttpSecret::AuthorizationHeader {
+                header_name,
+                prefix,
+                token,
+            } => Self::AuthorizationHeader {
+                header_name,
+                prefix,
+                token: token.async_get_or_error().await?,
+            },
+            HttpSecret::QueryParameter { name, token } => {
+                Self::QueryParameter {
+                    name,
+                    token: token.async_get_or_error().await?,
+                }
+            }
+        })
+    }
+}

--- a/core/src/domain/dtos/route.rs
+++ b/core/src/domain/dtos/route.rs
@@ -657,7 +657,7 @@ mod tests {
         let secret = HttpSecret::AuthorizationHeader {
             header_name: Some("Authorization".to_string()),
             prefix: Some("Bearer".to_string()),
-            token: "token123".to_string(),
+            token: SecretResolver::Value("token123".to_string()),
         };
 
         let service_secrets = vec![ServiceSecret {
@@ -686,7 +686,7 @@ mod tests {
         let secret = HttpSecret::AuthorizationHeader {
             header_name: Some("Authorization".to_string()),
             prefix: Some("Bearer".to_string()),
-            token: "token123".to_string(),
+            token: SecretResolver::Value("token123".to_string()),
         };
 
         let service_secrets = vec![ServiceSecret {
@@ -713,12 +713,12 @@ mod tests {
         let secret1 = HttpSecret::AuthorizationHeader {
             header_name: Some("Authorization".to_string()),
             prefix: Some("Bearer".to_string()),
-            token: "token1".to_string(),
+            token: SecretResolver::Value("token1".to_string()),
         };
 
         let secret2 = HttpSecret::QueryParameter {
             name: "api_key".to_string(),
-            token: "key123".to_string(),
+            token: SecretResolver::Value("key123".to_string()),
         };
 
         let service_secrets = vec![
@@ -750,7 +750,7 @@ mod tests {
 
         let secret = HttpSecret::QueryParameter {
             name: "api_key".to_string(),
-            token: "key123".to_string(),
+            token: SecretResolver::Value("key123".to_string()),
         };
 
         let service_secrets = vec![ServiceSecret {

--- a/core/src/domain/dtos/service.rs
+++ b/core/src/domain/dtos/service.rs
@@ -292,4 +292,28 @@ mod tests {
         let result = host.choose_host().unwrap();
         assert!(hosts.contains(&result));
     }
+
+    /// Reproduces the exact config shape from GitHub issue #165: an
+    /// `authorizationHeader` secret whose `token` is sourced from an
+    /// environment variable, nested inside the field-level
+    /// `SecretResolver<HttpSecret>` flatten on `ServiceSecret`.
+    #[test]
+    fn test_service_secret_with_env_token_parses() {
+        let toml = r#"
+            name = "picoclaw-alpha-authorization-header"
+            authorizationHeader = { headerName = "Authorization", prefix = "Bearer", token = { env = "MY_TOKEN_VAR" } }
+        "#;
+
+        let service_secret: ServiceSecret = toml::from_str(toml).unwrap();
+
+        let SecretResolver::Value(HttpSecret::AuthorizationHeader {
+            token,
+            ..
+        }) = service_secret.secret
+        else {
+            panic!("Expected SecretResolver::Value(AuthorizationHeader)");
+        };
+
+        assert_eq!(token, SecretResolver::Env("MY_TOKEN_VAR".to_string()));
+    }
 }

--- a/core/src/use_cases/support/dispatch_webhooks.rs
+++ b/core/src/use_cases/support/dispatch_webhooks.rs
@@ -2,7 +2,7 @@ use crate::{
     domain::{
         dtos::{
             http::HttpMethod,
-            http_secret::HttpSecret,
+            resolved_http_secret::ResolvedHttpSecret,
             webhook::{
                 HookResponse, WebHook, WebHookExecutionStatus,
                 WebHookPayloadArtifact, WebHookTrigger,
@@ -88,7 +88,7 @@ pub async fn dispatch_webhooks(
     // ? Decrypt all webhook secrets up-front (async, before the sync map)
     // ? -----------------------------------------------------------------------
 
-    let mut decrypted_secrets: Vec<Option<HttpSecret>> =
+    let mut decrypted_secrets: Vec<Option<ResolvedHttpSecret>> =
         Vec::with_capacity(hooks.len());
 
     for hook in &hooks {
@@ -106,7 +106,16 @@ pub async fn dispatch_webhooks(
                             "Error on decrypting secret: {err}"
                         ))
                     })?;
-                Some(ds)
+
+                let resolved = ResolvedHttpSecret::from_http_secret(ds)
+                    .await
+                    .map_err(|err| {
+                    use_case_err(format!(
+                        "Error on resolving secret token: {err}"
+                    ))
+                })?;
+
+                Some(resolved)
             }
             None => None,
         };
@@ -161,7 +170,7 @@ pub async fn dispatch_webhooks(
                 };
 
                 (match decrypted_secret {
-                    Some(HttpSecret::AuthorizationHeader {
+                    Some(ResolvedHttpSecret::AuthorizationHeader {
                         header_name,
                         prefix,
                         token,
@@ -175,9 +184,10 @@ pub async fn dispatch_webhooks(
                         };
                         base_request.header(key, value)
                     }
-                    Some(HttpSecret::QueryParameter { name, token }) => {
-                        base_request.query(&[(name, token)])
-                    }
+                    Some(ResolvedHttpSecret::QueryParameter {
+                        name,
+                        token,
+                    }) => base_request.query(&[(name, token)]),
                     None => base_request,
                 })
                 .body(payload)

--- a/ports/api/src/router/inject_downstream_secret.rs
+++ b/ports/api/src/router/inject_downstream_secret.rs
@@ -82,6 +82,17 @@ pub(super) async fn inject_downstream_secret(
                 prefix,
                 token,
             } => {
+                let token = match token.async_get_or_error().await {
+                    Err(err) => {
+                        tracing::warn!("{:?}", err);
+
+                        return Err(GatewayError::InternalServerError(
+                            format!("{err}"),
+                        ));
+                    }
+                    Ok(res) => res,
+                };
+
                 //
                 // Build the bearer token
                 //
@@ -109,7 +120,18 @@ pub(super) async fn inject_downstream_secret(
             // Insert the query parameter into the header
             //
             HttpSecret::QueryParameter { name, token } => {
-                req = match req.query(&[(name, token.to_owned())]) {
+                let token = match token.async_get_or_error().await {
+                    Err(err) => {
+                        tracing::warn!("{:?}", err);
+
+                        return Err(GatewayError::InternalServerError(
+                            format!("{err}"),
+                        ));
+                    }
+                    Ok(res) => res,
+                };
+
+                req = match req.query(&[(name, token)]) {
                     Err(err) => {
                         tracing::warn!("{:?}", err);
 


### PR DESCRIPTION
## Summary
- `HttpSecret::AuthorizationHeader.token` / `HttpSecret::QueryParameter.token` change from `String` to `SecretResolver<String>`, matching the docs (`token = { env = "..." }` / `token = { vault = { path, key } }`) and the existing `SmtpConfig.password: SecretResolver<String>` precedent.
- `encrypt_me` / `decrypt_me` / `redact_token` now only operate on `SecretResolver::Value(_)` tokens; `Env`/`Vault` tokens pass through untouched since they never hold a plaintext secret at rest.
- The two call sites that build outgoing requests from a resolved `HttpSecret` (`ports/api/src/router/inject_downstream_secret.rs`, `core/src/use_cases/support/dispatch_webhooks.rs`) resolve `token` via `SecretResolver::async_get_or_error()` at point of use.
- Added `ResolvedHttpSecret` (new `core/src/domain/dtos/resolved_http_secret.rs`) to carry the resolved plain-string token into the webhook dispatch flow.

Fixes #165

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace --all` (29/29 test binaries pass)
- [x] New unit tests deserialize the exact TOML shapes from the issue (`authorizationHeader.token = { env = "..." }`, `queryParameter.token = { vault = {...} }`, and the literal-string backward-compat case) at both the `HttpSecret` level and the full `ServiceSecret` (field-level flatten) level — reproducing and confirming the fix for the actual boot-time panic reported in the issue.
- [ ] Manual boot test against a config using the documented `token = { env = "..." }` syntax (not yet performed — see issue reproduction steps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)