### PR TITLE
fix(encryption): self-heal missing system tenant DEK row

### DIFF
--- a/adapters/diesel_postgres/src/repositories/encryption_key.rs
+++ b/adapters/diesel_postgres/src/repositories/encryption_key.rs
@@ -82,6 +82,7 @@ fn provision_missing_tenant_dek(
         .values((
             tenant_model::id.eq(tid),
             tenant_model::name.eq(SYSTEM_TENANT_NAME),
+            tenant_model::created.eq(chrono::Utc::now()),
             tenant_model::kek_version.eq(1),
         ))
         .on_conflict(tenant_model::id)

--- a/adapters/diesel_postgres/src/repositories/encryption_key.rs
+++ b/adapters/diesel_postgres/src/repositories/encryption_key.rs
@@ -103,12 +103,36 @@ fn provision_and_persist_dek(
     let aad = tid.as_bytes();
     let wrapped = wrap_dek(&dek, kek, aad)?;
 
-    diesel::update(tenant_dsl::tenant.filter(tenant_model::id.eq(tid)))
-        .set(tenant_model::encrypted_dek.eq(&wrapped))
-        .execute(conn)
+    // Only the first concurrent caller wins provisioning: the NULL guard makes
+    // a racing second caller a no-op instead of rekeying (and thus orphaning)
+    // an already-provisioned DEK.
+    let updated = diesel::update(
+        tenant_dsl::tenant
+            .filter(tenant_model::id.eq(tid))
+            .filter(tenant_model::encrypted_dek.is_null()),
+    )
+    .set(tenant_model::encrypted_dek.eq(&wrapped))
+    .execute(conn)
+    .map_err(|e| {
+        updating_err(format!("Failed to persist DEK for tenant {tid}: {e}"))
+    })?;
+
+    if updated == 1 {
+        return Ok(dek);
+    }
+
+    // A concurrent caller already provisioned (or the row vanished): read and
+    // unwrap the authoritative persisted key rather than returning ours.
+    let wrapped_existing = tenant_dsl::tenant
+        .filter(tenant_model::id.eq(tid))
+        .select(tenant_model::encrypted_dek)
+        .first::<Option<String>>(conn)
         .map_err(|e| {
-            updating_err(format!("Failed to persist DEK for tenant {tid}: {e}"))
+            fetching_err(format!("Failed to re-fetch tenant DEK row: {e}"))
+        })?
+        .ok_or_else(|| {
+            fetching_err(format!("Tenant not found: {tid}")).with_exp_true()
         })?;
 
-    Ok(dek)
+    unwrap_dek(&wrapped_existing, kek, aad)
 }

--- a/adapters/diesel_postgres/src/repositories/encryption_key.rs
+++ b/adapters/diesel_postgres/src/repositories/encryption_key.rs
@@ -8,7 +8,10 @@ use diesel::prelude::*;
 use myc_core::domain::{
     dtos::native_error_codes::NativeErrorCodes,
     entities::EncryptionKeyFetching,
-    utils::{generate_dek, unwrap_dek, wrap_dek, SYSTEM_TENANT_ID},
+    utils::{
+        generate_dek, unwrap_dek, wrap_dek, SYSTEM_TENANT_ID,
+        SYSTEM_TENANT_NAME,
+    },
 };
 use mycelium_base::utils::errors::{fetching_err, updating_err, MappedErrors};
 use shaku::Component;
@@ -43,10 +46,11 @@ impl EncryptionKeyFetching for EncryptionKeyFetchingSqlDbRepository {
             .optional()
             .map_err(|e| {
                 fetching_err(format!("Failed to fetch tenant DEK row: {e}"))
-            })?
-            .ok_or_else(|| {
-                fetching_err(format!("Tenant not found: {tid}")).with_exp_true()
             })?;
+
+        let Some(record) = record else {
+            return provision_missing_tenant_dek(conn, tid, kek);
+        };
 
         if let Some(wrapped) = record.encrypted_dek {
             let aad = tid.as_bytes();
@@ -55,6 +59,39 @@ impl EncryptionKeyFetching for EncryptionKeyFetchingSqlDbRepository {
 
         provision_and_persist_dek(conn, tid, kek)
     }
+}
+
+/// Provision a DEK for a tenant row that was not found.
+///
+/// The system tenant (`Uuid::nil`) is an infrastructure sentinel that stores
+/// the DEK used to encrypt tenant-less secrets (e.g. webhook secrets). It is
+/// not seeded by any migration, so on a fresh database it is created here on
+/// first use. A missing *real* tenant remains a genuine error.
+fn provision_missing_tenant_dek(
+    conn: &mut diesel::PgConnection,
+    tid: Uuid,
+    kek: &[u8; 32],
+) -> Result<[u8; 32], MappedErrors> {
+    if tid != SYSTEM_TENANT_ID {
+        return fetching_err(format!("Tenant not found: {tid}"))
+            .with_exp_true()
+            .as_error();
+    }
+
+    diesel::insert_into(tenant_dsl::tenant)
+        .values((
+            tenant_model::id.eq(tid),
+            tenant_model::name.eq(SYSTEM_TENANT_NAME),
+            tenant_model::kek_version.eq(1),
+        ))
+        .on_conflict(tenant_model::id)
+        .do_nothing()
+        .execute(conn)
+        .map_err(|e| {
+            updating_err(format!("Failed to seed system tenant row: {e}"))
+        })?;
+
+    provision_and_persist_dek(conn, tid, kek)
 }
 
 fn provision_and_persist_dek(

--- a/adapters/diesel_sqlite/src/repositories/encryption_key.rs
+++ b/adapters/diesel_sqlite/src/repositories/encryption_key.rs
@@ -112,14 +112,38 @@ fn provision_and_persist_dek(
     let aad = tid.as_bytes();
     let wrapped = wrap_dek(&dek, kek, aad)?;
 
-    diesel::update(tenant_dsl::tenant.filter(tenant::id.eq(tid_text)))
-        .set(tenant::encrypted_dek.eq(&wrapped))
-        .execute(conn)
+    // Only the first concurrent caller wins provisioning: the NULL guard makes
+    // a racing second caller a no-op instead of rekeying (and thus orphaning)
+    // an already-provisioned DEK.
+    let updated = diesel::update(
+        tenant_dsl::tenant
+            .filter(tenant::id.eq(tid_text))
+            .filter(tenant::encrypted_dek.is_null()),
+    )
+    .set(tenant::encrypted_dek.eq(&wrapped))
+    .execute(conn)
+    .map_err(|e| {
+        updating_err(format!("Failed to persist DEK for tenant {tid}: {e}"))
+    })?;
+
+    if updated == 1 {
+        return Ok(dek);
+    }
+
+    // A concurrent caller already provisioned (or the row vanished): read and
+    // unwrap the authoritative persisted key rather than returning ours.
+    let wrapped_existing = tenant_dsl::tenant
+        .filter(tenant::id.eq(tid_text))
+        .select(tenant::encrypted_dek)
+        .first::<Option<String>>(conn)
         .map_err(|e| {
-            updating_err(format!("Failed to persist DEK for tenant {tid}: {e}"))
+            fetching_err(format!("Failed to re-fetch tenant DEK row: {e}"))
+        })?
+        .ok_or_else(|| {
+            fetching_err(format!("Tenant not found: {tid}")).with_exp_true()
         })?;
 
-    Ok(dek)
+    unwrap_dek(&wrapped_existing, kek, aad)
 }
 
 // ? ---------------------------------------------------------------------------
@@ -199,6 +223,39 @@ mod tests {
         // The DEK is stable across calls once provisioned.
         let second_dek = fetching.get_or_provision_dek(None, &kek).await?;
         assert_eq!(first_dek, second_dek);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn provision_and_persist_dek_does_not_overwrite_existing(
+    ) -> Result<(), MappedErrors> {
+        // A second provisioning attempt (e.g. a concurrent caller) must not
+        // rekey an already-provisioned DEK -- it re-reads and returns the
+        // persisted one.
+        let db = setup_temp_db();
+        let kek = [5u8; 32];
+        let tid_text = uuid_to_text(&SYSTEM_TENANT_ID);
+
+        let conn = &mut db.provider.get_pool().get().unwrap();
+        diesel::insert_into(tenant::table)
+            .values((
+                tenant::id.eq(&tid_text),
+                tenant::name.eq(SYSTEM_TENANT_NAME),
+                tenant::created.eq(naive_timestamp_to_text(
+                    &chrono::Utc::now().naive_utc(),
+                )),
+                tenant::kek_version.eq(1),
+            ))
+            .execute(conn)
+            .unwrap();
+
+        let first =
+            provision_and_persist_dek(conn, &tid_text, SYSTEM_TENANT_ID, &kek)?;
+        let second =
+            provision_and_persist_dek(conn, &tid_text, SYSTEM_TENANT_ID, &kek)?;
+
+        assert_eq!(first, second);
 
         Ok(())
     }

--- a/adapters/diesel_sqlite/src/repositories/encryption_key.rs
+++ b/adapters/diesel_sqlite/src/repositories/encryption_key.rs
@@ -2,7 +2,7 @@ use crate::{
     config::SqliteDbPoolProvider,
     models::tenant::Tenant as TenantModel,
     schema::tenant::{self, dsl as tenant_dsl},
-    types::uuid_to_text,
+    types::{naive_timestamp_to_text, uuid_to_text},
 };
 
 use async_trait::async_trait;
@@ -10,7 +10,10 @@ use diesel::prelude::*;
 use myc_core::domain::{
     dtos::native_error_codes::NativeErrorCodes,
     entities::EncryptionKeyFetching,
-    utils::{generate_dek, unwrap_dek, wrap_dek, SYSTEM_TENANT_ID},
+    utils::{
+        generate_dek, unwrap_dek, wrap_dek, SYSTEM_TENANT_ID,
+        SYSTEM_TENANT_NAME,
+    },
 };
 use mycelium_base::utils::errors::{fetching_err, updating_err, MappedErrors};
 use shaku::Component;
@@ -47,10 +50,11 @@ impl EncryptionKeyFetching for EncryptionKeyFetchingSqlDbRepository {
             .optional()
             .map_err(|e| {
                 fetching_err(format!("Failed to fetch tenant DEK row: {e}"))
-            })?
-            .ok_or_else(|| {
-                fetching_err(format!("Tenant not found: {tid}")).with_exp_true()
             })?;
+
+        let Some(record) = record else {
+            return provision_missing_tenant_dek(conn, &tid_text, tid, kek);
+        };
 
         if let Some(wrapped) = record.encrypted_dek {
             let aad = tid.as_bytes();
@@ -59,6 +63,43 @@ impl EncryptionKeyFetching for EncryptionKeyFetchingSqlDbRepository {
 
         provision_and_persist_dek(conn, &tid_text, tid, kek)
     }
+}
+
+/// Provision a DEK for a tenant row that was not found.
+///
+/// The system tenant (`Uuid::nil`) is an infrastructure sentinel that stores
+/// the DEK used to encrypt tenant-less secrets (e.g. webhook secrets). It is
+/// not seeded by any migration, so on a fresh database it is created here on
+/// first use. A missing *real* tenant remains a genuine error.
+fn provision_missing_tenant_dek(
+    conn: &mut diesel::SqliteConnection,
+    tid_text: &str,
+    tid: Uuid,
+    kek: &[u8; 32],
+) -> Result<[u8; 32], MappedErrors> {
+    if tid != SYSTEM_TENANT_ID {
+        return fetching_err(format!("Tenant not found: {tid}"))
+            .with_exp_true()
+            .as_error();
+    }
+
+    let created = naive_timestamp_to_text(&chrono::Utc::now().naive_utc());
+
+    diesel::insert_into(tenant_dsl::tenant)
+        .values((
+            tenant::id.eq(tid_text),
+            tenant::name.eq(SYSTEM_TENANT_NAME),
+            tenant::created.eq(created),
+            tenant::kek_version.eq(1),
+        ))
+        .on_conflict(tenant::id)
+        .do_nothing()
+        .execute(conn)
+        .map_err(|e| {
+            updating_err(format!("Failed to seed system tenant row: {e}"))
+        })?;
+
+    provision_and_persist_dek(conn, tid_text, tid, kek)
 }
 
 fn provision_and_persist_dek(
@@ -128,6 +169,56 @@ mod tests {
         // Second call unwraps the persisted DEK -- must return the same key
         let second_dek = fetching.get_or_provision_dek(None, &kek).await?;
         assert_eq!(first_dek, second_dek);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn get_or_provision_dek_self_heals_missing_system_tenant(
+    ) -> Result<(), MappedErrors> {
+        // A fresh database has no system tenant row (no migration seeds it).
+        // The system DEK fetch must create the sentinel row on first use
+        // instead of failing with "Tenant not found".
+        let db = setup_temp_db();
+        let fetching = EncryptionKeyFetchingSqlDbRepository {
+            db_config: db.provider.clone(),
+        };
+        let kek = [9u8; 32];
+
+        // No seeding here on purpose.
+        let first_dek = fetching.get_or_provision_dek(None, &kek).await?;
+
+        // The sentinel row now exists with a persisted wrapped DEK.
+        let stored_wrapped = tenant_dsl::tenant
+            .filter(tenant::id.eq(uuid_to_text(&SYSTEM_TENANT_ID)))
+            .select(tenant::encrypted_dek)
+            .first::<Option<String>>(&mut db.provider.get_pool().get().unwrap())
+            .unwrap();
+        assert!(stored_wrapped.is_some());
+
+        // The DEK is stable across calls once provisioned.
+        let second_dek = fetching.get_or_provision_dek(None, &kek).await?;
+        assert_eq!(first_dek, second_dek);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn get_or_provision_dek_errors_for_missing_real_tenant(
+    ) -> Result<(), MappedErrors> {
+        // A missing *real* tenant is a genuine error -- only the system
+        // sentinel row self-heals.
+        let db = setup_temp_db();
+        let fetching = EncryptionKeyFetchingSqlDbRepository {
+            db_config: db.provider.clone(),
+        };
+        let kek = [3u8; 32];
+
+        let result = fetching
+            .get_or_provision_dek(Some(Uuid::new_v4()), &kek)
+            .await;
+
+        assert!(result.is_err());
 
         Ok(())
     }

--- a/core/src/domain/utils/envelope.rs
+++ b/core/src/domain/utils/envelope.rs
@@ -14,6 +14,13 @@ use uuid::Uuid;
 /// Sentinel tenant ID used for system-level (Staff, webhooks) DEK lookups.
 pub const SYSTEM_TENANT_ID: Uuid = Uuid::nil();
 
+/// Display name of the sentinel system tenant row.
+///
+/// The system tenant is not a real tenant — it only holds the system-level DEK
+/// used to encrypt tenant-less secrets (e.g. webhook secrets). This name is
+/// used when the row is seeded lazily on first use.
+pub const SYSTEM_TENANT_NAME: &str = "System";
+
 /// Build the AAD (Additional Authenticated Data) bytes for a ciphertext.
 ///
 /// AAD = tenant_id_bytes ++ field_tag prevents a ciphertext from being moved

--- a/core/src/domain/utils/mod.rs
+++ b/core/src/domain/utils/mod.rs
@@ -11,5 +11,6 @@ pub use envelope::{
     build_aad, decrypt_with_dek, encrypt_with_dek, generate_dek, unwrap_dek,
     wrap_dek, AAD_FIELD_HTTP_SECRET, AAD_FIELD_TELEGRAM_BOT_TOKEN,
     AAD_FIELD_TELEGRAM_WEBHOOK_SECRET, AAD_FIELD_TOTP_SECRET, SYSTEM_TENANT_ID,
+    SYSTEM_TENANT_NAME,
 };
 pub use try_as_uuid::*;


### PR DESCRIPTION
## Problem

Webhook registration is **completely broken on any fresh database**, failing with:

```
[codes=none error_type=fetching-error] Tenant not found: 00000000-0000-0000-0000-000000000000
```

`register_webhook` calls `get_or_provision_dek(None)` **unconditionally** (even for secretless webhooks) to fetch the system-level DEK used to encrypt tenant-less secrets. That DEK lives on a sentinel *system tenant* row (`id = Uuid::nil()`) in the `tenant` table — but **nothing seeds it**:

- `up.sql` / SQLite init: no tenant `INSERT`
- `20260421_01_envelope_encryption.sql`: only `ALTER TABLE ADD COLUMN`
- staff bootstrap: does not create it
- both adapters only `UPDATE` in provisioning, and the `SELECT` fails first

So the row never exists on a fresh install → `Tenant not found: 0000…`. This has been broken for every fresh deployment since envelope encryption (AD-004) shipped.

## Fix

When the DEK fetch finds no tenant row, **self-heal the system sentinel row** (insert it, then provision the DEK) instead of erroring. A missing *real* tenant still errors as before (only the `Uuid::nil` sentinel self-heals).

Applied to **both** the Postgres and SQLite adapters, so a fresh full-mode or standalone database works out of the box. Adds `SYSTEM_TENANT_NAME` to `core` as the single source of truth.

## Tests

Two new SQLite reproduction tests:
- `get_or_provision_dek_self_heals_missing_system_tenant` — no seed, succeeds
- `get_or_provision_dek_errors_for_missing_real_tenant` — real tenant still errors

## Gate checks (all green)

- `cargo fmt --all -- --check`
- `cargo build --workspace`
- `cargo build -p mycelium-api --no-default-features --features standalone`
- `cargo test --workspace --all` — 0 failed (331 core tests + all other crates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)