### PR TITLE
fix(docker): CARGO_FEATURES default postgres-backend → full

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,14 +14,14 @@ ENV VERSION=${VERSION}
 RUN echo "Building mycelium-api version: ${VERSION}"
 
 # ? Cargo features to build. Default reproduces the historical full-mode image
-# ? byte-for-byte (default `postgres-backend` + `rhai`). Override to build the
+# ? byte-for-byte (`full` + `rhai`). Override to build the
 # ? Redis-free Postgres-only mode:
 # ?   docker build --build-arg CARGO_FEATURES=postgres-only,rhai .
 # ? NOTE: `cargo install` from crates.io only works AFTER `mycelium-postgres-kv`
 # ? and the `postgres-only` feature are published. The first postgres-only image
 # ? (pre-publish) must be a source build instead:
 # ?   cargo build --release --no-default-features --features postgres-only,rhai -p mycelium-api
-ARG CARGO_FEATURES="postgres-backend,rhai"
+ARG CARGO_FEATURES="full,rhai"
 ENV CARGO_FEATURES=${CARGO_FEATURES}
 
 # ? If the VERSION is latest, instal using cargo install

--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -9,7 +9,7 @@
 # built from local source instead.
 #
 # `--no-default-features` is required: Cargo features are additive, so
-# without it the default `postgres-backend` feature would stay enabled and
+# without it the default `full` feature would stay enabled and
 # trip the mutual-exclusion `compile_error!` guard in ports/api/src/main.rs.
 #
 # `libsqlite3-sys`'s `bundled` feature compiles SQLite into the binary, so


### PR DESCRIPTION
## Problem

The Docker release build fails at `cargo install`. Run [29961159849](https://github.com/LepistaBioinformatics/mycelium/actions/runs/29961159849/job/89062241013) (tag `9.0.0-rc.9`):

```
error: the package 'mycelium-api' does not contain this feature: postgres-backend
...
buildx failed: "/usr/local/cargo/bin/myc-api": not found
```

## Root cause

The `postgres-backend` feature was renamed to `full` in commit `52809c6a` (postgres-only mode work), but the `Dockerfile`'s `ARG CARGO_FEATURES` default still said `postgres-backend,rhai`. `docker-release.yml` builds the published image with that default (no `--build-arg`), so `cargo install ... --features "postgres-backend,rhai"` aborts on the unknown feature, no `myc-api` binary is produced, and the `COPY --from=builder` step fails buildx.

## Fix

- `Dockerfile`: `ARG CARGO_FEATURES="postgres-backend,rhai"` → `"full,rhai"` (reproduces the historical full-mode image) + comment.
- `Dockerfile.standalone`: fix stale `postgres-backend` reference in a comment.

Verified `full` exists in `ports/api/Cargo.toml` (`full = ["dep:mycelium-diesel", "dep:mycelium-key-value"]`).

## Follow-up

The failed `9.0.0-rc.9` tag is immutable — after this merges to `develop`, a new RC (`rc.10`) must be cut so `docker-release` runs against a tag carrying the corrected Dockerfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)