### PR TITLE
fix(api): heap corruption from forged Arc::from_raw in email_dispatcher wiring

### DIFF
--- a/ports/api/src/main.rs
+++ b/ports/api/src/main.rs
@@ -434,21 +434,9 @@ pub async fn main() -> std::io::Result<()> {
 
     email_dispatcher(
         config.queue.to_owned(),
-        unsafe {
-            Arc::from_raw(*Arc::new(
-                sql_module.resolve_ref() as &dyn LocalMessageReading
-            ))
-        },
-        unsafe {
-            Arc::from_raw(*Arc::new(
-                sql_module.resolve_ref() as &dyn LocalMessageWrite
-            ))
-        },
-        unsafe {
-            Arc::from_raw(*Arc::new(
-                notifier_module.resolve_ref() as &dyn RemoteMessageWrite
-            ))
-        },
+        HasComponent::<dyn LocalMessageReading>::resolve(&*sql_module),
+        HasComponent::<dyn LocalMessageWrite>::resolve(&*sql_module),
+        HasComponent::<dyn RemoteMessageWrite>::resolve(&*notifier_module),
     )
     .instrument(span.to_owned())
     .await;


### PR DESCRIPTION
## Symptom

Running the gateway in **standalone** mode aborts with glibc heap corruption on shutdown:

```
tcache_thread_shutdown(): unaligned tcache chunk detected
corrupted double-linked list
malloc_consolidate(): unaligned fastbin chunk detected
```

(`IOT instruction (core dumped)`, SIGABRT / exit 134). Reproduced deterministically on two machines. gdb showed the abort during `drop_in_place<tokio::runtime::Runtime>` at `main.rs` teardown, in a worker thread's `tcache_thread_shutdown`.

## Root cause

The `email_dispatcher(...)` call constructed its `Arc<dyn ...>` arguments like this:

```rust
unsafe {
    Arc::from_raw(*Arc::new(
        sql_module.resolve_ref() as &dyn LocalMessageReading
    ))
}
```

`resolve_ref()` returns a `&dyn Trait` **borrowed from the shaku module** — that pointer never came from `Arc::into_raw`. `Arc::from_raw` then treats the bytes *before* the pointed-to object as the `ArcInner` strong/weak refcount header. When these forged `Arc`s drop at teardown, they decrement garbage refcounts and call `free` on memory `Arc` never allocated → heap corruption, detected at thread/runtime shutdown.

It surfaced in standalone (SQLite + moka), but the `email_dispatcher` wiring is **shared by all three modes**, so the UB was latent in `full` and `postgres-only` too (different heap layouts just hadn't tripped the detector).

## Fix

Use shaku's real resolver, which returns an owned `Arc<dyn Trait>`:

```rust
HasComponent::<dyn LocalMessageReading>::resolve(&*sql_module)
```

No `unsafe`, no forged `Arc`. Three call sites replaced.

## Verification

- **Before:** every standalone run aborted with SIGABRT (exit 134) + core dump.
- **After:** standalone boots and shuts down cleanly on SIGTERM (exit 124, no core, no corruption in logs) across repeated 3s/5s/7s runs.
- `full` (default) and `postgres-only` still compile; `cargo fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)