### PR TITLE
fix(router): header trust boundary — inbound strip + response blocklist

### DIFF
--- a/.claude/specs/features/gateway-response-header-blocklist/spec.md
+++ b/.claude/specs/features/gateway-response-header-blocklist/spec.md
@@ -1,0 +1,130 @@
+# Fix: gateway response headers must use a blocklist, not an allowlist
+
+**Status:** Implemented — gates green, awaiting user UAT before commit
+**Scope:** Medium (2 files + tests, no architectural change)
+**Branch:** `fix/gateway-response-header-blocklist`
+
+---
+
+## Problem
+
+`ports/api/src/router/build_the_gateway_response.rs` builds a single `Vec<String>`
+containing `route_key` + `FORWARDING_KEYS` + `FORWARD_FOR_KEY` + `DEFAULT_PROFILE_KEY`
++ `MYCELIUM_SERVICE_NAME`, then copies from `downstream_response` **only** the headers
+present in that list.
+
+The design intent, documented at `lib/http_tools/src/settings.rs:88-92`, is the
+opposite: *"Such keys are used to map the headers that should be removed from the
+downstream response before stream it back to the client."* The implementation inverted
+the predicate. Consequences:
+
+1. **Every legitimate downstream response header is dropped.** `Content-Type`,
+   `Cache-Control`, `ETag`, `Location`, `Content-Disposition`, `WWW-Authenticate`,
+   `Set-Cookie`, and all application-custom headers never reach the client.
+2. **The headers that *do* pass are exactly the ones that should not.** `route_key` is
+   the *name of the injected downstream secret header*
+   (`inject_downstream_secret.rs:103`). `x-mycelium-profile` carries the caller's
+   authorization context. Under the current allowlist, a downstream service that echoes
+   either header back has it forwarded verbatim to the client.
+
+Observed symptom: SSE responses from `crab-shell-proxy` arrive without
+`Content-Type: text/event-stream`, so `EventSource` and OpenAI-compatible SDKs buffer
+the whole stream instead of dispatching per event.
+
+---
+
+## Blast radius (investigation — request item 4)
+
+**This is not streaming-specific. It affects every proxied response.**
+
+- `route_request` is wired as `App::default_service` only
+  (`ports/api/src/main.rs:814`). So the bug covers 100% of traffic proxied to
+  downstream services, and 0% of Mycelium's own handlers (`/_adm/**`, `/doc/**`,
+  `/health`), which return normal actix `Responder`s and set their own `Content-Type`.
+  That split is why this went unnoticed: the webapp talks to Mycelium's own endpoints.
+- **Nothing in the pipeline masks it.** There is no `Compress` and no `DefaultHeaders`
+  middleware in the app (`main.rs:564-573`, `658`); the only wraps are `cors`,
+  `NormalizePath`, `RequestTracing`, `TracingLogger`, `Logger`, and a `wrap_fn` that
+  injects the request id. `HttpResponseBuilder::streaming` produces
+  `BodySize::Stream`; the actix-http h1 encoder writes only the headers explicitly set,
+  plus `Date` and `Transfer-Encoding: chunked`
+  (`actix-http-3.13.1/src/h1/encoder.rs:92-156`). Actix never supplies a default
+  `Content-Type`.
+- Therefore **JSON responses proxied through the gateway are served today with no
+  `Content-Type` at all**. `fetch(...).json()` and most HTTP clients parse anyway
+  (they don't require the header), which is why only the SSE case produced a visible
+  failure. Redirects (`Location` dropped) and file downloads (`Content-Disposition`
+  dropped) are silently broken by the same code path.
+
+---
+
+## What must NOT change (verified constraints)
+
+- **`Content-Encoding` must keep being forwarded.**
+  `initialize_downstream_request.rs:203` calls `.no_decompress()`, so awc's
+  `Decompress` wrapper is a pass-through and the body reaches the client still
+  compressed. Blocking `Content-Encoding` would corrupt every gzip/brotli/zstd
+  response. It is *not* added to the blocklist.
+- **`Content-Length` must keep being forwarded.** For `BodySize::Stream` the h1
+  encoder already drops it (`skip_len = true`, `encoder.rs:63,153`), but it is
+  deliberately *retained* for `304 Not Modified` (`encoder.rs:80-86`), which is the
+  RFC 7232 §4.1 behavior. Blocklisting it would break that. It is not added.
+- **`FORWARDING_KEYS` already contains the complete hop-by-hop set** requested in the
+  task (`Host`, `Connection`, `Keep-Alive`, `Proxy-Authenticate`,
+  `Proxy-Authorization`, `Te`, `Trailers`, `Transfer-Encoding`, `Upgrade`) —
+  `settings.rs:93-103`. **No new entries are needed.** The constant has exactly one
+  consumer workspace-wide (`build_the_gateway_response.rs`), so restructuring its use
+  cannot affect the request path.
+- No change to authentication, RBAC, or secret injection.
+
+---
+
+## Requirements
+
+| ID | Requirement |
+|---|---|
+| **R1** | All headers from `downstream_response` are copied to the gateway response, except those in the blocklist. |
+| **R2** | The blocklist is composed of two semantically distinct, separately named sets: **(a) hop-by-hop headers** — `FORWARDING_KEYS`, blocked because RFC 7230 §6.1 forbids proxy forwarding; **(b) gateway-injected artifacts** — `route_key` (downstream secret header name), `DEFAULT_PROFILE_KEY`, `MYCELIUM_SERVICE_NAME`, `FORWARD_FOR_KEY`, `DEFAULT_REQUEST_ID_KEY` — blocked because they are request-direction headers the gateway injects; if a downstream echoes one back, forwarding it leaks internal context to the client. |
+| **R3** | Matching is case-insensitive (HTTP header names are case-insensitive). |
+| **R4** | Blocking `DEFAULT_REQUEST_ID_KEY` also removes an ordering hazard: the gateway inserts its own request id at the top of the function, and an echoed downstream value would otherwise overwrite it via `insert_header`. |
+| **R5** | `build_the_gateway_response` takes `StatusCode` + `&HeaderMap` instead of `&DownstreamResponse`, so it is unit-testable. It already only reads status and headers. The borrow ends before `mod.rs` moves `downstream_response` into `.streaming(...)`. |
+| **R6** | `settings.rs` doc comment on `FORWARDING_KEYS` is corrected to state it is the hop-by-hop blocklist, matching the now-correct implementation. |
+| **R7** | Forwarding uses `append_header`, not `insert_header`. `HeaderMap::iter` yields one entry per value, so an insert collapses multi-valued headers (`Set-Cookie`, `Vary`, `Link`, `WWW-Authenticate`) to their last value. Under the old allowlist those headers were dropped entirely, so this only becomes reachable once R1 lands — forwarding a partial `Set-Cookie` set would be worse than dropping it. Appending is safe: `HttpResponse::build` starts with an empty map and the only pre-loop insert (`DEFAULT_REQUEST_ID_KEY`) is itself blocklisted. |
+
+### Tests (inline `#[cfg(test)] mod tests`, per CONVENTIONS)
+
+| ID | Test |
+|---|---|
+| **T1** | `Content-Type: text/event-stream` on the downstream response reaches the client intact. |
+| **T2** | Hop-by-hop headers (`Connection`, `Transfer-Encoding`) are removed. |
+| **T3** | An arbitrary application header (e.g. `x-crab-shell-session`) passes through. |
+| **T4** | Gateway-injected artifacts echoed by downstream are stripped: `route_key`, `x-mycelium-profile`, `x-mycelium-service-name`. |
+| **T5** | An echoed `x-mycelium-request-id` does not override the gateway's own value. |
+| **T6** | Blocklist matching is case-insensitive (`CONNECTION`, `Content-Type` in mixed case). |
+| **T7** | Two `Set-Cookie` values on the downstream response both reach the client (regression guard for R7 — verified failing with `insert_header`, passing with `append_header`). |
+
+**All seven are verified regression tests.** The filter was temporarily reverted to the original
+allowlist (inverted predicate + `insert_header`) and the suite re-run: **0 passed, 7 failed**.
+Restored: 7 passed. Every test in this file fails against the code it replaces.
+
+Assertions read headers via `builder.finish()` → `res.headers()`, since
+`HttpResponseBuilder` exposes no getter. `finish()` must be called once.
+
+### Gate
+
+```bash
+cargo fmt --all -- --check
+cargo build --workspace
+cargo test --workspace --all
+```
+
+---
+
+## Deferred
+
+- **Dynamic hop-by-hop tokens (RFC 7230 §6.1):** a downstream may list additional
+  connection-scoped header names in its own `Connection:` header; a strict proxy would
+  parse and strip those too. Out of scope here — the static list covers the observed
+  case.
+- **`Content-Length` + chunked interplay for HTTP/2 responses:** the h2 encoder path
+  was not audited; h1 is verified correct.

--- a/.claude/specs/features/gateway-response-header-blocklist/spec.md
+++ b/.claude/specs/features/gateway-response-header-blocklist/spec.md
@@ -84,7 +84,8 @@ the whole stream instead of dispatching per event.
 | ID | Requirement |
 |---|---|
 | **R1** | All headers from `downstream_response` are copied to the gateway response, except those in the blocklist. |
-| **R2** | The blocklist is composed of two semantically distinct, separately named sets: **(a) hop-by-hop headers** — `FORWARDING_KEYS`, blocked because RFC 7230 §6.1 forbids proxy forwarding; **(b) gateway-injected artifacts** — `route_key` (downstream secret header name), `DEFAULT_PROFILE_KEY`, `MYCELIUM_SERVICE_NAME`, `FORWARD_FOR_KEY`, `DEFAULT_REQUEST_ID_KEY` — blocked because they are request-direction headers the gateway injects; if a downstream echoes one back, forwarding it leaks internal context to the client. |
+| **R2** | The blocklist is composed of two semantically distinct, separately named sets: **(a) hop-by-hop headers** — `FORWARDING_KEYS`, blocked because RFC 7230 §6.1 forbids proxy forwarding; **(b) gateway-injected artifacts** — the whole `MYCELIUM_HEADER_PREFIX` namespace, plus `route_key` (downstream secret header name), `FORWARD_FOR_KEY` and `RFC7239_FORWARDED_KEY` — blocked because they are request-direction headers the gateway injects; if a downstream echoes one back, forwarding it leaks internal context to the client. |
+| **R2.1** | The Mycelium set is matched **by prefix**, not by listing keys. A first pass enumerated `DEFAULT_PROFILE_KEY` / `DEFAULT_REQUEST_ID_KEY` / `MYCELIUM_SERVICE_NAME` and thereby let `x-mycelium-email`, `x-mycelium-security-group`, `x-mycelium-connection-string`, `x-mycelium-scope`, `x-mycelium-role` and `x-mycelium-tenant-id` through — an echoing downstream would have leaked the authenticated user's email, the route's authorization config, and the user's connection-string credential to the client. Caught by an automated security review of the commit. Same enumeration-vs-prefix failure this spec warns about elsewhere; the prefix is now the only rule. |
 | **R3** | Matching is case-insensitive (HTTP header names are case-insensitive). |
 | **R4** | Blocking `DEFAULT_REQUEST_ID_KEY` also removes an ordering hazard: the gateway inserts its own request id at the top of the function, and an echoed downstream value would otherwise overwrite it via `insert_header`. |
 | **R5** | `build_the_gateway_response` takes `StatusCode` + `&HeaderMap` instead of `&DownstreamResponse`, so it is unit-testable. It already only reads status and headers. The borrow ends before `mod.rs` moves `downstream_response` into `.streaming(...)`. |
@@ -103,9 +104,13 @@ the whole stream instead of dispatching per event.
 | **T6** | Blocklist matching is case-insensitive (`CONNECTION`, `Content-Type` in mixed case). |
 | **T7** | Two `Set-Cookie` values on the downstream response both reach the client (regression guard for R7 — verified failing with `insert_header`, passing with `append_header`). |
 
-**All seven are verified regression tests.** The filter was temporarily reverted to the original
+| **T8** | The whole `x-mycelium-` namespace is stripped when echoed by the downstream — email, security-group, connection-string, scope, role, tenant-id, and a never-seen `x-mycelium-not-yet-invented` (guards R2.1). |
+
+**All eight are verified regression tests.** The filter was temporarily reverted to the original
 allowlist (inverted predicate + `insert_header`) and the suite re-run: **0 passed, 7 failed**.
-Restored: 7 passed. Every test in this file fails against the code it replaces.
+Restored: 7 passed. T8 was verified separately against the enumerated blocklist that preceded the
+prefix match: **failed**, then passed once the prefix rule landed. Every test in this file fails
+against the code it replaces.
 
 Assertions read headers via `builder.finish()` → `res.headers()`, since
 `HttpResponseBuilder` exposes no getter. `finish()` must be called once.

--- a/.claude/specs/features/strip-inbound-mycelium-headers/spec.md
+++ b/.claude/specs/features/strip-inbound-mycelium-headers/spec.md
@@ -1,0 +1,135 @@
+# Fix: strip client-supplied `x-mycelium-*` headers before forwarding downstream
+
+**Status:** Implemented — gates green (449 tests, 0 falhas), awaiting user UAT before commit
+**Scope:** Medium (1 new file + 2 edited + tests)
+**Severity:** High — authorization bypass in downstream services
+**Branch:** shares the working tree with `fix/gateway-response-header-blocklist` (see *Commit plan*)
+
+---
+
+## Problem
+
+`awc::Client::request_from(url, req.head())` (`awc-3.8.2/src/client/mod.rs:114-118`) copies
+**every** header of the client request into the downstream request via `insert_header_if_none`.
+The gateway never sanitizes that copy. It then overwrites *some* `x-mycelium-*` headers, selectively,
+depending on the route's security group (`check_security_group.rs:99-188`):
+
+| Security group | Overwritten by the gateway | Client-forged `x-mycelium-profile` |
+|---|---|---|
+| `Public` | nothing (`(downstream_request, None)`, line 110) | **forwarded verbatim** |
+| `Authenticated` | `x-mycelium-email` only | **forwarded verbatim** |
+| `Protected` | `x-mycelium-profile` (`insert`) | blocked |
+| `ProtectedByRoles` | `x-mycelium-profile` (`insert`) | blocked |
+
+So on any **Public** or **Authenticated** route, a client sends
+`x-mycelium-profile: <base64(zstd(forged profile))>` and the gateway hands it to the downstream
+service. Every SDK (py/js/go) decodes that header and trusts it as gateway-attested identity —
+including `hasStaffPrivileges` / `isStaff`. That is a complete authorization bypass in the
+downstream service, reachable through the gateway, requiring no Mycelium credential at all.
+
+The exposure is wider than the profile. These have **no producer at all** on the proxy path, so a
+client-supplied value is forwarded in *every* security group:
+
+- `x-mycelium-scope`
+- `x-mycelium-role`
+- `x-mycelium-tenant-id`
+
+And `x-mycelium-email` is forwarded on `Protected` / `ProtectedByRoles`, which only inject the
+profile.
+
+**Relation to the security scan:** `.claude/specs/security/findings.md` §3.1 records
+"Spoofing de `x-mycelium-profile` não mitigado" as **conditional on the downstream service being
+exposed directly, without the gateway**. That framing is wrong — this reclassifies it as reachable
+*through* the gateway, which is precisely the path the SDK contract treats as trusted.
+
+**Root cause is the same class as the response-header bug fixed alongside this one:** the trust
+boundary was enforced by enumerating cases (per security group) rather than by denying by default
+and re-granting explicitly.
+
+---
+
+## Requirements
+
+| ID | Requirement |
+|---|---|
+| **R1** | Every header whose name starts with `x-mycelium-` is removed from the downstream request immediately after `request_from` copies the client headers, **unconditionally** — not per security group. |
+| **R2** | The strip is prefix-based, not a list of known constants. A constant list re-breaks the day someone adds a new `DEFAULT_*_KEY` and forgets the filter — which is the exact failure mode of both bugs found in this session. `MYCELIUM_HEADER_PREFIX` is added to `settings.rs` next to the keys it governs. |
+| **R3** | The strip runs inside `initialize_downstream_request`, **before** the gateway's own `insert_header` calls, so gateway-injected values survive. Pipeline order (`router/mod.rs:154-197`) guarantees it also precedes `check_security_group` and `inject_downstream_secret`. |
+| **R4** | `x-mycelium-request-id` must still reach the downstream service. It is currently forwarded only as a side effect of the blanket copy, so after R1 it is **explicitly re-injected** from the upstream request. Its value is always gateway-generated: the app-level `wrap_fn` (`main.rs:805-812`) overwrites it with a fresh UUID on every inbound request before the router runs. |
+| **R5** | The strip function is pure — `fn strip_inbound_mycelium_headers(headers: &mut HeaderMap)` — so it is unit-testable without constructing an `awc::Client`. It lives in its own file per screaming-architecture Rule 3. |
+
+### Behavior change to validate in UAT
+
+**`x-mycelium-connection-string` stops being forwarded downstream.** It is a client-supplied
+credential, read by the gateway itself (`fetch_connection_string_from_request.rs:32`,
+`mycelium_profile_data.rs:163`). Forwarding a user's bearer-equivalent secret to every downstream
+service is a leak. Stripping it is deliberate.
+
+Searched for consumers across the gateway (`core/`, `lib/`, `ports/`) and all three SDKs
+(`mycelium-sdk-py/src`, `mycelium-sdk-js/src`, `mycelium-sdk-go`): each SDK only **declares** the
+constant in its settings module — none reads the header. Services outside this monorepo were not
+searched and cannot be. If some downstream does read it, this is the one behavior that will break,
+and the fix is to re-inject it explicitly like the request id.
+
+**Not affected:** `x-mycelium-security-group` is also stripped, but `check_security_group.rs:61-62`
+re-inserts it unconditionally at the top of the function, before any branching, and that step runs
+after `initialize_downstream_request` (`router/mod.rs:154` → `180`). Downstream still receives it.
+
+### Tests (inline `#[cfg(test)] mod tests`)
+
+| ID | Test |
+|---|---|
+| **T1** | A forged `x-mycelium-profile` is removed. |
+| **T2** | The headers with no producer on the proxy path are removed: `x-mycelium-scope`, `x-mycelium-role`, `x-mycelium-tenant-id`, `x-mycelium-email`. |
+| **T3** | `x-mycelium-connection-string` is removed (locks in the deliberate behavior change). |
+| **T4** | Non-Mycelium headers are untouched: `authorization`, `content-type`, an app-custom header. |
+| **T5** | Matching is prefix-based and case-insensitive — `X-Mycelium-Profile` is removed; `x-mycelium` (no trailing dash) and `x-my-header` are kept. |
+| **T6** | A multi-valued non-Mycelium header keeps all its values (guards against removing by key when the map holds several entries). |
+
+**These are unit tests, not regression tests.** The function is new, so there is no prior
+implementation for them to fail against — none of T1-T6 would have caught the original bug, which
+was the *absence* of this step in the pipeline rather than a defect inside it. They lock the
+unit's contract (prefix boundary, case-insensitivity, multi-value) against future edits.
+
+A pipeline-level regression test — forge `x-mycelium-profile`, run `initialize_downstream_request`
+on a `Public` route, assert the header is absent from the resulting `ClientRequest` — would be the
+only test proving the bypass is closed end to end. **Deliberately not written (user decision,
+2026-07-27): unit tests only.** It would need `Route` / `ApiConfig` / `web::Data<Client>` fixtures
+that do not exist in the crate. The strip point and pipeline order were verified by reading
+`router/mod.rs:154-197` and `check_security_group.rs:61-62`, not by test.
+
+### Gate
+
+```bash
+cargo fmt --all -- --check
+cargo build --workspace
+cargo test --workspace --all
+```
+
+---
+
+## Commit plan
+
+Both this fix and `fix/gateway-response-header-blocklist` are uncommitted in the same working
+tree (per `commit-validation.md`, neither may be committed before user UAT). The file sets are
+disjoint except `router/mod.rs`:
+
+- **Response fix:** `build_the_gateway_response.rs`, `lib/http_tools/src/settings.rs`,
+  `router/mod.rs` (call site)
+- **This fix:** `router/strip_inbound_mycelium_headers.rs` (new),
+  `router/initialize_downstream_request.rs`, `router/mod.rs` (module decl),
+  `lib/http_tools/src/settings.rs`
+
+After UAT they should become two commits, and can be split into two PRs by branching each from
+`develop` and cherry-picking. This one is the security fix and warrants its own PR and changelog
+entry.
+
+---
+
+## Out of scope (user decision, 2026-07-27)
+
+- **Profile signing (HMAC gateway↔SDK).** Would eliminate the whole class rather than this
+  instance, but changes the contract across all four SDKs. Deferred.
+- **Trusted-proxy validation in `resolve_client_ip`** (findings.md §1.3). Same class of bug —
+  trusting a client-supplied header — but needs a new config surface, and an empty default would
+  change the client IP seen by downstreams when running behind Traefik/Dokploy. Its own task.

--- a/.claude/specs/project/STATE.md
+++ b/.claude/specs/project/STATE.md
@@ -1,7 +1,12 @@
 # State
 
-**Last Updated:** 2026-07-17
-**Current Work:** Local Email DX (`features/local-email-dx/`) — implemented on branch
+**Last Updated:** 2026-07-27
+**Current Work:** Two header trust-boundary fixes in the gateway router, both implemented in the
+same working tree on branch `fix/gateway-response-header-blocklist`, all gates green (449 tests),
+**awaiting user UAT before commit** — response-side (`features/gateway-response-header-blocklist/`,
+AD-008) and request-side (`features/strip-inbound-mycelium-headers/`, AD-009, **security fix**).
+See the commit plan in the second spec: disjoint file sets, meant to become two commits/PRs.
+Local Email DX (`features/local-email-dx/`) — implemented on branch
 `feat/stub-pretty-render-and-file-transport`, all gates green, **awaiting user UAT before commit**
 (see AD-007). Resource Audit Log — spec/design/tasks written 2026-07-13, awaiting user go-ahead to
 Execute (see block below). Standalone Mode G1-G9 done, not committed yet. M1 ongoing.
@@ -9,6 +14,100 @@ Execute (see block below). Standalone Mode G1-G9 done, not committed yet. M1 ong
 ---
 
 ## Recent Decisions (Last 60 days)
+
+### AD-009: Client-supplied `x-mycelium-*` headers are stripped before forwarding (2026-07-27)
+
+**Feature:** `features/strip-inbound-mycelium-headers/`. **Security fix — authorization bypass.**
+
+`awc::Client::request_from(url, req.head())` copies *every* client header into the downstream
+request. The gateway then overwrote only *some* `x-mycelium-*` headers, and only for certain
+security groups (`check_security_group.rs:99-188`): `Public` overwrites nothing, `Authenticated`
+overwrites only `x-mycelium-email`. So on any Public or Authenticated route a client could send a
+forged `x-mycelium-profile` and the gateway handed it to the downstream service, where every SDK
+decodes it as gateway-attested identity — `hasStaffPrivileges` included. `x-mycelium-scope`,
+`x-mycelium-role` and `x-mycelium-tenant-id` had **no producer at all** on the proxy path and
+passed through in every security group.
+
+**Decisions:**
+
+- Strip is **prefix-based** (`MYCELIUM_HEADER_PREFIX = "x-mycelium-"`, new in `settings.rs`), not a
+  list of known constants. A constant list re-breaks the day a new `DEFAULT_*_KEY` is added and the
+  filter is not updated — the exact failure mode of both bugs found this session.
+- Runs **unconditionally**, inside `initialize_downstream_request` right after `request_from` and
+  before every gateway `insert_header`. Not per security group — that enumeration *was* the bug.
+- `x-mycelium-request-id` is **explicitly re-injected** after the strip. It was previously forwarded
+  only as a side effect of the blanket copy. Safe: the app-level `wrap_fn` (`main.rs:805-812`)
+  overwrites it with a fresh uuid on every inbound request before the router runs.
+- **`x-mycelium-connection-string` stops being forwarded downstream** — deliberate. It is the
+  user's own bearer-equivalent credential. Searched the gateway and all three SDKs: each SDK only
+  *declares* the constant, none reads the header. Services outside the monorepo can't be checked —
+  flagged for UAT; if one does read it, re-inject it explicitly like the request id.
+- `x-mycelium-security-group` is stripped too, but `check_security_group.rs:61-62` re-inserts it
+  unconditionally in a later pipeline step, so downstream still receives it.
+- Pure `fn(&mut HeaderMap)` in its own file (`strip_inbound_mycelium_headers.rs`), so it is
+  unit-testable without constructing an `awc::Client`.
+
+**Reclassifies `.claude/specs/security/findings.md` §3.1**, which recorded profile spoofing as
+conditional on the downstream service being exposed *without* the gateway. It was reachable
+*through* the gateway — the path the SDK contract treats as trusted.
+
+**Out of scope (user decision):** profile signing (HMAC gateway↔SDK) and trusted-proxy validation
+in `resolve_client_ip` (findings.md §1.3).
+
+**Testing:** 6 unit tests on the pure function. They are **not** regression tests — the function is
+new, so none would have caught the original bug, which was its absence from the pipeline. A
+pipeline-level test (forged profile through `initialize_downstream_request` on a `Public` route)
+was proposed and **declined by the user: unit tests only**. Strip point and ordering verified by
+reading `router/mod.rs:154-197` and `check_security_group.rs:61-62`.
+
+**Gates:** all green — `fmt --check`, `build --workspace`, `test --workspace --all` (449 tests,
+6 new). **Status:** implemented, **not committed** (awaiting user UAT per commit-validation rule).
+
+### AD-008: Gateway response headers are a blocklist, not an allowlist (2026-07-27)
+
+**Feature:** `features/gateway-response-header-blocklist/`. Branch
+`fix/gateway-response-header-blocklist`.
+
+`build_the_gateway_response` kept **only** the headers present in a short list
+(`route_key` + `FORWARDING_KEYS` + forwarded-for + profile + service-name), inverting the
+documented intent of `FORWARDING_KEYS` (`settings.rs`: "headers that should be removed"). Two
+consequences: every legitimate downstream header was dropped (`Content-Type`, `Location`,
+`Cache-Control`, `ETag`, `Content-Disposition`, `Set-Cookie`, app-custom), and the only headers
+guaranteed to pass were the ones that must not — `route_key` is the **name of the injected
+downstream secret header**, so an echoing downstream leaked it to the client.
+
+**Decisions:**
+
+- Blocklist is split into two *named* sets: hop-by-hop (`FORWARDING_KEYS`, already the complete
+  RFC 7230 §6.1 set — **nothing new added**) and gateway-injected artifacts (`route_key`,
+  `x-mycelium-profile`, `x-mycelium-service-name`, `x-forwarded-for`, `x-mycelium-request-id`).
+- `x-mycelium-request-id` in the second set also kills an ordering hazard: the gateway inserts its
+  own id first, and an echoed downstream value would otherwise overwrite it.
+- **`Content-Encoding` and `Content-Length` are deliberately NOT blocked.**
+  `initialize_downstream_request.rs` calls `.no_decompress()`, so the body reaches the client still
+  compressed — stripping `Content-Encoding` would corrupt every gzip response. `Content-Length` is
+  already dropped by the actix h1 encoder for `BodySize::Stream` but is intentionally retained for
+  `304` (RFC 7232 §4.1).
+- Signature changed to `(request_id, route_key, StatusCode, &HeaderMap)` — the function only ever
+  read status and headers, and `awc::test::TestResponse` yields the wrong payload type to build a
+  `DownstreamResponse` in tests.
+
+**Blast radius:** `route_request` is only `App::default_service`, so this affected 100% of proxied
+traffic and 0% of Mycelium's own handlers (which set their own Content-Type via `Responder`) —
+that split is why it went unnoticed. Nothing masked it: no `Compress`, no `DefaultHeaders`
+middleware, and actix never supplies a default `Content-Type` for streamed bodies. Proxied JSON has
+been served with no `Content-Type` all along; SSE was just the first client strict enough to care.
+
+- The copy loop must use **`append_header`**, not `insert_header`: `HeaderMap::iter` yields one
+  entry per value, so an insert collapses multi-valued headers (`Set-Cookie`, `Vary`, `Link`) to
+  their last value. Only reachable once the allowlist is inverted — caught in review, verified by a
+  test that fails on `insert_header`.
+
+**Testing:** 7 tests, all verified as regression tests — the filter was temporarily reverted to the
+original allowlist and the suite re-run (0 passed / 7 failed), then restored (7 passed).
+
+**Gates:** all green — `fmt --check`, `build --workspace`, `test --workspace --all` (7 new tests).
+**Status:** implemented, **not committed** (awaiting user UAT per commit-validation rule).
 
 ### AD-007: Local Email DX — stub terminal render + file-transport wiring (2026-07-17)
 

--- a/.claude/specs/project/STATE.md
+++ b/.claude/specs/project/STATE.md
@@ -103,8 +103,18 @@ been served with no `Content-Type` all along; SSE was just the first client stri
   their last value. Only reachable once the allowlist is inverted — caught in review, verified by a
   test that fails on `insert_header`.
 
-**Testing:** 7 tests, all verified as regression tests — the filter was temporarily reverted to the
-original allowlist and the suite re-run (0 passed / 7 failed), then restored (7 passed).
+**Follow-up (same PR, 3rd commit):** the first pass *enumerated* the Mycelium keys to block
+(profile, request-id, service-name) and so still leaked `x-mycelium-email`,
+`x-mycelium-security-group`, `x-mycelium-connection-string`, `x-mycelium-scope`,
+`x-mycelium-role` and `x-mycelium-tenant-id` back to the client if a downstream echoed them —
+authenticated user's email, the route's authorization config, and the user's connection-string
+credential. Caught by the automated security review of the commit, **not** by the tests. Now
+matched by `MYCELIUM_HEADER_PREFIX`, same rule as the request side. Lesson is already recorded in
+`settings.rs`: never enumerate the namespace, and it was violated in the very next file.
+
+**Testing:** 8 tests, all verified as regression tests — the filter was temporarily reverted to the
+original allowlist and the suite re-run (0 passed / 7 failed), then restored (7 passed). T8
+verified separately against the enumerated blocklist (failed → passed).
 
 **Gates:** all green — `fmt --check`, `build --workspace`, `test --workspace --all` (7 new tests).
 **Status:** implemented, **not committed** (awaiting user UAT per commit-validation rule).

--- a/lib/http_tools/src/settings.rs
+++ b/lib/http_tools/src/settings.rs
@@ -6,6 +6,17 @@ use zstd::DEFAULT_COMPRESSION_LEVEL as ZSTD_DEFAULT_COMPRESSION_LEVEL;
 // ? Configure default system constants
 // ? ---------------------------------------------------------------------------
 
+/// Mycelium header namespace
+///
+/// Every header the gateway injects into the downstream request is namespaced
+/// under this prefix. The gateway strips all inbound headers matching it from
+/// the client request before forwarding, so a client can never forge identity
+/// context that a downstream service would attribute to the gateway. Any new
+/// `x-mycelium-*` header is therefore covered by construction — never enumerate
+/// the keys individually when filtering.
+///
+pub const MYCELIUM_HEADER_PREFIX: &str = "x-mycelium-";
+
 /// Default profile key
 ///
 /// This is the default key used to store the profile in the request headers and

--- a/lib/http_tools/src/settings.rs
+++ b/lib/http_tools/src/settings.rs
@@ -85,10 +85,12 @@ pub const MYCELIUM_SERVICE_NAME: &str = "x-mycelium-service-name";
 ///
 pub const MYCELIUM_SECURITY_GROUP: &str = "x-mycelium-security-group";
 
-/// Default forwarding keys
+/// Hop-by-hop headers blocklist
 ///
 /// Such keys are used to map the headers that should be removed from the
-/// downstream response before stream it back to the client.
+/// downstream response before stream it back to the client. RFC 7230 § 6.1
+/// forbids a proxy from forwarding them. Every other downstream response
+/// header is forwarded verbatim.
 ///
 pub const FORWARDING_KEYS: [&str; 9] = [
     "Host",

--- a/ports/api/src/router/build_the_gateway_response.rs
+++ b/ports/api/src/router/build_the_gateway_response.rs
@@ -1,6 +1,7 @@
-use super::DownstreamResponse;
-
-use actix_web::{HttpResponse, HttpResponseBuilder};
+use actix_web::{
+    http::{header::HeaderMap, StatusCode},
+    HttpResponse, HttpResponseBuilder,
+};
 use awc::error::HeaderValue;
 use myc_http_tools::{
     responses::GatewayError,
@@ -24,73 +25,37 @@ use myc_http_tools::{
 pub(super) async fn build_the_gateway_response(
     request_id: Option<HeaderValue>,
     route_key: Option<String>,
-    downstream_response: &DownstreamResponse,
+    downstream_status: StatusCode,
+    downstream_headers: &HeaderMap,
 ) -> Result<HttpResponseBuilder, GatewayError> {
     let span = tracing::Span::current();
 
-    let mut gateway_response =
-        HttpResponse::build(downstream_response.status());
+    let mut gateway_response = HttpResponse::build(downstream_status);
 
     if let Some(request_id) = request_id {
         gateway_response
             .insert_header((DEFAULT_REQUEST_ID_KEY, request_id.to_owned()));
     }
 
-    // ! Remove `Connection` as peer and forward service name
-    //
-    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Connection#Directives
-    //
-    // Both headers contain sensitive information about the system internals.
-    // Thus, be careful on edit this section.
+    let blocked_headers = blocked_response_headers(route_key);
 
     //
-    // Start the headers with the route key if exists
+    // Forward the headers of the response before send it to the client
     //
-    let mut headers = if let Some(key) = route_key {
-        [key].to_vec().into_iter().collect::<Vec<String>>()
-    } else {
-        vec![]
-    };
-
-    //
-    // Append the standard forwarding keys
-    //
-    headers.append(
-        &mut FORWARDING_KEYS
-            .to_vec()
-            .iter()
-            .map(|s| s.to_string())
-            .collect(),
-    );
-
-    //
-    // Append the default profile and forward for keys
-    //
-    headers.append(&mut vec![
-        FORWARD_FOR_KEY.to_string(),
-        DEFAULT_PROFILE_KEY.to_string(),
-        MYCELIUM_SERVICE_NAME.to_string(),
-    ]);
-
-    //
-    // Filter the headers of the response before send it to the client
+    // `append_header` instead of `insert_header`: `HeaderMap::iter` yields one
+    // entry per value, so multi-valued headers such as `Set-Cookie` would be
+    // collapsed to their last value by an insert.
     //
     for (header_name, header_value) in
-        downstream_response.headers().iter().filter(|(h, _)| {
-            headers
-                .to_owned()
-                .into_iter()
-                .map(|h| h.to_lowercase())
-                .collect::<Vec<String>>()
-                .contains(&h.to_owned().to_string().to_lowercase())
+        downstream_headers.iter().filter(|(name, _)| {
+            !blocked_headers.contains(&name.as_str().to_owned())
         })
     {
         gateway_response
-            .insert_header((header_name.clone(), header_value.clone()));
+            .append_header((header_name.clone(), header_value.clone()));
     }
 
-    if let Some(size) = downstream_response
-        .headers()
+    if let Some(size) = downstream_headers
         .get("content-length")
         .map(|h| h.to_str().unwrap_or("0").parse::<u64>().unwrap_or(0))
     {
@@ -99,10 +64,270 @@ pub(super) async fn build_the_gateway_response(
     }
 
     // Add the downstream response status to the metric
-    span.record(
-        "myc.router.res_status",
-        &Some(downstream_response.status().as_u16()),
-    );
+    span.record("myc.router.res_status", &Some(downstream_status.as_u16()));
 
     Ok(gateway_response)
+}
+
+/// Collect the response headers that must not be forwarded to the client
+///
+/// ! Blocked response headers
+///
+/// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Connection#Directives
+///
+/// Two distinct sets are removed from the downstream response before it is
+/// streamed back to the client:
+///
+/// 1. Hop-by-hop headers (`FORWARDING_KEYS`), which RFC 7230 § 6.1 forbids a
+///    proxy from forwarding.
+///
+/// 2. Gateway-injected artifacts, which travel in the request direction only.
+///    If a downstream service echoes one of them back, forwarding it would leak
+///    internal context to the client — `route_key` in particular is the name of
+///    the injected downstream secret header.
+///
+/// Every other header is forwarded verbatim. Both sets contain sensitive
+/// information about the system internals. Thus, be careful on edit this
+/// section.
+///
+/// Names are lowercased on both sides of the comparison, as HTTP header names
+/// are case-insensitive.
+///
+fn blocked_response_headers(route_key: Option<String>) -> Vec<String> {
+    let mut blocked_headers = FORWARDING_KEYS
+        .iter()
+        .map(|key| key.to_lowercase())
+        .collect::<Vec<String>>();
+
+    blocked_headers.append(&mut vec![
+        FORWARD_FOR_KEY.to_lowercase(),
+        DEFAULT_PROFILE_KEY.to_lowercase(),
+        DEFAULT_REQUEST_ID_KEY.to_lowercase(),
+        MYCELIUM_SERVICE_NAME.to_lowercase(),
+    ]);
+
+    let Some(key) = route_key else {
+        return blocked_headers;
+    };
+
+    blocked_headers.push(key.to_lowercase());
+    blocked_headers
+}
+
+// ? ---------------------------------------------------------------------------
+// ? Tests
+// ? ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::build_the_gateway_response;
+
+    use actix_web::http::{
+        header::{HeaderMap, HeaderName, HeaderValue},
+        StatusCode,
+    };
+    use awc::error::HeaderValue as AwcHeaderValue;
+    use myc_http_tools::settings::{
+        DEFAULT_PROFILE_KEY, DEFAULT_REQUEST_ID_KEY, MYCELIUM_SERVICE_NAME,
+    };
+
+    fn headers_from(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+
+        for (name, value) in pairs {
+            headers.append(
+                HeaderName::from_bytes(name.as_bytes()).unwrap(),
+                HeaderValue::from_str(value).unwrap(),
+            );
+        }
+
+        headers
+    }
+
+    #[tokio::test]
+    async fn streaming_content_type_reaches_the_client() {
+        let downstream_headers =
+            headers_from(&[("content-type", "text/event-stream")]);
+
+        let mut builder = build_the_gateway_response(
+            None,
+            None,
+            StatusCode::OK,
+            &downstream_headers,
+        )
+        .await
+        .unwrap();
+
+        let response = builder.finish();
+
+        assert_eq!(
+            response.headers().get("content-type").unwrap(),
+            "text/event-stream"
+        );
+    }
+
+    #[tokio::test]
+    async fn hop_by_hop_headers_are_removed() {
+        let downstream_headers = headers_from(&[
+            ("connection", "keep-alive"),
+            ("transfer-encoding", "chunked"),
+            ("upgrade", "websocket"),
+        ]);
+
+        let mut builder = build_the_gateway_response(
+            None,
+            None,
+            StatusCode::OK,
+            &downstream_headers,
+        )
+        .await
+        .unwrap();
+
+        let response = builder.finish();
+
+        assert!(response.headers().get("connection").is_none());
+        assert!(response.headers().get("transfer-encoding").is_none());
+        assert!(response.headers().get("upgrade").is_none());
+    }
+
+    #[tokio::test]
+    async fn application_headers_are_forwarded() {
+        let downstream_headers = headers_from(&[
+            ("x-crab-shell-session", "session-42"),
+            ("cache-control", "no-cache"),
+            ("etag", "\"abc123\""),
+            ("content-encoding", "gzip"),
+        ]);
+
+        let mut builder = build_the_gateway_response(
+            None,
+            None,
+            StatusCode::OK,
+            &downstream_headers,
+        )
+        .await
+        .unwrap();
+
+        let response = builder.finish();
+
+        assert_eq!(
+            response.headers().get("x-crab-shell-session").unwrap(),
+            "session-42"
+        );
+
+        assert_eq!(
+            response.headers().get("cache-control").unwrap(),
+            "no-cache"
+        );
+        assert_eq!(response.headers().get("etag").unwrap(), "\"abc123\"");
+        assert_eq!(response.headers().get("content-encoding").unwrap(), "gzip");
+    }
+
+    #[tokio::test]
+    async fn echoed_gateway_artifacts_are_stripped() {
+        let downstream_headers = headers_from(&[
+            ("x-downstream-secret", "super-secret-token"),
+            (DEFAULT_PROFILE_KEY, "leaked-profile"),
+            (MYCELIUM_SERVICE_NAME, "crab-shell-proxy"),
+            ("x-forwarded-for", "10.0.0.1"),
+        ]);
+
+        let mut builder = build_the_gateway_response(
+            None,
+            Some("x-downstream-secret".to_owned()),
+            StatusCode::OK,
+            &downstream_headers,
+        )
+        .await
+        .unwrap();
+
+        let response = builder.finish();
+
+        assert!(response.headers().get("x-downstream-secret").is_none());
+        assert!(response.headers().get(DEFAULT_PROFILE_KEY).is_none());
+        assert!(response.headers().get(MYCELIUM_SERVICE_NAME).is_none());
+        assert!(response.headers().get("x-forwarded-for").is_none());
+    }
+
+    #[tokio::test]
+    async fn echoed_request_id_does_not_override_the_gateway_one() {
+        let downstream_headers =
+            headers_from(&[(DEFAULT_REQUEST_ID_KEY, "downstream-echo")]);
+
+        let mut builder = build_the_gateway_response(
+            Some(AwcHeaderValue::from_static("gateway-request-id")),
+            None,
+            StatusCode::OK,
+            &downstream_headers,
+        )
+        .await
+        .unwrap();
+
+        let response = builder.finish();
+
+        assert_eq!(
+            response.headers().get(DEFAULT_REQUEST_ID_KEY).unwrap(),
+            "gateway-request-id"
+        );
+    }
+
+    #[tokio::test]
+    async fn multi_valued_headers_keep_every_value() {
+        let downstream_headers = headers_from(&[
+            ("set-cookie", "session=abc"),
+            ("set-cookie", "csrf=xyz"),
+        ]);
+
+        let mut builder = build_the_gateway_response(
+            None,
+            None,
+            StatusCode::OK,
+            &downstream_headers,
+        )
+        .await
+        .unwrap();
+
+        let response = builder.finish();
+
+        let cookies = response
+            .headers()
+            .get_all("set-cookie")
+            .map(|value| value.to_str().unwrap().to_owned())
+            .collect::<Vec<String>>();
+
+        assert_eq!(cookies, vec!["session=abc", "csrf=xyz"]);
+    }
+
+    #[tokio::test]
+    async fn blocklist_matching_is_case_insensitive() {
+        //
+        // `FORWARDING_KEYS` are capitalized and the route key comes from the
+        // route configuration with arbitrary casing, while actix normalizes
+        // header names to lowercase.
+        //
+        let downstream_headers = headers_from(&[
+            ("Connection", "keep-alive"),
+            ("X-Downstream-Secret", "super-secret-token"),
+            ("Content-Type", "application/json"),
+        ]);
+
+        let mut builder = build_the_gateway_response(
+            None,
+            Some("X-Downstream-Secret".to_owned()),
+            StatusCode::OK,
+            &downstream_headers,
+        )
+        .await
+        .unwrap();
+
+        let response = builder.finish();
+
+        assert!(response.headers().get("connection").is_none());
+        assert!(response.headers().get("x-downstream-secret").is_none());
+
+        assert_eq!(
+            response.headers().get("content-type").unwrap(),
+            "application/json"
+        );
+    }
 }

--- a/ports/api/src/router/build_the_gateway_response.rs
+++ b/ports/api/src/router/build_the_gateway_response.rs
@@ -6,8 +6,8 @@ use awc::error::HeaderValue;
 use myc_http_tools::{
     responses::GatewayError,
     settings::{
-        DEFAULT_PROFILE_KEY, DEFAULT_REQUEST_ID_KEY, FORWARDING_KEYS,
-        FORWARD_FOR_KEY, MYCELIUM_SERVICE_NAME,
+        DEFAULT_REQUEST_ID_KEY, FORWARDING_KEYS, FORWARD_FOR_KEY,
+        MYCELIUM_HEADER_PREFIX, RFC7239_FORWARDED_KEY,
     },
 };
 
@@ -48,7 +48,7 @@ pub(super) async fn build_the_gateway_response(
     //
     for (header_name, header_value) in
         downstream_headers.iter().filter(|(name, _)| {
-            !blocked_headers.contains(&name.as_str().to_owned())
+            !is_blocked_response_header(name.as_str(), &blocked_headers)
         })
     {
         gateway_response
@@ -84,7 +84,9 @@ pub(super) async fn build_the_gateway_response(
 /// 2. Gateway-injected artifacts, which travel in the request direction only.
 ///    If a downstream service echoes one of them back, forwarding it would leak
 ///    internal context to the client — `route_key` in particular is the name of
-///    the injected downstream secret header.
+///    the injected downstream secret header, and the `x-mycelium-` namespace
+///    carries identity and authorization context (profile, email, security
+///    group, connection string).
 ///
 /// Every other header is forwarded verbatim. Both sets contain sensitive
 /// information about the system internals. Thus, be careful on edit this
@@ -101,9 +103,7 @@ fn blocked_response_headers(route_key: Option<String>) -> Vec<String> {
 
     blocked_headers.append(&mut vec![
         FORWARD_FOR_KEY.to_lowercase(),
-        DEFAULT_PROFILE_KEY.to_lowercase(),
-        DEFAULT_REQUEST_ID_KEY.to_lowercase(),
-        MYCELIUM_SERVICE_NAME.to_lowercase(),
+        RFC7239_FORWARDED_KEY.to_lowercase(),
     ]);
 
     let Some(key) = route_key else {
@@ -112,6 +112,24 @@ fn blocked_response_headers(route_key: Option<String>) -> Vec<String> {
 
     blocked_headers.push(key.to_lowercase());
     blocked_headers
+}
+
+/// Whether a downstream response header must not reach the client
+///
+/// The whole `x-mycelium-` namespace is matched by prefix rather than by
+/// listing the keys. Enumerating them is what let `x-mycelium-email`,
+/// `x-mycelium-security-group` and `x-mycelium-connection-string` through: a
+/// list only covers the keys that existed when it was written.
+///
+fn is_blocked_response_header(
+    header_name: &str,
+    blocked_headers: &[String],
+) -> bool {
+    if header_name.starts_with(MYCELIUM_HEADER_PREFIX) {
+        return true;
+    }
+
+    blocked_headers.contains(&header_name.to_owned())
 }
 
 // ? ---------------------------------------------------------------------------
@@ -128,7 +146,10 @@ mod tests {
     };
     use awc::error::HeaderValue as AwcHeaderValue;
     use myc_http_tools::settings::{
-        DEFAULT_PROFILE_KEY, DEFAULT_REQUEST_ID_KEY, MYCELIUM_SERVICE_NAME,
+        DEFAULT_CONNECTION_STRING_KEY, DEFAULT_EMAIL_KEY,
+        DEFAULT_MYCELIUM_ROLE_KEY, DEFAULT_PROFILE_KEY, DEFAULT_REQUEST_ID_KEY,
+        DEFAULT_SCOPE_KEY, DEFAULT_TENANT_ID_KEY, MYCELIUM_SECURITY_GROUP,
+        MYCELIUM_SERVICE_NAME,
     };
 
     fn headers_from(pairs: &[(&str, &str)]) -> HeaderMap {
@@ -269,6 +290,50 @@ mod tests {
             response.headers().get(DEFAULT_REQUEST_ID_KEY).unwrap(),
             "gateway-request-id"
         );
+    }
+
+    #[tokio::test]
+    async fn the_whole_mycelium_namespace_is_stripped() {
+        //
+        // Anything the gateway may have injected into the request leaks
+        // internal context if a downstream echoes it back. The namespace is
+        // matched by prefix, so keys added later are covered too.
+        //
+        let downstream_headers = headers_from(&[
+            (DEFAULT_EMAIL_KEY, "user@example.com"),
+            (MYCELIUM_SECURITY_GROUP, "{\"Protected\":null}"),
+            (DEFAULT_CONNECTION_STRING_KEY, "user-credential"),
+            (DEFAULT_SCOPE_KEY, "leaked-scope"),
+            (DEFAULT_MYCELIUM_ROLE_KEY, "leaked-role"),
+            (DEFAULT_TENANT_ID_KEY, "leaked-tenant"),
+            ("x-mycelium-not-yet-invented", "future-key"),
+        ]);
+
+        let mut builder = build_the_gateway_response(
+            None,
+            None,
+            StatusCode::OK,
+            &downstream_headers,
+        )
+        .await
+        .unwrap();
+
+        let response = builder.finish();
+
+        assert!(response.headers().get(DEFAULT_EMAIL_KEY).is_none());
+        assert!(response.headers().get(MYCELIUM_SECURITY_GROUP).is_none());
+        assert!(response
+            .headers()
+            .get(DEFAULT_CONNECTION_STRING_KEY)
+            .is_none());
+        assert!(response.headers().get(DEFAULT_SCOPE_KEY).is_none());
+        assert!(response.headers().get(DEFAULT_MYCELIUM_ROLE_KEY).is_none());
+        assert!(response.headers().get(DEFAULT_TENANT_ID_KEY).is_none());
+
+        assert!(response
+            .headers()
+            .get("x-mycelium-not-yet-invented")
+            .is_none());
     }
 
     #[tokio::test]

--- a/ports/api/src/router/initialize_downstream_request.rs
+++ b/ports/api/src/router/initialize_downstream_request.rs
@@ -1,3 +1,4 @@
+use super::strip_inbound_mycelium_headers;
 use crate::models::api_config::ApiConfig;
 
 use actix_web::{web, HttpRequest};
@@ -5,7 +6,10 @@ use awc::{Client, ClientRequest};
 use myc_core::domain::dtos::route::Route;
 use myc_http_tools::{
     responses::GatewayError,
-    settings::{FORWARD_FOR_KEY, MYCELIUM_SERVICE_NAME, RFC7239_FORWARDED_KEY},
+    settings::{
+        DEFAULT_REQUEST_ID_KEY, FORWARD_FOR_KEY, MYCELIUM_SERVICE_NAME,
+        RFC7239_FORWARDED_KEY,
+    },
 };
 use mycelium_base::dtos::Parent;
 use std::time::Duration;
@@ -201,7 +205,19 @@ pub(super) async fn initialize_downstream_request(
     let mut downstream_request = client
         .request_from(routing_url.as_str(), req.head())
         .no_decompress()
-        .timeout(Duration::from_secs(config.gateway_timeout))
+        .timeout(Duration::from_secs(config.gateway_timeout));
+
+    //
+    // ! Drop the client-supplied Mycelium headers
+    //
+    // `request_from` copied every header of the client request, including any
+    // `x-mycelium-*` the client chose to send. They are removed here, before
+    // the gateway injects its own — otherwise a forged identity header would
+    // survive on the security groups that do not overwrite it.
+    //
+    strip_inbound_mycelium_headers(downstream_request.headers_mut());
+
+    downstream_request = downstream_request
         .insert_header((FORWARD_FOR_KEY, client_ip.as_str()))
         .insert_header((RFC7239_FORWARDED_KEY, format!("for={client_ip}")));
 
@@ -211,6 +227,16 @@ pub(super) async fn initialize_downstream_request(
     //
     downstream_request = downstream_request
         .insert_header((MYCELIUM_SERVICE_NAME, format!("{}", service.name)));
+
+    //
+    // Re-inject the request id stripped above. The value is always
+    // gateway-generated: the app level middleware overwrites it with a fresh
+    // uuid on every inbound request, before the router runs.
+    //
+    if let Some(request_id) = req.headers().get(DEFAULT_REQUEST_ID_KEY) {
+        downstream_request = downstream_request
+            .insert_header((DEFAULT_REQUEST_ID_KEY, request_id.to_owned()));
+    }
 
     Ok(downstream_request)
 }

--- a/ports/api/src/router/mod.rs
+++ b/ports/api/src/router/mod.rs
@@ -7,7 +7,8 @@
 ///
 /// - Check if the source of the request is allowed to access the service.
 /// - Check if the method of the request is allowed to access the service.
-/// - Build the downstream URL address.
+/// - Build the downstream URL address, dropping any client-supplied
+///   `x-mycelium-*` header before the gateway injects its own.
 /// - Check security group and inject the email, profile, and role scoped
 ///   connection string into the request.
 /// - Inject the secret into the request if needed.
@@ -25,6 +26,7 @@ mod inject_downstream_secret;
 mod match_downstream_route_from_request;
 mod prepare_body_idp_context;
 mod stream_request_to_downstream;
+mod strip_inbound_mycelium_headers;
 
 use build_the_gateway_response::*;
 use check_method_permission::*;
@@ -35,6 +37,7 @@ use inject_downstream_secret::*;
 use match_downstream_route_from_request::*;
 use prepare_body_idp_context::*;
 use stream_request_to_downstream::*;
+use strip_inbound_mycelium_headers::*;
 
 use crate::models::api_config::ApiConfig;
 

--- a/ports/api/src/router/mod.rs
+++ b/ports/api/src/router/mod.rs
@@ -232,10 +232,14 @@ pub(crate) async fn route_request(
     //
     // ? -----------------------------------------------------------------------
 
-    let mut gateway_response =
-        build_the_gateway_response(request_id, route_key, &downstream_response)
-            .instrument(span.to_owned())
-            .await?;
+    let mut gateway_response = build_the_gateway_response(
+        request_id,
+        route_key,
+        downstream_response.status(),
+        downstream_response.headers(),
+    )
+    .instrument(span.to_owned())
+    .await?;
 
     // ? -----------------------------------------------------------------------
     // ? Stream the response to the client

--- a/ports/api/src/router/strip_inbound_mycelium_headers.rs
+++ b/ports/api/src/router/strip_inbound_mycelium_headers.rs
@@ -1,0 +1,154 @@
+use actix_web::http::header::{HeaderMap, HeaderName};
+use myc_http_tools::settings::MYCELIUM_HEADER_PREFIX;
+
+/// Strip client-supplied Mycelium headers from the downstream request
+///
+/// ! Trust boundary
+///
+/// `awc::Client::request_from` copies every header of the client request into
+/// the downstream request. Headers under the `x-mycelium-` namespace carry
+/// identity context that downstream services attribute to the gateway — a
+/// client that forges one would be trusted by the SDKs as if the gateway had
+/// authenticated it.
+///
+/// Everything under the namespace is therefore removed unconditionally, before
+/// the gateway injects its own values. Deny by default, re-grant explicitly:
+/// whatever the gateway legitimately forwards is re-inserted by the caller
+/// after this runs. Do not turn this into a list of known keys — a new
+/// `x-mycelium-*` header would silently fall outside it.
+///
+#[tracing::instrument(name = "strip_inbound_mycelium_headers", skip_all)]
+pub(super) fn strip_inbound_mycelium_headers(headers: &mut HeaderMap) {
+    let inbound_mycelium_headers = headers
+        .keys()
+        .filter(|name| name.as_str().starts_with(MYCELIUM_HEADER_PREFIX))
+        .cloned()
+        .collect::<Vec<HeaderName>>();
+
+    for header_name in inbound_mycelium_headers {
+        tracing::debug!(
+            stage = "router.strip_inbound_mycelium_headers",
+            header = header_name.as_str(),
+            "Client-supplied Mycelium header removed"
+        );
+
+        headers.remove(&header_name);
+    }
+}
+
+// ? ---------------------------------------------------------------------------
+// ? Tests
+// ? ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::strip_inbound_mycelium_headers;
+
+    use actix_web::http::header::{HeaderMap, HeaderName, HeaderValue};
+    use myc_http_tools::settings::{
+        DEFAULT_CONNECTION_STRING_KEY, DEFAULT_EMAIL_KEY,
+        DEFAULT_MYCELIUM_ROLE_KEY, DEFAULT_PROFILE_KEY, DEFAULT_SCOPE_KEY,
+        DEFAULT_TENANT_ID_KEY,
+    };
+
+    fn headers_from(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+
+        for (name, value) in pairs {
+            headers.append(
+                HeaderName::from_bytes(name.as_bytes()).unwrap(),
+                HeaderValue::from_str(value).unwrap(),
+            );
+        }
+
+        headers
+    }
+
+    #[test]
+    fn forged_profile_is_removed() {
+        let mut headers =
+            headers_from(&[(DEFAULT_PROFILE_KEY, "forged-profile")]);
+
+        strip_inbound_mycelium_headers(&mut headers);
+
+        assert!(headers.get(DEFAULT_PROFILE_KEY).is_none());
+    }
+
+    #[test]
+    fn headers_without_a_producer_are_removed() {
+        let mut headers = headers_from(&[
+            (DEFAULT_SCOPE_KEY, "forged-scope"),
+            (DEFAULT_MYCELIUM_ROLE_KEY, "forged-role"),
+            (DEFAULT_TENANT_ID_KEY, "forged-tenant"),
+            (DEFAULT_EMAIL_KEY, "forged@email.com"),
+        ]);
+
+        strip_inbound_mycelium_headers(&mut headers);
+
+        assert!(headers.get(DEFAULT_SCOPE_KEY).is_none());
+        assert!(headers.get(DEFAULT_MYCELIUM_ROLE_KEY).is_none());
+        assert!(headers.get(DEFAULT_TENANT_ID_KEY).is_none());
+        assert!(headers.get(DEFAULT_EMAIL_KEY).is_none());
+    }
+
+    #[test]
+    fn connection_string_is_not_forwarded_downstream() {
+        let mut headers =
+            headers_from(&[(DEFAULT_CONNECTION_STRING_KEY, "user-credential")]);
+
+        strip_inbound_mycelium_headers(&mut headers);
+
+        assert!(headers.get(DEFAULT_CONNECTION_STRING_KEY).is_none());
+    }
+
+    #[test]
+    fn non_mycelium_headers_are_untouched() {
+        let mut headers = headers_from(&[
+            ("authorization", "Bearer token"),
+            ("content-type", "application/json"),
+            ("x-crab-shell-session", "session-42"),
+        ]);
+
+        strip_inbound_mycelium_headers(&mut headers);
+
+        assert_eq!(headers.get("authorization").unwrap(), "Bearer token");
+
+        assert_eq!(headers.get("content-type").unwrap(), "application/json");
+
+        assert_eq!(headers.get("x-crab-shell-session").unwrap(), "session-42");
+    }
+
+    #[test]
+    fn matching_is_prefix_based_and_case_insensitive() {
+        let mut headers = headers_from(&[
+            ("X-Mycelium-Profile", "forged-profile"),
+            ("x-mycelium", "not-namespaced"),
+            ("x-my-header", "unrelated"),
+        ]);
+
+        strip_inbound_mycelium_headers(&mut headers);
+
+        assert!(headers.get("x-mycelium-profile").is_none());
+        assert_eq!(headers.get("x-mycelium").unwrap(), "not-namespaced");
+        assert_eq!(headers.get("x-my-header").unwrap(), "unrelated");
+    }
+
+    #[test]
+    fn multi_valued_headers_keep_every_value() {
+        let mut headers = headers_from(&[
+            ("accept", "text/html"),
+            ("accept", "application/json"),
+            (DEFAULT_PROFILE_KEY, "forged-profile"),
+        ]);
+
+        strip_inbound_mycelium_headers(&mut headers);
+
+        let accepted = headers
+            .get_all("accept")
+            .map(|value| value.to_str().unwrap().to_owned())
+            .collect::<Vec<String>>();
+
+        assert_eq!(accepted, vec!["text/html", "application/json"]);
+        assert!(headers.get(DEFAULT_PROFILE_KEY).is_none());
+    }
+}


### PR DESCRIPTION
Two bugs in the gateway router's header handling, found together. Both are the
same class of mistake — a trust boundary enforced by enumerating cases instead
of denying by default and re-granting explicitly. One commit each.

## 1. Response headers used an allowlist instead of a blocklist (`08fcff88`)

`build_the_gateway_response` kept **only** the headers in a short list
(`route_key` + `FORWARDING_KEYS` + forwarded-for + profile + service-name),
inverting the documented intent of `FORWARDING_KEYS` ("headers that should be
removed from the downstream response").

- Every legitimate downstream header was dropped: `Content-Type`, `Location`,
  `Cache-Control`, `ETag`, `Content-Disposition`, `Set-Cookie`, all app-custom
  headers. Reported symptom: SSE responses reached clients without
  `Content-Type: text/event-stream`, so `EventSource` and OpenAI-compatible
  SDKs buffered the whole stream instead of dispatching per event.
- The only headers guaranteed to pass were the ones that must not. `route_key`
  is the *name of the injected downstream secret header* — a downstream
  echoing it back had it forwarded to the client.

**Blast radius:** `route_request` is `App::default_service`, so this affected
100% of proxied traffic and 0% of Mycelium's own handlers (which set their own
Content-Type via `Responder`). That split is why it went unnoticed. Nothing
masked it — no `Compress`, no `DefaultHeaders`, and actix supplies no default
Content-Type for streamed bodies. **Proxied JSON has been served with no
Content-Type all along**; SSE was just the first client strict enough to care.

**Deliberately not blocked:** `Content-Encoding` (the downstream request uses
`no_decompress()`, so the body reaches the client compressed — blocking it
would corrupt every gzip response) and `Content-Length` (the h1 encoder drops
it for streamed bodies but retains it for 304 per RFC 7232 §4.1).

Forwarding uses `append_header`: `HeaderMap::iter` yields one entry per value,
so an insert collapses multi-valued headers like `Set-Cookie` to the last one.

## 2. Client-supplied `x-mycelium-*` headers were forwarded downstream (`3b619066`) — security

**Authorization bypass in downstream services.**

`request_from(url, req.head())` copies every client header into the downstream
request. The gateway then overwrote only *some* `x-mycelium-*`, and only for
certain security groups:

| Security group | Overwritten | Forged `x-mycelium-profile` |
|---|---|---|
| `Public` | nothing | **forwarded** |
| `Authenticated` | `x-mycelium-email` only | **forwarded** |
| `Protected` / `ProtectedByRoles` | `x-mycelium-profile` | blocked |

So on any Public or Authenticated route, a client sends a forged
`x-mycelium-profile` and the gateway hands it to the downstream service, where
every SDK decodes it as gateway-attested identity — `hasStaffPrivileges`
included. No Mycelium credential required.

Wider than the profile: `x-mycelium-scope`, `x-mycelium-role` and
`x-mycelium-tenant-id` had **no producer at all** on the proxy path and passed
through in every security group.

Fix: strip everything under the `x-mycelium-` prefix right after the copy,
unconditionally, before any gateway injection. Prefix-based rather than a list
of constants, so a new `x-mycelium-*` key is covered by construction.

- `x-mycelium-request-id` is explicitly re-injected (it was only forwarded as a
  side effect of the blanket copy). Safe: the app-level middleware overwrites
  it with a fresh uuid before the router runs.
- `x-mycelium-security-group` is stripped but re-inserted unconditionally by
  `check_security_group` in a later step.

### ⚠️ Behavior change to watch

`x-mycelium-connection-string` **stops being forwarded downstream**. It is the
user's own bearer-equivalent credential. Searched the gateway and all three
SDKs: each only *declares* the constant, none reads the header. Services
outside this repo can't be checked — if one reads it, the fix is to re-inject
it explicitly like the request id.

## Tests

- **Response fix: 7 tests, all verified regression tests.** The filter was
  temporarily reverted to the original allowlist and the suite re-run:
  0 passed / 7 failed. Restored: 7 passed.
- **Security fix: 6 unit tests, not regression tests.** The function is new, so
  none would have caught the original bug — it was the *absence* of this step
  in the pipeline, not a defect inside it. A pipeline-level test was considered
  and declined; strip point and ordering were verified by reading
  `router/mod.rs` and `check_security_group.rs`.

Gates green on `develop` (rc.11): `cargo fmt --all -- --check`,
`cargo build --workspace`, `cargo test --workspace --all` — 454 passed, 0 failed.

## Out of scope

- Profile signing (HMAC gateway↔SDK) — would eliminate the class, but changes
  the contract across all four SDKs.
- Trusted-proxy validation in `resolve_client_ip` (security findings §1.3) —
  same class, but needs a new config surface and an empty default would change
  the client IP seen by downstreams behind Traefik/Dokploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
