### PR TITLE
feat(notifier): support STARTTLS for SMTP (port 587 — ACS, O365) — closes #178

### DIFF
--- a/adapters/notifier/src/models/mod.rs
+++ b/adapters/notifier/src/models/mod.rs
@@ -3,9 +3,11 @@ mod config;
 mod local_email_config;
 mod queue_config;
 mod smtp_config;
+mod smtp_security;
 
 pub use config::*;
 #[cfg(feature = "local-transport")]
 pub use local_email_config::*;
 pub use queue_config::*;
 pub use smtp_config::*;
+pub use smtp_security::*;

--- a/adapters/notifier/src/models/smtp_config.rs
+++ b/adapters/notifier/src/models/smtp_config.rs
@@ -1,3 +1,5 @@
+use super::SmtpSecurity;
+
 use lettre::{transport::smtp::authentication::Credentials, SmtpTransport};
 use myc_config::{
     load_config_from_file, optional_config::OptionalConfig,
@@ -14,6 +16,12 @@ pub struct SmtpConfig {
     pub username: SecretResolver<String>,
     pub password: SecretResolver<String>,
     pub port: SecretResolver<u16>,
+
+    /// TLS mode for the connection. When omitted, it is auto-selected from
+    /// `port` (587 -> STARTTLS, otherwise implicit TLS) so existing 465
+    /// deployments are unaffected and 587 providers work without extra config.
+    #[serde(default)]
+    pub security: Option<SmtpSecurity>,
 }
 
 unsafe impl Send for SmtpConfig {}
@@ -76,21 +84,30 @@ impl SmtpConfig {
 
     /// Build a real `SmtpTransport` from this config. Shared by full mode's
     /// `NotifierClientImpl` and standalone's opt-in SMTP wiring (SM-R8), so
-    /// the connection-building logic exists in exactly one place.
+    /// the connection-building logic exists in exactly one place. The TLS mode
+    /// is taken from `security`, falling back to a port-based default (#178).
+    #[tracing::instrument(name = "build_smtp_transport", skip_all)]
     pub async fn build_transport(&self) -> Result<SmtpTransport, MappedErrors> {
         let host = self.host.async_get_or_error().await?;
         let username = self.username.async_get_or_error().await?;
         let password = self.password.async_get_or_error().await?;
         let port = self.port.async_get_or_error().await?;
 
-        let transport = SmtpTransport::relay(&host)
-            .map_err(|err| {
-                execution_err(format!("Failed to connect to SMTP: {err}"))
-            })?
+        let security = self
+            .security
+            .unwrap_or_else(|| SmtpSecurity::from_port(port));
+
+        let builder = match security {
+            SmtpSecurity::StartTls => SmtpTransport::starttls_relay(&host),
+            SmtpSecurity::Implicit => SmtpTransport::relay(&host),
+        }
+        .map_err(|err| {
+            execution_err(format!("Failed to connect to SMTP: {err}"))
+        })?;
+
+        Ok(builder
             .credentials(Credentials::new(username, password))
             .port(port)
-            .build();
-
-        Ok(transport)
+            .build())
     }
 }

--- a/adapters/notifier/src/models/smtp_security.rs
+++ b/adapters/notifier/src/models/smtp_security.rs
@@ -1,0 +1,58 @@
+use serde::Deserialize;
+
+/// Transport security for the SMTP connection.
+///
+/// Selects which `lettre` builder is used: implicit TLS (SMTPS, the classic
+/// port 465) versus STARTTLS (the modern submission standard, port 587 --
+/// RFC 6409/8314). See issue #178: providers such as Azure Communication
+/// Services and Office 365 only accept STARTTLS on 587.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SmtpSecurity {
+    /// TLS negotiated up front on connect (`SmtpTransport::relay`, port 465).
+    Implicit,
+
+    /// Plaintext connect, upgraded via the `STARTTLS` command
+    /// (`SmtpTransport::starttls_relay`, port 587).
+    StartTls,
+}
+
+impl SmtpSecurity {
+    /// Auto-select the security mode when `[smtp] security` is omitted: 587 is
+    /// the STARTTLS submission port; every other port (notably 465) keeps
+    /// implicit TLS, preserving the pre-#178 behavior for existing deployments.
+    pub(super) fn from_port(port: u16) -> Self {
+        match port {
+            587 => Self::StartTls,
+            _ => Self::Implicit,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_port_selects_starttls_for_587() {
+        assert_eq!(SmtpSecurity::from_port(587), SmtpSecurity::StartTls);
+    }
+
+    #[test]
+    fn from_port_defaults_to_implicit_for_465_and_others() {
+        assert_eq!(SmtpSecurity::from_port(465), SmtpSecurity::Implicit);
+        assert_eq!(SmtpSecurity::from_port(25), SmtpSecurity::Implicit);
+        assert_eq!(SmtpSecurity::from_port(2525), SmtpSecurity::Implicit);
+    }
+
+    #[test]
+    fn deserializes_lowercase_variants() {
+        let implicit: SmtpSecurity =
+            serde_json::from_str("\"implicit\"").unwrap();
+        let starttls: SmtpSecurity =
+            serde_json::from_str("\"starttls\"").unwrap();
+
+        assert_eq!(implicit, SmtpSecurity::Implicit);
+        assert_eq!(starttls, SmtpSecurity::StartTls);
+    }
+}

--- a/adapters/notifier/src/repositories/local_transport_sending.rs
+++ b/adapters/notifier/src/repositories/local_transport_sending.rs
@@ -1,7 +1,9 @@
 #![cfg(feature = "local-transport")]
 
 use crate::rendering::render_stub_email_for_terminal;
-use crate::repositories::shared::build_lettre_message;
+use crate::repositories::shared::{
+    build_lettre_message, smtp_send_error_message,
+};
 
 use async_trait::async_trait;
 use lettre::transport::{file::FileTransport, stub::StubTransport};
@@ -83,9 +85,7 @@ impl RemoteMessageWrite for LocalTransportMessageSendingRepository {
 
                 Ok(CreateResponseKind::Created(None))
             }
-            Err(err) => {
-                creation_err(format!("Could not send email: {err}")).as_error()
-            }
+            Err(err) => creation_err(smtp_send_error_message(err)).as_error(),
         }
     }
 }

--- a/adapters/notifier/src/repositories/remote_message_sending.rs
+++ b/adapters/notifier/src/repositories/remote_message_sending.rs
@@ -1,5 +1,7 @@
 use crate::models::ClientProvider;
-use crate::repositories::shared::build_lettre_message;
+use crate::repositories::shared::{
+    build_lettre_message, smtp_send_error_message,
+};
 
 use async_trait::async_trait;
 use lettre::Transport;
@@ -31,9 +33,7 @@ impl RemoteMessageWrite for RemoteMessageSendingRepository {
 
         match connection.send(&email) {
             Ok(_) => Ok(CreateResponseKind::Created(None)),
-            Err(err) => {
-                creation_err(format!("Could not send email: {err}")).as_error()
-            }
+            Err(err) => creation_err(smtp_send_error_message(err)).as_error(),
         }
     }
 }

--- a/adapters/notifier/src/repositories/shared.rs
+++ b/adapters/notifier/src/repositories/shared.rs
@@ -10,6 +10,11 @@ use mycelium_base::utils::errors::{creation_err, MappedErrors};
 pub(crate) fn smtp_send_error_message(err: impl ToString) -> String {
     let err = err.to_string();
 
+    // Best-effort UX hint only. `lettre`/native-tls surface this TLS-record
+    // mismatch as an OpenSSL text string (no granular error kind to match on),
+    // so we substring-match. If the wording changes across OpenSSL versions the
+    // hint silently disappears -- the underlying error is still reported, so
+    // this degrades gracefully rather than breaking.
     if err.contains("wrong version number") {
         return format!(
             "Could not send email: {err} (hint: the server likely expects \

--- a/adapters/notifier/src/repositories/shared.rs
+++ b/adapters/notifier/src/repositories/shared.rs
@@ -2,6 +2,25 @@ use lettre::{message::header::ContentType, Message as LettreMessage};
 use myc_core::domain::dtos::message::{FromEmail, Message};
 use mycelium_base::utils::errors::{creation_err, MappedErrors};
 
+/// Format an SMTP send failure for the caller.
+///
+/// When the underlying error is the OpenSSL "wrong version number" record
+/// mismatch, the client attempted an implicit-TLS handshake against a
+/// plaintext/STARTTLS-only port -- append a hint pointing at the fix (#178).
+pub(crate) fn smtp_send_error_message(err: impl ToString) -> String {
+    let err = err.to_string();
+
+    if err.contains("wrong version number") {
+        return format!(
+            "Could not send email: {err} (hint: the server likely expects \
+             STARTTLS -- set `[smtp] security = \"starttls\"`, typically with \
+             port 587)"
+        );
+    }
+
+    format!("Could not send email: {err}")
+}
+
 pub(crate) fn build_lettre_message(
     message: &Message,
 ) -> Result<LettreMessage, MappedErrors> {
@@ -26,4 +45,28 @@ pub(crate) fn build_lettre_message(
         .map_err(|e| {
             creation_err(format!("Could not build email message: {e}"))
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wrong_version_number_error_gets_starttls_hint() {
+        let message = smtp_send_error_message(
+            "Connection error: error:0A00010B:SSL routines:ssl3_get_record:\
+             wrong version number",
+        );
+
+        assert!(message.contains("Could not send email"));
+        assert!(message.contains("security = \"starttls\""));
+    }
+
+    #[test]
+    fn unrelated_error_has_no_hint() {
+        let message = smtp_send_error_message("authentication failed");
+
+        assert_eq!(message, "Could not send email: authentication failed");
+        assert!(!message.contains("starttls"));
+    }
 }

--- a/settings/config.full.example.toml
+++ b/settings/config.full.example.toml
@@ -175,6 +175,11 @@ username = { vault = { path = "myc/smtp", key = "username" } }       # required
 # ! Should be collected from vault or an environment variable in production
 password = { vault = { path = "myc/smtp", key = "password" } }       # required
 port = 465                                                           # required -- SMTP submission port (465 for implicit TLS, 587 for STARTTLS)
+# TLS mode: "implicit" (SMTPS, port 465) or "starttls" (submission, port 587).
+# Optional -- if omitted it is auto-selected from `port` (587 -> starttls,
+# otherwise implicit). Set it explicitly for providers like Azure Communication
+# Services or Office 365, which require STARTTLS on 587.
+# security = "starttls"
 
 # ------------------------------------------------------------------------------
 # EMAIL DISPATCHER POLLING SETTINGS

--- a/settings/config.full.example.toml
+++ b/settings/config.full.example.toml
@@ -178,7 +178,8 @@ port = 465                                                           # required 
 # TLS mode: "implicit" (SMTPS, port 465) or "starttls" (submission, port 587).
 # Optional -- if omitted it is auto-selected from `port` (587 -> starttls,
 # otherwise implicit). Set it explicitly for providers like Azure Communication
-# Services or Office 365, which require STARTTLS on 587.
+# Services or Office 365, which require STARTTLS on 587. Any other port (e.g.
+# plain SMTP on 25) defaults to implicit TLS -- set `security` explicitly there.
 # security = "starttls"
 
 # ------------------------------------------------------------------------------

--- a/settings/config.postgres-only.example.toml
+++ b/settings/config.postgres-only.example.toml
@@ -70,7 +70,8 @@ username = { env = "SMTP_USERNAME" }
 password = { env = "SMTP_PASSWORD" }
 port = 465
 # TLS mode: "implicit" (port 465) or "starttls" (port 587). Optional -- when
-# omitted it is auto-selected from `port` (587 -> starttls, else implicit).
+# omitted it is auto-selected from `port` (587 -> starttls, else implicit); any
+# other port (e.g. 25) defaults to implicit, so set `security` explicitly there.
 # security = "starttls"
 
 [queue]

--- a/settings/config.postgres-only.example.toml
+++ b/settings/config.postgres-only.example.toml
@@ -69,6 +69,9 @@ host = "smtp.example.com"
 username = { env = "SMTP_USERNAME" }
 password = { env = "SMTP_PASSWORD" }
 port = 465
+# TLS mode: "implicit" (port 465) or "starttls" (port 587). Optional -- when
+# omitted it is auto-selected from `port` (587 -> starttls, else implicit).
+# security = "starttls"
 
 [queue]
 emailQueueName = "emails"

--- a/settings/config.standalone.example.toml
+++ b/settings/config.standalone.example.toml
@@ -155,7 +155,8 @@ path = "./data/mycelium.db"
 # password = { env = "MYC_SMTP_PASSWORD" }
 # port = 587
 # TLS mode: "implicit" (port 465) or "starttls" (port 587). Optional -- when
-# omitted it is auto-selected from `port` (587 -> starttls, else implicit).
+# omitted it is auto-selected from `port` (587 -> starttls, else implicit); any
+# other port (e.g. 25) defaults to implicit, so set `security` explicitly there.
 # security = "starttls"
 
 # ------------------------------------------------------------------------------

--- a/settings/config.standalone.example.toml
+++ b/settings/config.standalone.example.toml
@@ -149,11 +149,14 @@ path = "./data/mycelium.db"
 # four fields are required once you enable this section.
 # ------------------------------------------------------------------------------
 
-# [smtp]
+# [smtp.define]
 # host = "smtp.example.com"
 # username = "apikey"
 # password = { env = "MYC_SMTP_PASSWORD" }
 # port = 587
+# TLS mode: "implicit" (port 465) or "starttls" (port 587). Optional -- when
+# omitted it is auto-selected from `port` (587 -> starttls, else implicit).
+# security = "starttls"
 
 # ------------------------------------------------------------------------------
 # LOCAL FILE EMAIL DELIVERY (optional -- opt-in `.eml` files)


### PR DESCRIPTION
Closes #178.

## Problem

The SMTP notifier only built **implicit-TLS** transports (`SmtpTransport::relay()`, port 465). STARTTLS-only providers on port 587 — Azure Communication Services, Office 365 — could not be used at all: the client sent a TLS ClientHello into a plaintext banner and OpenSSL aborted with `wrong version number`, so no email was sent. There was no config knob for the TLS mode.

## Change

- **`SmtpSecurity`** enum (`"implicit"` | `"starttls"`) in its own module, with `from_port()` auto-select (587 → STARTTLS, else implicit).
- **`SmtpConfig.security`** — optional. `build_transport()` now picks `starttls_relay()` vs `relay()`. When omitted it auto-selects by port, so:
  - existing `465` deployments are byte-for-byte unchanged,
  - `587` now works with no extra config,
  - other ports stay implicit.
  Also added the missing `#[tracing::instrument]`.
- **Error hint**: SMTP send failures containing the `wrong version number` TLS-record mismatch now append a hint suggesting `security = "starttls"` (both send paths, via a shared helper).
- **Docs**: documented `security` in the full / postgres-only / standalone example configs, and fixed the standalone example's `[smtp]` → `[smtp.define]` shape (it deserializes through `OptionalConfig`, which uses the `.define` wrapper).

Single chokepoint (`build_transport`) → fix applies to all three modes.

## Config

```toml
[smtp]              # full / postgres-only
port = 587
security = "starttls"   # optional; 587 auto-detects
```
```toml
[smtp.define]       # standalone (OptionalConfig wrapper)
port = 587
security = "starttls"
```

## Verification

- **End-to-end**: validated in standalone against a real ACS `587` STARTTLS endpoint — handshake + auth succeed, mail delivered. (The earlier `501 5.1.7` was an unrelated sender-address misconfig, since fixed.)
- 20 notifier unit tests pass (`from_port`, serde round-trip, hint string).
- `full` (default) + `postgres-only` compile; `cargo fmt --all -- --check` clean.

> Note: builds on the `Arc::from_raw` heap-corruption fix (#179), already merged — standalone now boots/shuts down cleanly, which is what allowed this end-to-end validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)