### PR TITLE
style(templates): align email templates with the web pages' visual language

### DIFF
--- a/.claude/specs/features/email-template-web-parity/design.md
+++ b/.claude/specs/features/email-template-web-parity/design.md
@@ -1,0 +1,403 @@
+# Design: Email Template Web Parity
+
+The structural work is identical for all 33 files: **one token map + eight component recipes,
+applied three times.** This document is the single source of truth for the implementation — the
+tasks reference recipe names from §3, not ad-hoc styling.
+
+---
+
+## 1. Token map (`templates/web/*.html` → e-mail)
+
+| Role | Web source | E-mail value | Note |
+|---|---|---|---|
+| Canvas | `body { background: #f5f3ff }` | `#f5f3ff` on `<body>`, outer `<table bgcolor>` and `<style>` | |
+| Card surface | `.card { background:#fff; border-radius:12px; box-shadow:0 2px 12px rgba(0,0,0,.08) }` | same three declarations inline on the 600px card `<table>` | radius/shadow ignored by Outlook (DEC-5) |
+| Card padding | `48px 40px` | `40px` horizontal, `40px` top / `32px` bottom via padding + spacer rows | |
+| Card width | `max-width: 420px` | `600px` | ADAPT-1 |
+| Sans stack | `'Inter','Open Sans',Arial,sans-serif` | `'Inter','Open Sans',Helvetica,Arial,sans-serif` | `Helvetica` inserted for Apple clients |
+| Mono stack | `'JetBrains Mono','Courier New',monospace` | `'JetBrains Mono','Courier New',Courier,monospace` | |
+| Brand eyebrow | `.brand` — `#8b5cf6` 13px/600 uppercase `letter-spacing:.04em` | identical | replaces the dark header band |
+| Heading | `h1` — `#4c1d95` 22px | `#4c1d95` 22px/1.3 weight 600, sans stack | Georgia and the 2px violet rule are dropped |
+| Body copy | `p` — `#555` 14px/1.6 | identical | |
+| Strong emphasis | `.code { color:#1a1a1a }` | `#1a1a1a` | was `#18181b` |
+| Code chip | `.code` — `#bae6fd` radius 6px, mono 36px bold `letter-spacing:.18em`, `#1a1a1a`, padding `16px 40px` | identical, centred | was `#f4f4f5` + `#e4e4e7` border |
+| Primary button | `button` — `#8b5cf6` radius 6px, `#fff` 14px/600, padding `12px` | `#8b5cf6` radius 6px, `#fff` 14px/600, padding `12px 32px`, **not** uppercase | was square uppercase `#7c3aed` |
+| Field box | `input` — `1px solid #ddd` radius 6px padding `10px 12px` | identical, white fill | serves the URL block and labeled values |
+| Field label | `label` — 13px/500 `#333` | identical | was 11px uppercase `#71717a` |
+| Info callout | `.stakes` — `#f0f9ff`, `3px solid #7dd3fc` left, radius 4px, `#4c1d95` 12.5px/1.5, padding `10px 12px` | identical | was `#faf5ff` + `#7c3aed` |
+| Warning callout | *(no web equivalent)* | `#fff7ed`, `3px solid #f59e0b` left, radius 4px, `#92400e` 12.5px/1.5 | DEC-4 — geometry from `.stakes`, amber hues kept |
+| Muted note | `.note` — `#999` 12px | identical | expiry captions + footer |
+| Link | `.copy-button { color:#6d28d9 }` | `#6d28d9`, `text-decoration:none` | was `#7c3aed` |
+| Hairline | `.copy-button { border:1px solid #ddd6fe }` | `#ddd6fe` 1px | was `#e4e4e7` |
+
+### Tokens deliberately not carried over
+
+`#18181b` (dark header), `#f4f4f5` / `#e4e4e7` / `#71717a` / `#a1a1aa` (zinc scale), `#7c3aed`
+(old violet), `#faf5ff`, Georgia serif, `text-transform: uppercase` on buttons. After the refactor
+none of these hexes should appear under `templates/*/email/`.
+
+### Documented e-mail adaptations
+
+| ID | Adaptation | Why |
+|---|---|---|
+| ADAPT-1 | Card is 600px, not 420px | 600px is the e-mail client safe width; 420px would leave the copy cramped |
+| ADAPT-2 | Eyebrow, heading and body copy are **left**-aligned (web centres everything) | The web card holds one short line; e-mails hold paragraphs. Only the code chip and the CTA are centred, matching the web's own centred treatment of those two elements |
+| ADAPT-3 | Footer moves *inside* the card, below a `#ddd6fe` hairline, using the muted-note token | The web pages have no footer; the zinc band outside the card has no web analogue |
+| ADAPT-4 | Spacer `<tr>` rows replace `margin-bottom` | `margin` is unreliable on `td` in Outlook |
+| ADAPT-5 | No icons, no script, no flex, no CSS classes for layout | DEC-2 / DEC-3 / ET-R15 |
+| ADAPT-6 | Webfonts via `<link>` **and** `@import`, with full inline fallbacks | DEC-3 — `<link>` survives in Apple Mail, `@import` in a few others, inline stacks cover the rest |
+
+---
+
+## 2. Canonical base (`templates/en-us/email/base.jinja`)
+
+`es` and `pt-br` are byte-identical apart from `lang`, the `extends` path in children, and the two
+footer strings. Blocks and context variables (`domain_name`, `support_email`, `domain_url`) are
+unchanged.
+
+```html
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+
+<head>
+  {% block head %}
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="x-apple-disable-message-reformatting" />
+  <title>{% block title %}{% endblock title %} — {{ domain_name }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="crossorigin" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;700&amp;display=swap" rel="stylesheet" />
+  <style type="text/css">
+    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;700&display=swap');
+    body, table, td, p, a, span { -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }
+    table, td { mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse; }
+    img { -ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none; }
+    body { margin: 0 !important; padding: 0 !important; background-color: #f5f3ff; }
+  </style>
+  {% endblock head %}
+</head>
+
+<body style="margin: 0; padding: 0; background-color: #f5f3ff;">
+
+<!-- Outer wrapper -->
+<table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f5f3ff"
+  style="background-color: #f5f3ff;">
+  <tr>
+    <td align="center" style="padding: 40px 16px;">
+
+      <!-- Card: 600px max, white, rounded, soft shadow -->
+      <table width="600" cellpadding="0" cellspacing="0" border="0" bgcolor="#ffffff"
+        style="max-width: 600px; width: 100%; background-color: #ffffff; border-radius: 12px; box-shadow: 0 2px 12px rgba(0,0,0,0.08);">
+
+        <tr>
+          <td style="padding: 40px 40px 0;">
+
+            <!-- Brand eyebrow -->
+            <table width="100%" cellpadding="0" cellspacing="0" border="0">
+              <tr>
+                <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: 600; color: #8b5cf6; letter-spacing: 0.04em; text-transform: uppercase;">
+                  {{ domain_name }}
+                </td>
+              </tr>
+              <tr>
+                <td height="20" style="font-size: 0; line-height: 0;">&nbsp;</td>
+              </tr>
+            </table>
+
+            {% block content %}
+            <!-- Title -->
+            <table width="100%" cellpadding="0" cellspacing="0" border="0">
+              <tr>
+                <td>
+                  <h1 style="margin: 0; font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 22px; font-weight: 600; color: #4c1d95; line-height: 1.3;">
+                    {% block contenttitle %}{% endblock contenttitle %}
+                  </h1>
+                </td>
+              </tr>
+              <tr>
+                <td height="20" style="font-size: 0; line-height: 0;">&nbsp;</td>
+              </tr>
+            </table>
+
+            <!-- Body content -->
+            <table width="100%" cellpadding="0" cellspacing="0" border="0">
+              {% block contenttable %}{% endblock contenttable %}
+            </table>
+            {% endblock content %}
+
+          </td>
+        </tr>
+
+        <!-- Footer (inside the card, below a hairline) -->
+        <tr>
+          <td style="padding: 28px 40px 32px;">
+            <table width="100%" cellpadding="0" cellspacing="0" border="0">
+              <tr>
+                <td height="1" bgcolor="#ddd6fe"
+                  style="background-color: #ddd6fe; height: 1px; font-size: 0; line-height: 0;">&#8203;</td>
+              </tr>
+              <tr>
+                <td height="16" style="font-size: 0; line-height: 0;">&nbsp;</td>
+              </tr>
+
+              {% if support_email %}
+              <tr>
+                <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12px; color: #999999; line-height: 1.6;">
+                  Questions?&#32;<a href="mailto:{{ support_email }}"
+                    style="color: #6d28d9; text-decoration: none;">{{ support_email }}</a>
+                </td>
+              </tr>
+              {% endif %}
+
+              {% if domain_url %}
+              <tr>
+                <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12px; color: #999999; line-height: 1.6;">
+                  <a href="{{ domain_url }}" style="color: #6d28d9; text-decoration: none;">{{ domain_url }}</a>
+                </td>
+              </tr>
+              {% endif %}
+
+              <tr>
+                <td height="8" style="font-size: 0; line-height: 0;">&nbsp;</td>
+              </tr>
+              <tr>
+                <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12px; color: #999999; line-height: 1.5;">
+                  Powered by&#32;<a href="https://lepista.com.br"
+                    style="color: #999999; text-decoration: none;">LepistaBioinformatics</a>
+                </td>
+              </tr>
+
+            </table>
+          </td>
+        </tr>
+
+      </table>
+    </td>
+  </tr>
+</table>
+
+</body>
+</html>
+```
+
+### Per-locale footer strings
+
+| Locale | `support_email` lead-in | Attribution |
+|---|---|---|
+| `en-us` | `Questions?` | `Powered by` |
+| `es` | `&#191;Preguntas?` | `Desarrollado por` |
+| `pt-br` | `D&#250;vidas?` | `Desenvolvido por` — **fixes ET-R17**, currently `Questions?` |
+
+> No child `td` inside the card may declare its own `bgcolor` / `background-color` at the card's
+> outer edge — a square child background would paint over the parent's rounded corners in
+> webkit-based clients. The card table alone owns the white fill.
+
+---
+
+## 3. Component recipes
+
+Each recipe is a `<tr>` fragment for `{% block contenttable %}`. The trailing spacer belongs to the
+component, so blocks compose by concatenation.
+
+### R-A — Body paragraph
+
+```html
+<tr>
+  <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555; line-height: 1.6; padding-bottom: 24px;">
+    … copy, with <strong style="color: #1a1a1a;">emphasis</strong> …
+  </td>
+</tr>
+```
+
+### R-B — Code chip + expiry caption (`activation-code`, `password-reset-initiated`)
+
+```html
+<tr>
+  <td style="padding-bottom: 24px;">
+    <table width="100%" cellpadding="0" cellspacing="0" border="0">
+      <tr>
+        <td align="center" bgcolor="#bae6fd"
+          style="background-color: #bae6fd; border-radius: 6px; padding: 16px 40px; text-align: center;">
+          <span style="font-family: 'JetBrains Mono', 'Courier New', Courier, monospace; font-size: 36px; font-weight: bold; color: #1a1a1a; letter-spacing: 0.18em;">{{ verification_code }}</span>
+        </td>
+      </tr>
+      <tr>
+        <td height="12" style="font-size: 0; line-height: 0;">&nbsp;</td>
+      </tr>
+      <tr>
+        <td align="center"
+          style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12px; color: #999999; text-align: center;">
+          … expiry caption …
+        </td>
+      </tr>
+    </table>
+  </td>
+</tr>
+```
+
+### R-C — Primary CTA button (`magic-link-request`)
+
+```html
+<tr>
+  <td align="center" style="padding-bottom: 24px; text-align: center;">
+    <table cellpadding="0" cellspacing="0" border="0" align="center">
+      <tr>
+        <td bgcolor="#8b5cf6" style="background-color: #8b5cf6; border-radius: 6px;">
+          <a href="{{ magic_link_url }}"
+            style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; font-weight: 600; color: #ffffff; text-decoration: none; display: inline-block; padding: 12px 32px;">
+            … label …
+          </a>
+        </td>
+      </tr>
+    </table>
+  </td>
+</tr>
+```
+
+### R-D — Field box with label (`create-connection-string`, `create-user-account`, `guest-to-subscription-account`)
+
+```html
+<tr>
+  <td style="padding-bottom: 24px;">
+    <table width="100%" cellpadding="0" cellspacing="0" border="0">
+      <tr>
+        <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: 500; color: #333333; padding-bottom: 6px;">
+          … label …
+        </td>
+      </tr>
+      <tr>
+        <td bgcolor="#ffffff"
+          style="background-color: #ffffff; border: 1px solid #dddddd; border-radius: 6px; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555;">{{ value }}</span>
+        </td>
+      </tr>
+    </table>
+  </td>
+</tr>
+```
+
+Monospace variant (`create-user-account` → `account_name`): swap the value `<span>` stack for
+`'JetBrains Mono','Courier New',Courier,monospace`.
+
+### R-E — Copy-paste URL block (`magic-link-request`)
+
+Same geometry as R-D; the label uses the muted-note token because it is helper text, not a field
+name. The URL stays visible as text (ET-R11).
+
+```html
+<tr>
+  <td style="padding-bottom: 24px;">
+    <table width="100%" cellpadding="0" cellspacing="0" border="0">
+      <tr>
+        <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12px; color: #999999; padding-bottom: 6px;">
+          … "button didn't work?" helper …
+        </td>
+      </tr>
+      <tr>
+        <td bgcolor="#ffffff"
+          style="background-color: #ffffff; border: 1px solid #dddddd; border-radius: 6px; padding: 10px 12px;">
+          <span style="font-family: 'JetBrains Mono', 'Courier New', Courier, monospace; font-size: 12px; color: #555555; word-break: break-all;">{{ magic_link_url }}</span>
+        </td>
+      </tr>
+    </table>
+  </td>
+</tr>
+```
+
+### R-F — Info callout (all templates except the two amber ones)
+
+```html
+<tr>
+  <td>
+    <table width="100%" cellpadding="0" cellspacing="0" border="0">
+      <tr>
+        <td width="3" bgcolor="#7dd3fc"
+          style="background-color: #7dd3fc; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
+        <td bgcolor="#f0f9ff"
+          style="background-color: #f0f9ff; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12.5px; color: #4c1d95; line-height: 1.5;">
+            … notice …
+          </span>
+        </td>
+      </tr>
+    </table>
+  </td>
+</tr>
+```
+
+> The 4px radius from `.stakes` is intentionally not applied here: a two-cell rule+fill construct
+> cannot round only its outer corners without a wrapper that Outlook mishandles. The 3px left rule
+> is the load-bearing part of the token. This is the one place the web geometry is approximated —
+> recorded so it is not mistaken for an oversight.
+
+### R-G — Warning callout (`mfa-disable`, `password-reset-confirmation`)
+
+R-F with `#f59e0b` rule, `#fff7ed` fill, `#92400e` text (DEC-4).
+
+### R-H — Spacer row
+
+```html
+<tr>
+  <td height="N" style="font-size: 0; line-height: 0;">&nbsp;</td>
+</tr>
+```
+
+---
+
+## 4. Component usage per template
+
+| Template | Recipes |
+|---|---|
+| `activation-code` | R-A, R-B, R-F |
+| `password-reset-initiated` | R-A, R-B, R-F |
+| `magic-link-request` | R-A, R-C, R-E, R-F |
+| `create-connection-string` | R-A, R-D, R-F |
+| `create-user-account` | R-A, R-D (mono), R-F |
+| `guest-to-subscription-account` | R-A, R-D, R-F |
+| `mfa-activation-start` | R-A, R-F |
+| `mfa-activation-validated` | R-A, R-F |
+| `mfa-disable` | R-A, R-G |
+| `password-reset-confirmation` | R-A, R-G |
+
+Human copy, `{% block %}` names and context variables are carried over verbatim from the current
+files — only markup and inline styles change (except ET-R17's Portuguese footer fix).
+
+---
+
+## 5. Verification harness (scratchpad only — never committed)
+
+Gate checks are blind to template breakage (spec §2), so verification is a rendered-output check.
+
+```
+$SCRATCHPAD/render_email_previews/
+  Cargo.toml        — bin depending on tera only
+  src/main.rs       — Tera::new("<repo>/templates/**/*"), superset context,
+                      render every name matching `*/email/*.jinja`
+                      → $SCRATCHPAD/previews/<locale>/<template>.html
+```
+
+Superset context (union of every variable used across the 10 templates plus the base):
+
+| Variable | Sample |
+|---|---|
+| `domain_name` | `Mycelium` |
+| `domain_url` | `https://mycelium.local` |
+| `support_email` | `support@mycelium.local` |
+| `verification_code` | `481902` |
+| `magic_link_url` | `https://mycelium.local/_adm/beginners/users/magic-link/display?token=eyJhbGciOiJI…` (long, to exercise `word-break`) |
+| `account_name` | `ada.lovelace` |
+| `role_name` | `Subscriptions Manager` |
+| `role_permissions` | `read, write` |
+| `expires_in` | `30 days` |
+
+Also render the `.subject` files, to prove ET-R18 left them intact and they still render.
+
+Static assertions run with `grep` over `templates/*/email/`:
+
+- Zero hits: `<svg`, `<script`, `display:\s*flex`, `Georgia`, `#18181b`, `#f4f4f5`, `#e4e4e7`,
+  `#71717a`, `#a1a1aa`, `#7c3aed`, `#faf5ff`, `text-transform: uppercase` (outside the eyebrow).
+- Locale structural equivalence: the tag + inline-token diff from spec §2 reports `SAME` for all
+  11 files in both `en-us`↔`pt-br` and `en-us`↔`es`.
+
+Manual UAT: open `previews/en-us/*.html` next to `templates/web/magic-link-display.html`.

--- a/.claude/specs/features/email-template-web-parity/spec.md
+++ b/.claude/specs/features/email-template-web-parity/spec.md
@@ -1,0 +1,205 @@
+# Feature Spec: Email Template Web Parity
+
+**Feature:** email-template-web-parity
+**Milestone:** Brand consistency across gateway-rendered surfaces
+**Status:** Implemented (2026-07-29) on `feat/email-template-web-parity` — pending user UAT before commit
+**Created:** 2026-07-29
+**Scope:** Large (33 template files across 3 locales; one design decision applied uniformly).
+Presentation-only — no Rust code, no config, no behaviour change.
+
+---
+
+## 1. Objective
+
+The gateway renders two families of user-facing HTML from the same `TEMPLATES` (Tera) registry:
+
+- **Web pages** — `templates/web/*.html` (4 files): magic-link code display, magic-link error,
+  instance bootstrap claim form, instance bootstrap error.
+- **Transactional e-mails** — `templates/{en-us,es,pt-br}/email/*.jinja` (33 files: 1 base +
+  10 messages, ×3 locales).
+
+They currently look like two unrelated products. The e-mails use a dark zinc header band with a
+Georgia serif wordmark, zinc-neutral surfaces, square corners and a violet `#7c3aed` accent. The
+web pages use a violet-tinted canvas, a white rounded card with a soft shadow, an Inter type stack,
+a violet `#8b5cf6` uppercase brand eyebrow and a sky `#bae6fd` code chip.
+
+Bring the e-mail templates onto the **web templates' visual language** — same palette, same type
+roles, same component geometry — while keeping every construct that e-mail clients actually render.
+
+---
+
+## 2. Verified current state (baseline)
+
+Established by direct inspection on 2026-07-29.
+
+| Concern | Reality |
+|---|---|
+| Template engine | **Tera**, `lazy_static TEMPLATES` in `core/src/settings.rs`. Loads `${TEMPLATES_DIR:-templates}/**/*`. `autoescape_on([".jinja", ".subject"])`. A load failure only `tracing::warn!`s and falls back to `Tera::default()` — broken templates fail at **render** time, not at boot. |
+| E-mail render path | `core/src/use_cases/support/dispatch_notification.rs` — resolves `{locale}/{prefix}.jinja`, falls back to `{prefix}.jinja`, renders body + `.subject` separately. |
+| Locale sets | `templates/en-us/email/`, `templates/es/email/`, `templates/pt-br/email/`. Verified **structurally identical** (same tags, same inline colors, same font stacks) — only the human copy differs. Each child does `{% extends "<locale>/email/base.jinja" %}`, so the three `base.jinja` files must stay separate. |
+| Message templates (×3 locales) | `activation-code`, `create-connection-string`, `create-user-account`, `guest-to-subscription-account`, `magic-link-request`, `mfa-activation-start`, `mfa-activation-validated`, `mfa-disable`, `password-reset-confirmation`, `password-reset-initiated`. |
+| Base blocks | `head`, `title`, `content`, `contenttitle`, `contenttable`. Children only override `title`, `contenttitle`, `contenttable`. |
+| Base context variables | `domain_name`, `support_email` (optional), `domain_url` (optional). |
+| Test coverage of rendered HTML | **None.** The `dispatch_notification` tests assert only `CreateResponseKind::Created` / `is_err()`. `local_transport_sending.rs` tests build a synthetic `Message`, never a rendered template. `cargo fmt --check && cargo build --workspace && cargo test --workspace --all` passes on structurally broken templates. |
+| Gate reach | `ports/api` has `default = ["full"]`; `local-transport` is only enabled by `standalone` / `postgres-only`. So the default workspace test run does **not** even compile the notifier's local-transport tests — the gate is blinder than "no HTML assertions" alone implies. |
+| Web page style tokens | Inter 400/500/600 + JetBrains Mono via Google Fonts `<link>`; canvas `#f5f3ff`; card `#fff` / radius 12px / `0 2px 12px rgba(0,0,0,.08)` / padding `48px 40px` / max-width 420px; brand eyebrow `#8b5cf6` 13px/600 uppercase tracking `.04em`; `h1` `#4c1d95` 22px; body `#555` 14px/1.6; code chip `#bae6fd` radius 6px mono 36px bold tracking `.18em` on `#1a1a1a`; primary button `#8b5cf6` radius 6px 14px/600; input `1px #ddd` radius 6px padding `10px 12px`; info panel `#f0f9ff` + `3px #7dd3fc` left border, text `#4c1d95` 12.5px; error `#ef4444` on `#fef2f2`; muted note `#999` 12px; link/secondary violet `#6d28d9`, hairline `#ddd6fe`. |
+| Web-only mechanisms | Inline SVG badges/icons, `display:flex` layout, `<script>` clipboard + form handling, external stylesheet `<link>`, CSS classes. None of these survive the e-mail client matrix intact. |
+| Known defect in scope | `templates/pt-br/email/base.jinja:106` renders the English string `Questions?` inside the Portuguese footer (`es/` and `en-us/` are correct). |
+| Amber tier | `mfa-disable` and `password-reset-confirmation` use an amber callout (`#f59e0b` / `#fff7ed` / `#92400e`). The web templates have no amber role. |
+
+---
+
+## 3. Decisions (resolved gray areas)
+
+- **DEC-1 — Source of truth is `templates/web/*.html`.** Confirmed by the user. The webapp carries
+  a newer canonical "Lepista DS" (Bricolage/Hanken Grotesk, brand violet `#7b49a0`, cyan
+  neobrutalist hard shadows) and `templates/web/` is stale relative to it. Aligning the e-mails to
+  the **web templates** is the explicit ask; re-basing either surface onto the webapp DS is a
+  separate, later decision.
+- **DEC-2 — No icons in e-mail.** The web pages' inline SVG badges (check, error, eye, copy) are
+  dropped rather than translated. Gmail and Outlook strip inline SVG, leaving a blank hole.
+  Hierarchy is carried by type, color and colored table cells — which is already how the current
+  e-mails work.
+- **DEC-3 — Webfonts as progressive enhancement.** Emit the Google Fonts `<link>` **and** an
+  `@import` in the `<style>` block, and always declare the full fallback stack inline on every text
+  element. Apple Mail / iOS Mail get Inter and JetBrains Mono; Gmail and Outlook fall back to
+  Helvetica/Arial and Courier New with no layout damage.
+- **DEC-4 — Amber is a documented semantic extension.** The warning tier is kept (not remapped to
+  the web's red `#ef4444`), because "MFA disabled" / "your password changed" are security-relevant
+  notices, not errors. Amber is restyled to the web callout *geometry* (3px left rule, 4px radius,
+  12.5px text) while retaining its amber hues, which come from the same Tailwind family the web
+  tokens draw on.
+- **DEC-5 — Graceful degradation over VML.** `border-radius` and `box-shadow` are declared inline
+  and simply ignored by Outlook/Word-engine clients, yielding a square, shadowless card. No VML
+  round-rect or shadow hacks are introduced.
+- **DEC-6 — Three `base.jinja` files stay three files.** Children reference their base by
+  locale-prefixed path. Unifying would mean rewriting 30 `extends` lines to gain one file.
+- **DEC-7 — Verification is a throwaway render harness.** Because the gate checks are blind to
+  template breakage (see §2), correctness is established by rendering all 33 templates to HTML in
+  the scratchpad and opening them. The harness is **not** committed.
+
+---
+
+## 4. Requirements
+
+### P1 — Visual parity of the shell ⭐ MVP
+
+**User Story:** As a recipient of a Mycelium e-mail, I want it to look like the Mycelium pages I
+land on, so that the message is recognisably from the same product and not a phishing attempt.
+
+| ID | Requirement |
+|---|---|
+| ET-R1 | WHEN any e-mail template renders THEN the canvas SHALL be `#f5f3ff` and the message SHALL sit on a white card with `border-radius: 12px` and `box-shadow: 0 2px 12px rgba(0,0,0,0.08)` declared inline. |
+| ET-R2 | WHEN the base template renders THEN the dark `#18181b` header band and the Georgia serif wordmark SHALL be gone, replaced by the web brand eyebrow — `{{ domain_name }}` in `#8b5cf6`, 13px, weight 600, uppercase, `letter-spacing: 0.04em` — rendered inside the card. |
+| ET-R3 | WHEN the base template renders `contenttitle` THEN the heading SHALL use the Inter-first sans stack at 22px in `#4c1d95`, and the 2px violet underline rule below it SHALL be removed (the web pages have no such rule). |
+| ET-R4 | WHEN any body copy renders THEN it SHALL use the Inter-first sans stack at 14px, `line-height: 1.6`, color `#555`; inline `<strong>` emphasis SHALL use `#1a1a1a` instead of `#18181b`. |
+| ET-R5 | WHEN the footer renders THEN it SHALL sit inside the card below a 1px `#ddd6fe` hairline, use 12px `#999` muted note styling, and render `support_email` / `domain_url` links in `#6d28d9`. The zinc `#f4f4f5` footer band with `#e4e4e7` borders SHALL be gone. |
+| ET-R6 | WHEN the base `<head>` renders THEN it SHALL include the Google Fonts `<link>` and `@import` for Inter + JetBrains Mono, AND every text-bearing element SHALL still carry a complete inline `font-family` fallback stack. |
+| ET-R7 | WHEN a template is rendered by a Word-engine client (Outlook desktop) THEN the layout SHALL remain intact with square corners and no shadow — no VML is introduced (DEC-5). |
+
+**Independent test:** render `activation-code` for all three locales, open in a browser, and compare
+side by side with `templates/web/magic-link-display.html`. Canvas, card, eyebrow, heading and body
+type must match.
+
+### P1 — Visual parity of the content components ⭐ MVP
+
+**User Story:** As a recipient, I want the code, button and callout in the e-mail to look exactly
+like the ones on the page I'm being sent to, so the flow feels continuous.
+
+| ID | Requirement |
+|---|---|
+| ET-R8 | WHEN a verification code renders (`activation-code`, `password-reset-initiated`) THEN the chip SHALL be `#bae6fd` with `border-radius: 6px`, JetBrains-Mono-first stack, 36px bold, `letter-spacing: 0.18em`, color `#1a1a1a`, centred — replacing the `#f4f4f5` box with the `#e4e4e7` border. |
+| ET-R9 | WHEN the expiry caption below a code renders THEN it SHALL use the web muted-note token (12px, `#999`). |
+| ET-R10 | WHEN the CTA button renders (`magic-link-request`) THEN it SHALL be `#8b5cf6` with `border-radius: 6px`, white 14px/600 label in the Inter-first stack, padding `12px 32px`, and SHALL NOT be uppercase — replacing the square uppercase `#7c3aed` button. |
+| ET-R11 | WHEN the copy-paste URL block renders (`magic-link-request`) THEN it SHALL adopt the web input token — `1px solid #ddd`, `border-radius: 6px`, padding `10px 12px`, white background — with the URL in the JetBrains-Mono-first stack at 12px, `word-break: break-all`. The visible URL SHALL remain present as text (it is what makes the standalone stub transport readable). |
+| ET-R12 | WHEN a labeled value renders (`create-connection-string`, `create-user-account`, `guest-to-subscription-account`) THEN the label SHALL use the web label token (13px, weight 500, `#333`) and the value SHALL sit in the web input token box; monospace values keep the JetBrains-Mono-first stack. |
+| ET-R13 | WHEN an informational callout renders THEN it SHALL use the web info-panel token — background `#f0f9ff`, 3px `#7dd3fc` left rule, `border-radius: 4px`, text `#4c1d95` at 12.5px/1.5 — replacing the violet `#faf5ff` / `#7c3aed` callout. |
+| ET-R14 | WHEN a warning callout renders (`mfa-disable`, `password-reset-confirmation`) THEN it SHALL keep the amber hues (`#fff7ed` fill, `#f59e0b` rule, `#92400e` text) but adopt the web callout geometry from ET-R13 (DEC-4). |
+| ET-R15 | WHEN any template renders THEN it SHALL contain no `<svg>`, no `<script>`, no `display:flex`, and no layout that depends on CSS classes or the external stylesheet (DEC-2, DEC-3). |
+
+**Independent test:** render `magic-link-request` (button + URL block + info callout),
+`activation-code` (code chip), `create-user-account` (labeled value) and `mfa-disable` (amber
+callout) and confirm each component against its web counterpart.
+
+### P2 — Locale integrity
+
+| ID | Requirement |
+|---|---|
+| ET-R16 | WHEN the three locales are compared THEN they SHALL remain structurally identical — same tags, same inline tokens — differing only in human copy. |
+| ET-R17 | WHEN the `pt-br` footer renders THEN the support-e-mail lead-in SHALL be Portuguese (`Dúvidas?`), not the current English `Questions?`. |
+| ET-R18 | WHEN this feature completes THEN every `.subject` file SHALL be byte-identical to its current content (subjects carry no styling). |
+
+**Independent test:** the structural-equivalence diff from §2 (tags + inline colors + font stacks)
+must report `SAME` for all 11 files across `en-us` vs `pt-br` and `en-us` vs `es`.
+
+### P2 — Render verification
+
+| ID | Requirement |
+|---|---|
+| ET-R19 | WHEN all 33 templates are rendered with a superset context THEN every render SHALL succeed (no Tera syntax, inheritance or undefined-variable failure). |
+| ET-R20 | WHEN the feature is delivered THEN no render harness, preview script or fixture SHALL be committed to the repository (DEC-7). |
+
+**Independent test:** the scratchpad harness exits 0 for 33/33 templates and `git status` shows only
+`templates/{en-us,es,pt-br}/email/*.jinja` as modified.
+
+---
+
+## 5. Out of scope
+
+| Item | Reason |
+|---|---|
+| Changing `templates/web/*.html` | They are the reference, not the target. |
+| Adopting the webapp's Lepista DS | DEC-1 — separate decision, would move both surfaces. |
+| Adding new e-mail templates or new context variables | Presentation-only refactor. |
+| Rust changes (`settings.rs`, `dispatch_notification.rs`, notifier adapters) | No behaviour change is required. |
+| `.subject` files | ET-R18 — no styling to align. |
+| Plain-text (`multipart/alternative`) e-mail bodies | The `Message` DTO carries a single HTML `body`; adding a text part is a separate feature. |
+| Dark-mode e-mail (`prefers-color-scheme`) | The web reference has no dark variant. |
+| New locales | Out of scope. |
+| Committing a preview/render harness | ET-R20 / DEC-7. |
+| VML round-rect / shadow shims for Outlook | DEC-5. |
+
+---
+
+## 6. Requirement traceability
+
+| ID | Story | Phase | Status |
+|---|---|---|---|
+| ET-R1 … ET-R7 | P1: Shell parity | T2, T3 | Implemented |
+| ET-R8 … ET-R15 | P1: Component parity | T4–T7, T8 | Implemented |
+| ET-R16 … ET-R18 | P2: Locale integrity | T3, T8 | Implemented |
+| ET-R19 … ET-R20 | P2: Render verification | T1, T8, T9 | Implemented |
+
+**Coverage:** 20 total, 20 mapped to tasks, 0 unmapped
+
+### Verification results (2026-07-29)
+
+| Check | Result |
+|---|---|
+| Harness render | 64/64 PASS — 30 e-mail bodies + 30 `.subject` + 4 `web/*.html` reference pages (the 3 abstract `base.jinja` render only through children) |
+| Banned tokens under `templates/*/email/` | 0 hits for `<svg`, `<script`, `display:flex`, `Georgia`, `#18181b`, `#f4f4f5`, `#e4e4e7`, `#71717a`, `#a1a1aa`, `#7c3aed`, `#faf5ff`, `#3f3f46`, `BlinkMacSystemFont` |
+| `text-transform: uppercase` | exactly 3 — the brand eyebrow in each `base.jinja` |
+| Locale structural equivalence | `SAME` for all 11 files, `en-us`↔`pt-br` and `en-us`↔`es` (diff over tags, colors, font stacks, font weights, paddings, radii, spacer heights, letter-spacing) |
+| `.subject` files | byte-identical to baseline renders (ET-R18) |
+| Diff scope | 33 files, all `templates/{en-us,es,pt-br}/email/*.jinja`; no Rust, no `templates/web/`, no harness committed |
+| `cargo fmt --all -- --check` | pass |
+| `cargo build --workspace` | pass |
+| `TEMPLATES_DIR=$PWD/templates cargo test --workspace --all` | pass — 331 + 37 + 32 + 20 + … / 0 failed |
+
+**Incidental fixes** (pre-existing inconsistencies removed by normalising to the recipes):
+`es/magic-link-request` URL box padding was `12px 16px` while the other locales used `10px 14px`;
+`create-connection-string` / `create-user-account` value spans carried `font-weight: 600` in
+`en-us`/`pt-br` but not in `es`.
+
+---
+
+## 7. Success criteria
+
+- [ ] All 33 `.jinja` files render without error via the scratchpad harness (ET-R19).
+- [ ] An e-mail and a web page opened side by side share canvas, card, brand eyebrow, heading,
+      body type, code chip, button and callout treatments (ET-R1–R14).
+- [ ] Zero `<svg>`, `<script>` or `display:flex` occurrences under `templates/*/email/` (ET-R15).
+- [ ] Structural-equivalence diff reports `SAME` for all 11 files in both locale pairs (ET-R16).
+- [ ] `git diff --stat` touches only `templates/{en-us,es,pt-br}/email/*.jinja` (ET-R20).
+- [ ] `cargo fmt --all -- --check`, `cargo build --workspace`, `cargo test --workspace --all` pass
+      — necessary but, per §2, **not sufficient**; the harness render is the real gate.

--- a/.claude/specs/features/email-template-web-parity/tasks.md
+++ b/.claude/specs/features/email-template-web-parity/tasks.md
@@ -1,0 +1,182 @@
+# Tasks: Email Template Web Parity
+
+Presentation-only. Every task consumes the token map and recipes in `design.md` §1–§3 — no task
+invents styling. `[P]` = parallelizable with other `[P]` tasks in the same group.
+
+**Working rule for every task:** touch only `templates/{en-us,es,pt-br}/email/*.jinja`. Never
+`.subject` files (ET-R18), never `templates/web/`, never Rust.
+
+---
+
+## T0 — Branch
+
+- **Where:** `modules/mycelium-api-gateway/` (submodule, currently on `develop`).
+- **Done when:** work happens on `feat/email-template-web-parity` cut from `develop`. Never commit
+  to `develop` directly; integration is via PR.
+
+---
+
+## T1 — Render harness (scratchpad, throwaway)
+
+- **Where:** `$SCRATCHPAD/render_email_previews/` — **outside the repo**.
+- **Depends on:** T0.
+- **Reuses:** the `tera` version already pinned in the workspace; the superset context table in
+  `design.md` §5.
+- **Done when:** `cargo run` renders all 33 `*/email/*.jinja` **plus** the 30 `.subject` files with
+  the superset context, writes `previews/<locale>/<template>.html`, prints a per-template
+  PASS/FAIL line, and exits non-zero if any render fails. Baseline run against the **current**
+  templates is 60/60 PASS (30 bodies + 30 subjects; the 3 `base.jinja` are abstract and render only
+  through their children) — this proves the harness itself works before anything is edited. The
+  final run also renders the 4 `web/*.html` reference pages for side-by-side comparison, for 64/64.
+- **Satisfies:** ET-R19, ET-R20 (nothing under the repo).
+
+---
+
+## T2 — Base template, canonical locale
+
+- **Where:** `templates/en-us/email/base.jinja`.
+- **Depends on:** T1.
+- **Reuses:** `design.md` §2 verbatim.
+- **Done when:** the file matches `design.md` §2 with `lang="en"` and the `en-us` footer strings;
+  blocks (`head`, `title`, `content`, `contenttitle`, `contenttable`) and context variables
+  (`domain_name`, `support_email`, `domain_url`) are unchanged; the dark header band, Georgia stack,
+  violet title rule and zinc footer band are gone. Harness re-render: all 11 `en-us` templates
+  still PASS (children are untouched and still inherit).
+- **Satisfies:** ET-R1, ET-R2, ET-R3, ET-R5, ET-R6, ET-R7.
+
+---
+
+## T3 — Base template, `es` and `pt-br`
+
+- **Where:** `templates/es/email/base.jinja`, `templates/pt-br/email/base.jinja`.
+- **Depends on:** T2.
+- **Reuses:** T2's output; the per-locale footer string table in `design.md` §2.
+- **Done when:** both files are structurally identical to T2 — same tags, same inline tokens, same
+  block names, same spacer heights — with exactly three known text deltas: `lang`
+  (`es` / `pt-BR`), the support lead-in, and the attribution string. **`pt-br` renders
+  `D&#250;vidas?` instead of the current English `Questions?`**. Harness re-render: 33/33 PASS.
+- **Satisfies:** ET-R16, ET-R17.
+
+---
+
+## Content group — all three locales per task
+
+Each task rewrites `{% block contenttable %}` for its templates in **all three locales at once**,
+so the three files stay structurally identical by construction (ET-R16). Human copy, block names
+and context variables are carried over verbatim from the existing files.
+
+### T4 [P] — Code-chip templates
+
+- **Where:** `templates/{en-us,es,pt-br}/email/activation-code.jinja`,
+  `templates/{en-us,es,pt-br}/email/password-reset-initiated.jinja` (6 files).
+- **Depends on:** T3.
+- **Reuses:** recipes R-A, R-B, R-F.
+- **Done when:** the code sits in the `#bae6fd` radius-6px chip with the JetBrains-Mono-first stack
+  at 36px bold / `.18em` on `#1a1a1a`; the expiry caption uses the muted-note token; the closing
+  notice is the sky info callout. No `#f4f4f5` box, no `#e4e4e7` border, no `#faf5ff` callout
+  remains in these files. Harness re-render PASSes for all 6.
+- **Satisfies:** ET-R4, ET-R8, ET-R9, ET-R13.
+
+### T5 [P] — Magic-link request
+
+- **Where:** `templates/{en-us,es,pt-br}/email/magic-link-request.jinja` (3 files).
+- **Depends on:** T3.
+- **Reuses:** recipes R-A, R-C, R-E, R-F.
+- **Done when:** the CTA is the `#8b5cf6` radius-6px button with a non-uppercase 14px/600 white
+  label; the copy-paste block uses the field-box token with the URL **visible as text** and
+  `word-break: break-all`; the closing notice is the sky info callout. Harness preview with the long
+  sample URL shows no horizontal overflow of the 600px card, and — since Tera autoescapes `.jinja` —
+  the *visible* URL text must still be a URL a user can select and paste (a pre-existing condition
+  of the current templates; the preview must surface it, not hide it).
+- **Satisfies:** ET-R4, ET-R10, ET-R11, ET-R13.
+
+### T6 [P] — Field-box templates
+
+- **Where:** `templates/{en-us,es,pt-br}/email/create-connection-string.jinja`,
+  `create-user-account.jinja`, `guest-to-subscription-account.jinja` (9 files).
+- **Depends on:** T3.
+- **Reuses:** recipes R-A, R-D (mono variant for `account_name`), R-F.
+- **Done when:** each labeled value uses the 13px/500 `#333` label plus the white
+  `1px #dddddd` radius-6px field box; `account_name` keeps a monospace value stack; the closing
+  notice is the sky info callout. The 11px uppercase `#71717a` label treatment is gone.
+- **Satisfies:** ET-R4, ET-R12, ET-R13.
+
+### T7 [P] — Notice-only templates
+
+- **Where:** `templates/{en-us,es,pt-br}/email/mfa-activation-start.jinja`,
+  `mfa-activation-validated.jinja`, `mfa-disable.jinja`,
+  `password-reset-confirmation.jinja` (12 files).
+- **Depends on:** T3.
+- **Reuses:** recipes R-A, R-F (first two templates), R-G (`mfa-disable`,
+  `password-reset-confirmation`).
+- **Done when:** body copy uses the web body token; `mfa-activation-start` and
+  `mfa-activation-validated` close with the sky info callout; `mfa-disable` and
+  `password-reset-confirmation` keep the amber tier with the R-G geometry.
+- **Satisfies:** ET-R4, ET-R13, ET-R14.
+
+---
+
+## T8 — Static assertion sweep
+
+- **Where:** read-only over `templates/*/email/`.
+- **Depends on:** T4, T5, T6, T7.
+- **Reuses:** the grep list and the locale-equivalence diff in `design.md` §5.
+- **Done when:**
+  - zero hits for `<svg`, `<script`, `display:\s*flex`, `Georgia`, `#18181b`, `#f4f4f5`,
+    `#e4e4e7`, `#71717a`, `#a1a1aa`, `#7c3aed`, `#faf5ff`;
+  - the only `text-transform: uppercase` occurrences are the three brand eyebrows — this holds only
+    if T6 dropped the 11px uppercase labels in the three field-box templates and T5 dropped it from
+    the CTA, so verify by grep after those tasks rather than assuming;
+  - the tag + inline-token diff reports `SAME` for all 11 files in `en-us`↔`pt-br` **and**
+    `en-us`↔`es`;
+  - `git diff --name-only` lists exactly 33 paths, all under `templates/{en-us,es,pt-br}/email/`
+    and all `.jinja`.
+- **Satisfies:** ET-R15, ET-R16, ET-R18, ET-R20.
+
+---
+
+## T9 — Gate checks + UAT package
+
+- **Where:** `modules/mycelium-api-gateway/`.
+- **Depends on:** T8.
+- **Done when:**
+  - harness reports 64/64 PASS (30 bodies + 30 subjects + 4 web reference pages);
+  - `cargo fmt --all -- --check`, `cargo build --workspace`, `cargo test --workspace --all` pass
+    — recorded as necessary-but-insufficient per spec §2;
+  - the preview directory path is handed to the user with a short side-by-side checklist (canvas,
+    card, eyebrow, heading, body, code chip, button, field box, info callout, amber callout,
+    footer) against `templates/web/magic-link-display.html` and
+    `templates/web/instance-bootstrap-claim.html`.
+- **Satisfies:** ET-R19, spec §7.
+
+---
+
+## T10 — Commit (blocked on user approval)
+
+- **Depends on:** T9 **and** explicit user approval after UAT (repo rule: no commit before manual
+  testing and sign-off).
+- **Done when:** one commit on `feat/email-template-web-parity` inside the submodule, then a PR into
+  `develop` (never a direct push to a protected branch). The monorepo pointer commit follows only
+  after the submodule commit is pushed.
+
+---
+
+## Traceability
+
+| Requirement | Task |
+|---|---|
+| ET-R1, ET-R2, ET-R3, ET-R5, ET-R6, ET-R7 | T2 |
+| ET-R4 | T4, T5, T6, T7 |
+| ET-R8, ET-R9 | T4 |
+| ET-R10, ET-R11 | T5 |
+| ET-R12 | T6 |
+| ET-R13 | T4, T5, T6, T7 |
+| ET-R14 | T7 |
+| ET-R15 | T8 |
+| ET-R16 | T3, T8 |
+| ET-R17 | T3 |
+| ET-R18 | T8 |
+| ET-R19 | T1, T9 |
+| ET-R20 | T1, T8 |
+
+**Coverage:** 20 requirements, 20 mapped, 0 unmapped.

--- a/templates/en-us/email/activation-code.jinja
+++ b/templates/en-us/email/activation-code.jinja
@@ -6,8 +6,8 @@
 
 {% block contenttable %}
 <tr>
-  <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #3f3f46; line-height: 1.6; padding-bottom: 20px;">
-    Thanks for registering on <strong style="color: #18181b;">{{ domain_name }}</strong>.
+  <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555; line-height: 1.6; padding-bottom: 24px;">
+    Thanks for registering on <strong style="color: #1a1a1a;">{{ domain_name }}</strong>.
     Enter the code below to confirm your email and finish setting up your account.
   </td>
 </tr>
@@ -15,16 +15,17 @@
   <td style="padding-bottom: 24px;">
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td bgcolor="#f4f4f5"
-          style="background-color: #f4f4f5; border: 1px solid #e4e4e7; padding: 24px; text-align: center;">
-          <span style="font-family: 'Courier New', Courier, monospace; font-size: 36px; font-weight: bold; color: #18181b; letter-spacing: 0.15em;">{{ verification_code }}</span>
+        <td align="center" bgcolor="#bae6fd"
+          style="background-color: #bae6fd; border-radius: 6px; padding: 16px 40px; text-align: center;">
+          <span style="font-family: 'JetBrains Mono', 'Courier New', Courier, monospace; font-size: 36px; font-weight: bold; color: #1a1a1a; letter-spacing: 0.18em;">{{ verification_code }}</span>
         </td>
       </tr>
       <tr>
-        <td height="8" style="font-size: 0; line-height: 0;">&nbsp;</td>
+        <td height="12" style="font-size: 0; line-height: 0;">&nbsp;</td>
       </tr>
       <tr>
-        <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #71717a; text-align: center;">
+        <td align="center"
+          style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12px; color: #999999; text-align: center;">
           Expires in 15 minutes.
         </td>
       </tr>
@@ -35,11 +36,11 @@
   <td>
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td width="3" bgcolor="#7c3aed"
-          style="background-color: #7c3aed; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
-        <td bgcolor="#faf5ff"
-          style="background-color: #faf5ff; padding: 10px 14px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #6d28d9;">
+        <td width="3" bgcolor="#7dd3fc"
+          style="background-color: #7dd3fc; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
+        <td bgcolor="#f0f9ff"
+          style="background-color: #f0f9ff; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12.5px; color: #4c1d95; line-height: 1.5;">
             Didn't register on {{ domain_name }}? You can safely ignore this email.
           </span>
         </td>

--- a/templates/en-us/email/base.jinja
+++ b/templates/en-us/email/base.jinja
@@ -7,104 +7,93 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="x-apple-disable-message-reformatting" />
   <title>{% block title %}{% endblock title %} — {{ domain_name }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="crossorigin" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;700&amp;display=swap" rel="stylesheet" />
   <style type="text/css">
+    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;700&display=swap');
     body, table, td, p, a, span { -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }
     table, td { mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse; }
     img { -ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none; }
-    body { margin: 0 !important; padding: 0 !important; background-color: #f4f4f5; }
+    body { margin: 0 !important; padding: 0 !important; background-color: #f5f3ff; }
   </style>
   {% endblock head %}
 </head>
 
-<body style="margin: 0; padding: 0; background-color: #f4f4f5;">
+<body style="margin: 0; padding: 0; background-color: #f5f3ff;">
 
 <!-- Outer wrapper -->
-<table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f4f4f5"
-  style="background-color: #f4f4f5;">
+<table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f5f3ff"
+  style="background-color: #f5f3ff;">
   <tr>
     <td align="center" style="padding: 40px 16px;">
 
-      <!-- Card: 600px max -->
-      <table width="600" cellpadding="0" cellspacing="0" border="0"
-        style="max-width: 600px; width: 100%;">
+      <!-- Card: 600px max, white, rounded, soft shadow. The card table alone owns the
+           white fill — no inner cell may set a background at the card edge, or it
+           would paint over the rounded corners. -->
+      <table width="600" cellpadding="0" cellspacing="0" border="0" bgcolor="#ffffff"
+        style="max-width: 600px; width: 100%; background-color: #ffffff; border-radius: 12px; box-shadow: 0 2px 12px rgba(0,0,0,0.08);">
 
-        <!-- ── HEADER ── -->
         <tr>
-          <td bgcolor="#18181b" style="background-color: #18181b; padding: 0;">
+          <td style="padding: 40px 40px 0;">
+
+            <!-- Brand eyebrow -->
             <table width="100%" cellpadding="0" cellspacing="0" border="0">
               <tr>
-                <!-- Violet accent bar -->
-                <td width="4" bgcolor="#7c3aed"
-                  style="background-color: #7c3aed; width: 4px; font-size: 0; line-height: 0;">&#8203;</td>
-                <!-- Wordmark -->
-                <td style="padding: 24px 32px;">
-                  <span
-                    style="font-family: Georgia, 'Times New Roman', Times, serif; font-size: 22px; font-weight: bold; color: #ffffff; letter-spacing: -0.02em;">{{ domain_name }}</span>
+                <td
+                  style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: 600; color: #8b5cf6; letter-spacing: 0.04em; text-transform: uppercase;">
+                  {{ domain_name }}
                 </td>
+              </tr>
+              <tr>
+                <td height="20" style="font-size: 0; line-height: 0;">&nbsp;</td>
               </tr>
             </table>
-          </td>
-        </tr>
-
-        <!-- ── CONTENT ── -->
-        <tr>
-          <td bgcolor="#ffffff"
-            style="background-color: #ffffff; border-left: 1px solid #e4e4e7; border-right: 1px solid #e4e4e7;">
 
             {% block content %}
-            <!-- Inner padding cell -->
+            <!-- Title -->
             <table width="100%" cellpadding="0" cellspacing="0" border="0">
               <tr>
-                <td style="padding: 36px 40px 0;">
-
-                  <!-- Title -->
-                  <table width="100%" cellpadding="0" cellspacing="0" border="0">
-                    <tr>
-                      <td>
-                        <h1
-                          style="margin: 0; font-family: Georgia, 'Times New Roman', Times, serif; font-size: 20px; font-weight: bold; color: #18181b; letter-spacing: -0.01em; line-height: 1.3;">
-                          {% block contenttitle %}{% endblock contenttitle %}
-                        </h1>
-                      </td>
-                    </tr>
-                    <!-- Violet underline (table row, not CSS border) -->
-                    <tr>
-                      <td height="2" bgcolor="#7c3aed"
-                        style="background-color: #7c3aed; height: 2px; font-size: 0; line-height: 0; padding-top: 12px;">&#8203;</td>
-                    </tr>
-                    <tr>
-                      <td height="28" style="font-size: 0; line-height: 0;">&nbsp;</td>
-                    </tr>
-                  </table>
-
-                  <!-- Body content -->
-                  <table width="100%" cellpadding="0" cellspacing="0" border="0">
-                    {% block contenttable %}{% endblock contenttable %}
-                  </table>
-
+                <td>
+                  <h1
+                    style="margin: 0; font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 22px; font-weight: 600; color: #4c1d95; line-height: 1.3;">
+                    {% block contenttitle %}{% endblock contenttitle %}
+                  </h1>
                 </td>
               </tr>
               <tr>
-                <td height="40" style="font-size: 0; line-height: 0;">&nbsp;</td>
+                <td height="20" style="font-size: 0; line-height: 0;">&nbsp;</td>
               </tr>
+            </table>
+
+            <!-- Body content -->
+            <table width="100%" cellpadding="0" cellspacing="0" border="0">
+              {% block contenttable %}{% endblock contenttable %}
             </table>
             {% endblock content %}
 
           </td>
         </tr>
 
-        <!-- ── FOOTER ── -->
+        <!-- ── FOOTER (inside the card, below a hairline) ── -->
         <tr>
-          <td bgcolor="#f4f4f5"
-            style="background-color: #f4f4f5; padding: 20px 40px; border: 1px solid #e4e4e7; border-top: none;">
+          <td style="padding: 28px 40px 32px;">
             <table width="100%" cellpadding="0" cellspacing="0" border="0">
+
+              <tr>
+                <td height="1" bgcolor="#ddd6fe"
+                  style="background-color: #ddd6fe; height: 1px; font-size: 0; line-height: 0;">&#8203;</td>
+              </tr>
+              <tr>
+                <td height="16" style="font-size: 0; line-height: 0;">&nbsp;</td>
+              </tr>
 
               {% if support_email %}
               <tr>
                 <td
-                  style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #71717a; line-height: 1.6; padding-bottom: 4px;">
+                  style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12px; color: #999999; line-height: 1.6;">
                   Questions?&#32;<a href="mailto:{{ support_email }}"
-                    style="color: #7c3aed; text-decoration: none;">{{ support_email }}</a>
+                    style="color: #6d28d9; text-decoration: none;">{{ support_email }}</a>
                 </td>
               </tr>
               {% endif %}
@@ -112,24 +101,20 @@
               {% if domain_url %}
               <tr>
                 <td
-                  style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #71717a; line-height: 1.6; padding-bottom: 12px;">
-                  <a href="{{ domain_url }}" style="color: #7c3aed; text-decoration: none;">{{ domain_url }}</a>
+                  style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12px; color: #999999; line-height: 1.6;">
+                  <a href="{{ domain_url }}" style="color: #6d28d9; text-decoration: none;">{{ domain_url }}</a>
                 </td>
               </tr>
               {% endif %}
 
               <tr>
-                <td height="1" bgcolor="#e4e4e7"
-                  style="background-color: #e4e4e7; height: 1px; font-size: 0; line-height: 0;">&#8203;</td>
-              </tr>
-              <tr>
-                <td height="12" style="font-size: 0; line-height: 0;">&nbsp;</td>
+                <td height="8" style="font-size: 0; line-height: 0;">&nbsp;</td>
               </tr>
               <tr>
                 <td
-                  style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 11px; color: #a1a1aa; line-height: 1.5;">
+                  style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12px; color: #999999; line-height: 1.5;">
                   Powered by&#32;<a href="https://lepista.com.br"
-                    style="color: #a1a1aa; text-decoration: none;">LepistaBioinformatics</a>
+                    style="color: #999999; text-decoration: none;">LepistaBioinformatics</a>
                 </td>
               </tr>
 

--- a/templates/en-us/email/create-connection-string.jinja
+++ b/templates/en-us/email/create-connection-string.jinja
@@ -6,7 +6,7 @@
 
 {% block contenttable %}
 <tr>
-  <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #3f3f46; line-height: 1.6; padding-bottom: 20px;">
+  <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555; line-height: 1.6; padding-bottom: 24px;">
     A new connection string was just added to your account.
   </td>
 </tr>
@@ -14,14 +14,14 @@
   <td style="padding-bottom: 24px;">
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 11px; font-weight: 600; color: #71717a; text-transform: uppercase; letter-spacing: 0.05em; padding-bottom: 4px;">
+        <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: 500; color: #333333; padding-bottom: 6px;">
           Expires in
         </td>
       </tr>
       <tr>
-        <td bgcolor="#f4f4f5"
-          style="background-color: #f4f4f5; border: 1px solid #e4e4e7; padding: 12px 16px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; font-weight: 600; color: #18181b;">{{ expires_in }}</span>
+        <td bgcolor="#ffffff"
+          style="background-color: #ffffff; border: 1px solid #dddddd; border-radius: 6px; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555;">{{ expires_in }}</span>
         </td>
       </tr>
     </table>
@@ -31,11 +31,11 @@
   <td>
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td width="3" bgcolor="#7c3aed"
-          style="background-color: #7c3aed; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
-        <td bgcolor="#faf5ff"
-          style="background-color: #faf5ff; padding: 10px 14px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #6d28d9;">
+        <td width="3" bgcolor="#7dd3fc"
+          style="background-color: #7dd3fc; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
+        <td bgcolor="#f0f9ff"
+          style="background-color: #f0f9ff; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12.5px; color: #4c1d95; line-height: 1.5;">
             Wasn't you? Contact your administrator right away.
           </span>
         </td>

--- a/templates/en-us/email/create-user-account.jinja
+++ b/templates/en-us/email/create-user-account.jinja
@@ -6,7 +6,7 @@
 
 {% block contenttable %}
 <tr>
-  <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #3f3f46; line-height: 1.6; padding-bottom: 20px;">
+  <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555; line-height: 1.6; padding-bottom: 24px;">
     Your account on {{ domain_name }} has been set up and is ready to use.
   </td>
 </tr>
@@ -14,14 +14,14 @@
   <td style="padding-bottom: 24px;">
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 11px; font-weight: 600; color: #71717a; text-transform: uppercase; letter-spacing: 0.05em; padding-bottom: 4px;">
+        <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: 500; color: #333333; padding-bottom: 6px;">
           Username
         </td>
       </tr>
       <tr>
-        <td bgcolor="#f4f4f5"
-          style="background-color: #f4f4f5; border: 1px solid #e4e4e7; padding: 12px 16px;">
-          <span style="font-family: 'Courier New', Courier, monospace; font-size: 14px; font-weight: 600; color: #18181b;">{{ account_name }}</span>
+        <td bgcolor="#ffffff"
+          style="background-color: #ffffff; border: 1px solid #dddddd; border-radius: 6px; padding: 10px 12px;">
+          <span style="font-family: 'JetBrains Mono', 'Courier New', Courier, monospace; font-size: 14px; color: #555555;">{{ account_name }}</span>
         </td>
       </tr>
     </table>
@@ -31,11 +31,11 @@
   <td>
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td width="3" bgcolor="#7c3aed"
-          style="background-color: #7c3aed; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
-        <td bgcolor="#faf5ff"
-          style="background-color: #faf5ff; padding: 10px 14px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #6d28d9;">
+        <td width="3" bgcolor="#7dd3fc"
+          style="background-color: #7dd3fc; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
+        <td bgcolor="#f0f9ff"
+          style="background-color: #f0f9ff; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12.5px; color: #4c1d95; line-height: 1.5;">
             Weren't expecting this? Reach out to your system administrator.
           </span>
         </td>

--- a/templates/en-us/email/guest-to-subscription-account.jinja
+++ b/templates/en-us/email/guest-to-subscription-account.jinja
@@ -6,23 +6,23 @@
 
 {% block contenttable %}
 <tr>
-  <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #3f3f46; line-height: 1.6; padding-bottom: 20px;">
-    You've been invited to join <strong style="color: #18181b;">{{ account_name }}</strong>
-    as a <strong style="color: #18181b;">{{ role_name }}</strong>.
+  <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555; line-height: 1.6; padding-bottom: 24px;">
+    You've been invited to join <strong style="color: #1a1a1a;">{{ account_name }}</strong>
+    as a <strong style="color: #1a1a1a;">{{ role_name }}</strong>.
   </td>
 </tr>
 <tr>
   <td style="padding-bottom: 24px;">
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 11px; font-weight: 600; color: #71717a; text-transform: uppercase; letter-spacing: 0.05em; padding-bottom: 4px;">
+        <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: 500; color: #333333; padding-bottom: 6px;">
           Role permissions
         </td>
       </tr>
       <tr>
-        <td bgcolor="#f4f4f5"
-          style="background-color: #f4f4f5; border: 1px solid #e4e4e7; padding: 12px 16px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #18181b;">{{ role_permissions }}</span>
+        <td bgcolor="#ffffff"
+          style="background-color: #ffffff; border: 1px solid #dddddd; border-radius: 6px; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555;">{{ role_permissions }}</span>
         </td>
       </tr>
     </table>
@@ -32,11 +32,11 @@
   <td>
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td width="3" bgcolor="#7c3aed"
-          style="background-color: #7c3aed; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
-        <td bgcolor="#faf5ff"
-          style="background-color: #faf5ff; padding: 10px 14px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #6d28d9;">
+        <td width="3" bgcolor="#7dd3fc"
+          style="background-color: #7dd3fc; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
+        <td bgcolor="#f0f9ff"
+          style="background-color: #f0f9ff; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12.5px; color: #4c1d95; line-height: 1.5;">
             Weren't expecting this invitation? Let your system administrator know.
           </span>
         </td>

--- a/templates/en-us/email/magic-link-request.jinja
+++ b/templates/en-us/email/magic-link-request.jinja
@@ -6,19 +6,19 @@
 
 {% block contenttable %}
 <tr>
-  <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #3f3f46; line-height: 1.6; padding-bottom: 20px;">
+  <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555; line-height: 1.6; padding-bottom: 24px;">
     Here's your login link for {{ domain_name }}. Click the button and you'll
     see a 6-digit code to enter in the app — valid for
-    <strong style="color: #18181b;">15 minutes</strong>, one use only.
+    <strong style="color: #1a1a1a;">15 minutes</strong>, one use only.
   </td>
 </tr>
 <tr>
-  <td style="padding-bottom: 24px;">
-    <table cellpadding="0" cellspacing="0" border="0">
+  <td align="center" style="padding-bottom: 24px; text-align: center;">
+    <table cellpadding="0" cellspacing="0" border="0" align="center">
       <tr>
-        <td bgcolor="#7c3aed" style="background-color: #7c3aed;">
+        <td bgcolor="#8b5cf6" style="background-color: #8b5cf6; border-radius: 6px;">
           <a href="{{ magic_link_url }}"
-            style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; font-weight: 600; color: #ffffff; text-decoration: none; display: inline-block; padding: 12px 32px; text-transform: uppercase;">
+            style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; font-weight: 600; color: #ffffff; text-decoration: none; display: inline-block; padding: 12px 32px;">
             View Login Code
           </a>
         </td>
@@ -27,17 +27,17 @@
   </td>
 </tr>
 <tr>
-  <td style="padding-bottom: 20px;">
+  <td style="padding-bottom: 24px;">
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #71717a; padding-bottom: 6px;">
+        <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12px; color: #999999; padding-bottom: 6px;">
           Button not working? Copy and paste this URL into your browser:
         </td>
       </tr>
       <tr>
-        <td bgcolor="#f4f4f5"
-          style="background-color: #f4f4f5; border: 1px solid #e4e4e7; padding: 10px 14px;">
-          <span style="font-family: 'Courier New', Courier, monospace; font-size: 12px; color: #18181b; word-break: break-all;">{{ magic_link_url }}</span>
+        <td bgcolor="#ffffff"
+          style="background-color: #ffffff; border: 1px solid #dddddd; border-radius: 6px; padding: 10px 12px;">
+          <span style="font-family: 'JetBrains Mono', 'Courier New', Courier, monospace; font-size: 12px; color: #555555; word-break: break-all;">{{ magic_link_url }}</span>
         </td>
       </tr>
     </table>
@@ -47,11 +47,11 @@
   <td>
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td width="3" bgcolor="#7c3aed"
-          style="background-color: #7c3aed; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
-        <td bgcolor="#faf5ff"
-          style="background-color: #faf5ff; padding: 10px 14px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #6d28d9;">
+        <td width="3" bgcolor="#7dd3fc"
+          style="background-color: #7dd3fc; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
+        <td bgcolor="#f0f9ff"
+          style="background-color: #f0f9ff; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12.5px; color: #4c1d95; line-height: 1.5;">
             Didn't request this? Just ignore it — nothing will change on your account.
           </span>
         </td>

--- a/templates/en-us/email/mfa-activation-start.jinja
+++ b/templates/en-us/email/mfa-activation-start.jinja
@@ -6,7 +6,7 @@
 
 {% block contenttable %}
 <tr>
-  <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #3f3f46; line-height: 1.6; padding-bottom: 20px;">
+  <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555; line-height: 1.6; padding-bottom: 24px;">
     You started enabling two-factor authentication (2FA) on your
     {{ domain_name }} account. Head to the app to finish the setup.
   </td>
@@ -15,11 +15,11 @@
   <td>
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td width="3" bgcolor="#7c3aed"
-          style="background-color: #7c3aed; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
-        <td bgcolor="#faf5ff"
-          style="background-color: #faf5ff; padding: 10px 14px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #6d28d9;">
+        <td width="3" bgcolor="#7dd3fc"
+          style="background-color: #7dd3fc; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
+        <td bgcolor="#f0f9ff"
+          style="background-color: #f0f9ff; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12.5px; color: #4c1d95; line-height: 1.5;">
             Wasn't you? Secure your account and contact support right away.
           </span>
         </td>

--- a/templates/en-us/email/mfa-activation-validated.jinja
+++ b/templates/en-us/email/mfa-activation-validated.jinja
@@ -6,7 +6,7 @@
 
 {% block contenttable %}
 <tr>
-  <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #3f3f46; line-height: 1.6; padding-bottom: 20px;">
+  <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555; line-height: 1.6; padding-bottom: 24px;">
     Two-factor authentication is now active on your {{ domain_name }} account.
     Your account is in good shape.
   </td>
@@ -15,11 +15,11 @@
   <td>
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td width="3" bgcolor="#7c3aed"
-          style="background-color: #7c3aed; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
-        <td bgcolor="#faf5ff"
-          style="background-color: #faf5ff; padding: 10px 14px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #6d28d9;">
+        <td width="3" bgcolor="#7dd3fc"
+          style="background-color: #7dd3fc; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
+        <td bgcolor="#f0f9ff"
+          style="background-color: #f0f9ff; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12.5px; color: #4c1d95; line-height: 1.5;">
             Wasn't you? Contact support immediately.
           </span>
         </td>

--- a/templates/en-us/email/mfa-disable.jinja
+++ b/templates/en-us/email/mfa-disable.jinja
@@ -6,7 +6,7 @@
 
 {% block contenttable %}
 <tr>
-  <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #3f3f46; line-height: 1.6; padding-bottom: 20px;">
+  <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555; line-height: 1.6; padding-bottom: 24px;">
     Two-factor authentication was disabled on your {{ domain_name }} account.
   </td>
 </tr>
@@ -17,8 +17,8 @@
         <td width="3" bgcolor="#f59e0b"
           style="background-color: #f59e0b; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
         <td bgcolor="#fff7ed"
-          style="background-color: #fff7ed; padding: 10px 14px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #92400e;">
+          style="background-color: #fff7ed; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12.5px; color: #92400e; line-height: 1.5;">
             Your account is less protected without 2FA. If this wasn't you,
             re-enable it right away and contact support.
           </span>

--- a/templates/en-us/email/password-reset-confirmation.jinja
+++ b/templates/en-us/email/password-reset-confirmation.jinja
@@ -6,7 +6,7 @@
 
 {% block contenttable %}
 <tr>
-  <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #3f3f46; line-height: 1.6; padding-bottom: 20px;">
+  <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555; line-height: 1.6; padding-bottom: 24px;">
     Your {{ domain_name }} password was just changed successfully.
   </td>
 </tr>
@@ -17,8 +17,8 @@
         <td width="3" bgcolor="#f59e0b"
           style="background-color: #f59e0b; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
         <td bgcolor="#fff7ed"
-          style="background-color: #fff7ed; padding: 10px 14px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #92400e;">
+          style="background-color: #fff7ed; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12.5px; color: #92400e; line-height: 1.5;">
             Wasn't you? Contact support right away — your account may be at risk.
           </span>
         </td>

--- a/templates/en-us/email/password-reset-initiated.jinja
+++ b/templates/en-us/email/password-reset-initiated.jinja
@@ -6,7 +6,7 @@
 
 {% block contenttable %}
 <tr>
-  <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #3f3f46; line-height: 1.6; padding-bottom: 20px;">
+  <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555; line-height: 1.6; padding-bottom: 24px;">
     A password reset was requested for your {{ domain_name }} account.
     Use the code below to proceed.
   </td>
@@ -15,16 +15,17 @@
   <td style="padding-bottom: 24px;">
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td bgcolor="#f4f4f5"
-          style="background-color: #f4f4f5; border: 1px solid #e4e4e7; padding: 24px; text-align: center;">
-          <span style="font-family: 'Courier New', Courier, monospace; font-size: 36px; font-weight: bold; color: #18181b; letter-spacing: 0.15em;">{{ verification_code }}</span>
+        <td align="center" bgcolor="#bae6fd"
+          style="background-color: #bae6fd; border-radius: 6px; padding: 16px 40px; text-align: center;">
+          <span style="font-family: 'JetBrains Mono', 'Courier New', Courier, monospace; font-size: 36px; font-weight: bold; color: #1a1a1a; letter-spacing: 0.18em;">{{ verification_code }}</span>
         </td>
       </tr>
       <tr>
-        <td height="8" style="font-size: 0; line-height: 0;">&nbsp;</td>
+        <td height="12" style="font-size: 0; line-height: 0;">&nbsp;</td>
       </tr>
       <tr>
-        <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #71717a; text-align: center;">
+        <td align="center"
+          style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12px; color: #999999; text-align: center;">
           Expires in 15 minutes.
         </td>
       </tr>
@@ -35,11 +36,11 @@
   <td>
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td width="3" bgcolor="#7c3aed"
-          style="background-color: #7c3aed; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
-        <td bgcolor="#faf5ff"
-          style="background-color: #faf5ff; padding: 10px 14px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #6d28d9;">
+        <td width="3" bgcolor="#7dd3fc"
+          style="background-color: #7dd3fc; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
+        <td bgcolor="#f0f9ff"
+          style="background-color: #f0f9ff; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12.5px; color: #4c1d95; line-height: 1.5;">
             Didn't ask for this? Just ignore it — your password will stay the same.
           </span>
         </td>

--- a/templates/es/email/activation-code.jinja
+++ b/templates/es/email/activation-code.jinja
@@ -6,8 +6,8 @@
 
 {% block contenttable %}
 <tr>
-  <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #3f3f46; line-height: 1.6; padding-bottom: 20px;">
-    Gracias por registrarse en <strong style="color: #18181b;">{{ domain_name }}</strong>.
+  <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555; line-height: 1.6; padding-bottom: 24px;">
+    Gracias por registrarse en <strong style="color: #1a1a1a;">{{ domain_name }}</strong>.
     Use el código a continuación para confirmar su correo y finalizar la configuración de su cuenta.
   </td>
 </tr>
@@ -15,16 +15,17 @@
   <td style="padding-bottom: 24px;">
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td bgcolor="#f4f4f5"
-          style="background-color: #f4f4f5; border: 1px solid #e4e4e7; padding: 24px; text-align: center;">
-          <span style="font-family: 'Courier New', Courier, monospace; font-size: 36px; font-weight: bold; color: #18181b; letter-spacing: 0.15em;">{{ verification_code }}</span>
+        <td align="center" bgcolor="#bae6fd"
+          style="background-color: #bae6fd; border-radius: 6px; padding: 16px 40px; text-align: center;">
+          <span style="font-family: 'JetBrains Mono', 'Courier New', Courier, monospace; font-size: 36px; font-weight: bold; color: #1a1a1a; letter-spacing: 0.18em;">{{ verification_code }}</span>
         </td>
       </tr>
       <tr>
-        <td height="8" style="font-size: 0; line-height: 0;">&nbsp;</td>
+        <td height="12" style="font-size: 0; line-height: 0;">&nbsp;</td>
       </tr>
       <tr>
-        <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #71717a; text-align: center;">
+        <td align="center"
+          style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12px; color: #999999; text-align: center;">
           Expira en 15 minutos.
         </td>
       </tr>
@@ -35,11 +36,11 @@
   <td>
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td width="3" bgcolor="#7c3aed"
-          style="background-color: #7c3aed; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
-        <td bgcolor="#faf5ff"
-          style="background-color: #faf5ff; padding: 10px 14px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #6d28d9;">
+        <td width="3" bgcolor="#7dd3fc"
+          style="background-color: #7dd3fc; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
+        <td bgcolor="#f0f9ff"
+          style="background-color: #f0f9ff; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12.5px; color: #4c1d95; line-height: 1.5;">
             ¿No se registró en {{ domain_name }}? Puede ignorar este correo.
           </span>
         </td>

--- a/templates/es/email/base.jinja
+++ b/templates/es/email/base.jinja
@@ -7,104 +7,93 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="x-apple-disable-message-reformatting" />
   <title>{% block title %}{% endblock title %} — {{ domain_name }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="crossorigin" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;700&amp;display=swap" rel="stylesheet" />
   <style type="text/css">
+    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;700&display=swap');
     body, table, td, p, a, span { -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }
     table, td { mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse; }
     img { -ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none; }
-    body { margin: 0 !important; padding: 0 !important; background-color: #f4f4f5; }
+    body { margin: 0 !important; padding: 0 !important; background-color: #f5f3ff; }
   </style>
   {% endblock head %}
 </head>
 
-<body style="margin: 0; padding: 0; background-color: #f4f4f5;">
+<body style="margin: 0; padding: 0; background-color: #f5f3ff;">
 
 <!-- Outer wrapper -->
-<table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f4f4f5"
-  style="background-color: #f4f4f5;">
+<table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f5f3ff"
+  style="background-color: #f5f3ff;">
   <tr>
     <td align="center" style="padding: 40px 16px;">
 
-      <!-- Card: 600px max -->
-      <table width="600" cellpadding="0" cellspacing="0" border="0"
-        style="max-width: 600px; width: 100%;">
+      <!-- Card: 600px max, white, rounded, soft shadow. The card table alone owns the
+           white fill — no inner cell may set a background at the card edge, or it
+           would paint over the rounded corners. -->
+      <table width="600" cellpadding="0" cellspacing="0" border="0" bgcolor="#ffffff"
+        style="max-width: 600px; width: 100%; background-color: #ffffff; border-radius: 12px; box-shadow: 0 2px 12px rgba(0,0,0,0.08);">
 
-        <!-- ── HEADER ── -->
         <tr>
-          <td bgcolor="#18181b" style="background-color: #18181b; padding: 0;">
+          <td style="padding: 40px 40px 0;">
+
+            <!-- Brand eyebrow -->
             <table width="100%" cellpadding="0" cellspacing="0" border="0">
               <tr>
-                <!-- Violet accent bar -->
-                <td width="4" bgcolor="#7c3aed"
-                  style="background-color: #7c3aed; width: 4px; font-size: 0; line-height: 0;">&#8203;</td>
-                <!-- Wordmark -->
-                <td style="padding: 24px 32px;">
-                  <span
-                    style="font-family: Georgia, 'Times New Roman', Times, serif; font-size: 22px; font-weight: bold; color: #ffffff; letter-spacing: -0.02em;">{{ domain_name }}</span>
+                <td
+                  style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: 600; color: #8b5cf6; letter-spacing: 0.04em; text-transform: uppercase;">
+                  {{ domain_name }}
                 </td>
+              </tr>
+              <tr>
+                <td height="20" style="font-size: 0; line-height: 0;">&nbsp;</td>
               </tr>
             </table>
-          </td>
-        </tr>
-
-        <!-- ── CONTENT ── -->
-        <tr>
-          <td bgcolor="#ffffff"
-            style="background-color: #ffffff; border-left: 1px solid #e4e4e7; border-right: 1px solid #e4e4e7;">
 
             {% block content %}
-            <!-- Inner padding cell -->
+            <!-- Title -->
             <table width="100%" cellpadding="0" cellspacing="0" border="0">
               <tr>
-                <td style="padding: 36px 40px 0;">
-
-                  <!-- Title -->
-                  <table width="100%" cellpadding="0" cellspacing="0" border="0">
-                    <tr>
-                      <td>
-                        <h1
-                          style="margin: 0; font-family: Georgia, 'Times New Roman', Times, serif; font-size: 20px; font-weight: bold; color: #18181b; letter-spacing: -0.01em; line-height: 1.3;">
-                          {% block contenttitle %}{% endblock contenttitle %}
-                        </h1>
-                      </td>
-                    </tr>
-                    <!-- Violet underline (table row, not CSS border) -->
-                    <tr>
-                      <td height="2" bgcolor="#7c3aed"
-                        style="background-color: #7c3aed; height: 2px; font-size: 0; line-height: 0; padding-top: 12px;">&#8203;</td>
-                    </tr>
-                    <tr>
-                      <td height="28" style="font-size: 0; line-height: 0;">&nbsp;</td>
-                    </tr>
-                  </table>
-
-                  <!-- Body content -->
-                  <table width="100%" cellpadding="0" cellspacing="0" border="0">
-                    {% block contenttable %}{% endblock contenttable %}
-                  </table>
-
+                <td>
+                  <h1
+                    style="margin: 0; font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 22px; font-weight: 600; color: #4c1d95; line-height: 1.3;">
+                    {% block contenttitle %}{% endblock contenttitle %}
+                  </h1>
                 </td>
               </tr>
               <tr>
-                <td height="40" style="font-size: 0; line-height: 0;">&nbsp;</td>
+                <td height="20" style="font-size: 0; line-height: 0;">&nbsp;</td>
               </tr>
+            </table>
+
+            <!-- Body content -->
+            <table width="100%" cellpadding="0" cellspacing="0" border="0">
+              {% block contenttable %}{% endblock contenttable %}
             </table>
             {% endblock content %}
 
           </td>
         </tr>
 
-        <!-- ── FOOTER ── -->
+        <!-- ── FOOTER (inside the card, below a hairline) ── -->
         <tr>
-          <td bgcolor="#f4f4f5"
-            style="background-color: #f4f4f5; padding: 20px 40px; border: 1px solid #e4e4e7; border-top: none;">
+          <td style="padding: 28px 40px 32px;">
             <table width="100%" cellpadding="0" cellspacing="0" border="0">
+
+              <tr>
+                <td height="1" bgcolor="#ddd6fe"
+                  style="background-color: #ddd6fe; height: 1px; font-size: 0; line-height: 0;">&#8203;</td>
+              </tr>
+              <tr>
+                <td height="16" style="font-size: 0; line-height: 0;">&nbsp;</td>
+              </tr>
 
               {% if support_email %}
               <tr>
                 <td
-                  style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #71717a; line-height: 1.6; padding-bottom: 4px;">
+                  style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12px; color: #999999; line-height: 1.6;">
                   &#191;Preguntas?&#32;<a href="mailto:{{ support_email }}"
-                    style="color: #7c3aed; text-decoration: none;">{{ support_email }}</a>
+                    style="color: #6d28d9; text-decoration: none;">{{ support_email }}</a>
                 </td>
               </tr>
               {% endif %}
@@ -112,24 +101,20 @@
               {% if domain_url %}
               <tr>
                 <td
-                  style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #71717a; line-height: 1.6; padding-bottom: 12px;">
-                  <a href="{{ domain_url }}" style="color: #7c3aed; text-decoration: none;">{{ domain_url }}</a>
+                  style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12px; color: #999999; line-height: 1.6;">
+                  <a href="{{ domain_url }}" style="color: #6d28d9; text-decoration: none;">{{ domain_url }}</a>
                 </td>
               </tr>
               {% endif %}
 
               <tr>
-                <td height="1" bgcolor="#e4e4e7"
-                  style="background-color: #e4e4e7; height: 1px; font-size: 0; line-height: 0;">&#8203;</td>
-              </tr>
-              <tr>
-                <td height="12" style="font-size: 0; line-height: 0;">&nbsp;</td>
+                <td height="8" style="font-size: 0; line-height: 0;">&nbsp;</td>
               </tr>
               <tr>
                 <td
-                  style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 11px; color: #a1a1aa; line-height: 1.5;">
+                  style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12px; color: #999999; line-height: 1.5;">
                   Desarrollado por&#32;<a href="https://lepista.com.br"
-                    style="color: #a1a1aa; text-decoration: none;">LepistaBioinformatics</a>
+                    style="color: #999999; text-decoration: none;">LepistaBioinformatics</a>
                 </td>
               </tr>
 

--- a/templates/es/email/create-connection-string.jinja
+++ b/templates/es/email/create-connection-string.jinja
@@ -6,7 +6,7 @@
 
 {% block contenttable %}
 <tr>
-  <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #3f3f46; line-height: 1.6; padding-bottom: 20px;">
+  <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555; line-height: 1.6; padding-bottom: 24px;">
     Se acaba de agregar una nueva cadena de conexión a su cuenta.
   </td>
 </tr>
@@ -14,14 +14,14 @@
   <td style="padding-bottom: 24px;">
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 11px; font-weight: 600; color: #71717a; text-transform: uppercase; letter-spacing: 0.05em; padding-bottom: 4px;">
+        <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: 500; color: #333333; padding-bottom: 6px;">
           Expira en
         </td>
       </tr>
       <tr>
-        <td bgcolor="#f4f4f5"
-          style="background-color: #f4f4f5; border: 1px solid #e4e4e7; padding: 12px 16px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #18181b;">{{ expires_in }}</span>
+        <td bgcolor="#ffffff"
+          style="background-color: #ffffff; border: 1px solid #dddddd; border-radius: 6px; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555;">{{ expires_in }}</span>
         </td>
       </tr>
     </table>
@@ -31,11 +31,11 @@
   <td>
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td width="3" bgcolor="#7c3aed"
-          style="background-color: #7c3aed; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
-        <td bgcolor="#faf5ff"
-          style="background-color: #faf5ff; padding: 10px 14px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #6d28d9;">
+        <td width="3" bgcolor="#7dd3fc"
+          style="background-color: #7dd3fc; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
+        <td bgcolor="#f0f9ff"
+          style="background-color: #f0f9ff; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12.5px; color: #4c1d95; line-height: 1.5;">
             ¿No fue usted? Contacte a su administrador de inmediato.
           </span>
         </td>

--- a/templates/es/email/create-user-account.jinja
+++ b/templates/es/email/create-user-account.jinja
@@ -6,7 +6,7 @@
 
 {% block contenttable %}
 <tr>
-  <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #3f3f46; line-height: 1.6; padding-bottom: 20px;">
+  <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555; line-height: 1.6; padding-bottom: 24px;">
     Su cuenta en {{ domain_name }} fue creada y está lista para usar.
   </td>
 </tr>
@@ -14,14 +14,14 @@
   <td style="padding-bottom: 24px;">
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 11px; font-weight: 600; color: #71717a; text-transform: uppercase; letter-spacing: 0.05em; padding-bottom: 4px;">
+        <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: 500; color: #333333; padding-bottom: 6px;">
           Nombre de usuario
         </td>
       </tr>
       <tr>
-        <td bgcolor="#f4f4f5"
-          style="background-color: #f4f4f5; border: 1px solid #e4e4e7; padding: 12px 16px;">
-          <span style="font-family: 'Courier New', Courier, monospace; font-size: 14px; color: #18181b;">{{ account_name }}</span>
+        <td bgcolor="#ffffff"
+          style="background-color: #ffffff; border: 1px solid #dddddd; border-radius: 6px; padding: 10px 12px;">
+          <span style="font-family: 'JetBrains Mono', 'Courier New', Courier, monospace; font-size: 14px; color: #555555;">{{ account_name }}</span>
         </td>
       </tr>
     </table>
@@ -31,11 +31,11 @@
   <td>
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td width="3" bgcolor="#7c3aed"
-          style="background-color: #7c3aed; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
-        <td bgcolor="#faf5ff"
-          style="background-color: #faf5ff; padding: 10px 14px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #6d28d9;">
+        <td width="3" bgcolor="#7dd3fc"
+          style="background-color: #7dd3fc; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
+        <td bgcolor="#f0f9ff"
+          style="background-color: #f0f9ff; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12.5px; color: #4c1d95; line-height: 1.5;">
             ¿No lo esperaba? Comuníquese con el administrador del sistema.
           </span>
         </td>

--- a/templates/es/email/guest-to-subscription-account.jinja
+++ b/templates/es/email/guest-to-subscription-account.jinja
@@ -6,23 +6,23 @@
 
 {% block contenttable %}
 <tr>
-  <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #3f3f46; line-height: 1.6; padding-bottom: 20px;">
-    Ha sido invitado a unirse a <strong style="color: #18181b;">{{ account_name }}</strong>
-    como <strong style="color: #18181b;">{{ role_name }}</strong>.
+  <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555; line-height: 1.6; padding-bottom: 24px;">
+    Ha sido invitado a unirse a <strong style="color: #1a1a1a;">{{ account_name }}</strong>
+    como <strong style="color: #1a1a1a;">{{ role_name }}</strong>.
   </td>
 </tr>
 <tr>
   <td style="padding-bottom: 24px;">
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 11px; font-weight: 600; color: #71717a; text-transform: uppercase; letter-spacing: 0.05em; padding-bottom: 4px;">
+        <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: 500; color: #333333; padding-bottom: 6px;">
           Permisos del rol
         </td>
       </tr>
       <tr>
-        <td bgcolor="#f4f4f5"
-          style="background-color: #f4f4f5; border: 1px solid #e4e4e7; padding: 12px 16px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #18181b;">{{ role_permissions }}</span>
+        <td bgcolor="#ffffff"
+          style="background-color: #ffffff; border: 1px solid #dddddd; border-radius: 6px; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555;">{{ role_permissions }}</span>
         </td>
       </tr>
     </table>
@@ -32,11 +32,11 @@
   <td>
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td width="3" bgcolor="#7c3aed"
-          style="background-color: #7c3aed; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
-        <td bgcolor="#faf5ff"
-          style="background-color: #faf5ff; padding: 10px 14px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #6d28d9;">
+        <td width="3" bgcolor="#7dd3fc"
+          style="background-color: #7dd3fc; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
+        <td bgcolor="#f0f9ff"
+          style="background-color: #f0f9ff; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12.5px; color: #4c1d95; line-height: 1.5;">
             ¿No esperaba esta invitación? Avise a su administrador del sistema.
           </span>
         </td>

--- a/templates/es/email/magic-link-request.jinja
+++ b/templates/es/email/magic-link-request.jinja
@@ -6,19 +6,19 @@
 
 {% block contenttable %}
 <tr>
-  <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #3f3f46; line-height: 1.6; padding-bottom: 20px;">
+  <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555; line-height: 1.6; padding-bottom: 24px;">
     Aquí está su enlace de acceso para {{ domain_name }}. Haga clic en el botón y verá un código
     de 6 dígitos para ingresar en la aplicación — válido por
-    <strong style="color: #18181b;">15 minutos</strong>, un solo uso.
+    <strong style="color: #1a1a1a;">15 minutos</strong>, un solo uso.
   </td>
 </tr>
 <tr>
-  <td style="padding-bottom: 24px;">
-    <table cellpadding="0" cellspacing="0" border="0">
+  <td align="center" style="padding-bottom: 24px; text-align: center;">
+    <table cellpadding="0" cellspacing="0" border="0" align="center">
       <tr>
-        <td bgcolor="#7c3aed" style="background-color: #7c3aed;">
+        <td bgcolor="#8b5cf6" style="background-color: #8b5cf6; border-radius: 6px;">
           <a href="{{ magic_link_url }}"
-            style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; font-weight: 600; color: #ffffff; text-decoration: none; display: inline-block; padding: 12px 32px; text-transform: uppercase;">
+            style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; font-weight: 600; color: #ffffff; text-decoration: none; display: inline-block; padding: 12px 32px;">
             Ver código de inicio de sesión
           </a>
         </td>
@@ -27,17 +27,17 @@
   </td>
 </tr>
 <tr>
-  <td style="padding-bottom: 20px;">
+  <td style="padding-bottom: 24px;">
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #71717a; padding-bottom: 6px;">
+        <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12px; color: #999999; padding-bottom: 6px;">
           ¿El botón no funcionó? Copie y pegue esta URL en su navegador:
         </td>
       </tr>
       <tr>
-        <td bgcolor="#f4f4f5"
-          style="background-color: #f4f4f5; border: 1px solid #e4e4e7; padding: 12px 16px;">
-          <span style="font-family: 'Courier New', Courier, monospace; font-size: 12px; color: #18181b; word-break: break-all;">{{ magic_link_url }}</span>
+        <td bgcolor="#ffffff"
+          style="background-color: #ffffff; border: 1px solid #dddddd; border-radius: 6px; padding: 10px 12px;">
+          <span style="font-family: 'JetBrains Mono', 'Courier New', Courier, monospace; font-size: 12px; color: #555555; word-break: break-all;">{{ magic_link_url }}</span>
         </td>
       </tr>
     </table>
@@ -47,11 +47,11 @@
   <td>
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td width="3" bgcolor="#7c3aed"
-          style="background-color: #7c3aed; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
-        <td bgcolor="#faf5ff"
-          style="background-color: #faf5ff; padding: 10px 14px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #6d28d9;">
+        <td width="3" bgcolor="#7dd3fc"
+          style="background-color: #7dd3fc; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
+        <td bgcolor="#f0f9ff"
+          style="background-color: #f0f9ff; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12.5px; color: #4c1d95; line-height: 1.5;">
             ¿No fue usted? Ignórelo — nada cambiará en su cuenta.
           </span>
         </td>

--- a/templates/es/email/mfa-activation-start.jinja
+++ b/templates/es/email/mfa-activation-start.jinja
@@ -6,7 +6,7 @@
 
 {% block contenttable %}
 <tr>
-  <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #3f3f46; line-height: 1.6; padding-bottom: 20px;">
+  <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555; line-height: 1.6; padding-bottom: 24px;">
     Inició la activación de la autenticación de dos factores (2FA) en su cuenta de
     {{ domain_name }}. Abra la aplicación para completar la configuración.
   </td>
@@ -15,11 +15,11 @@
   <td>
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td width="3" bgcolor="#7c3aed"
-          style="background-color: #7c3aed; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
-        <td bgcolor="#faf5ff"
-          style="background-color: #faf5ff; padding: 10px 14px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #6d28d9;">
+        <td width="3" bgcolor="#7dd3fc"
+          style="background-color: #7dd3fc; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
+        <td bgcolor="#f0f9ff"
+          style="background-color: #f0f9ff; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12.5px; color: #4c1d95; line-height: 1.5;">
             ¿No fue usted? Proteja su cuenta y contacte al soporte ahora.
           </span>
         </td>

--- a/templates/es/email/mfa-activation-validated.jinja
+++ b/templates/es/email/mfa-activation-validated.jinja
@@ -6,7 +6,7 @@
 
 {% block contenttable %}
 <tr>
-  <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #3f3f46; line-height: 1.6; padding-bottom: 20px;">
+  <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555; line-height: 1.6; padding-bottom: 24px;">
     La autenticación de dos factores está activa en su cuenta de {{ domain_name }}.
     Su cuenta está bien protegida.
   </td>
@@ -15,11 +15,11 @@
   <td>
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td width="3" bgcolor="#7c3aed"
-          style="background-color: #7c3aed; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
-        <td bgcolor="#faf5ff"
-          style="background-color: #faf5ff; padding: 10px 14px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #6d28d9;">
+        <td width="3" bgcolor="#7dd3fc"
+          style="background-color: #7dd3fc; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
+        <td bgcolor="#f0f9ff"
+          style="background-color: #f0f9ff; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12.5px; color: #4c1d95; line-height: 1.5;">
             ¿No fue usted? Contacte al soporte de inmediato.
           </span>
         </td>

--- a/templates/es/email/mfa-disable.jinja
+++ b/templates/es/email/mfa-disable.jinja
@@ -6,7 +6,7 @@
 
 {% block contenttable %}
 <tr>
-  <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #3f3f46; line-height: 1.6; padding-bottom: 20px;">
+  <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555; line-height: 1.6; padding-bottom: 24px;">
     La autenticación de dos factores fue desactivada en su cuenta de {{ domain_name }}.
   </td>
 </tr>
@@ -17,8 +17,8 @@
         <td width="3" bgcolor="#f59e0b"
           style="background-color: #f59e0b; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
         <td bgcolor="#fff7ed"
-          style="background-color: #fff7ed; padding: 10px 14px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #92400e;">
+          style="background-color: #fff7ed; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12.5px; color: #92400e; line-height: 1.5;">
             Sin 2FA su cuenta queda menos protegida. Si no fue usted, reactívelo ahora y contacte
             al soporte.
           </span>

--- a/templates/es/email/password-reset-confirmation.jinja
+++ b/templates/es/email/password-reset-confirmation.jinja
@@ -6,7 +6,7 @@
 
 {% block contenttable %}
 <tr>
-  <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #3f3f46; line-height: 1.6; padding-bottom: 20px;">
+  <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555; line-height: 1.6; padding-bottom: 24px;">
     La contraseña de su cuenta en {{ domain_name }} fue cambiada exitosamente.
   </td>
 </tr>
@@ -17,8 +17,8 @@
         <td width="3" bgcolor="#f59e0b"
           style="background-color: #f59e0b; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
         <td bgcolor="#fff7ed"
-          style="background-color: #fff7ed; padding: 10px 14px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #92400e;">
+          style="background-color: #fff7ed; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12.5px; color: #92400e; line-height: 1.5;">
             ¿No fue usted? Contacte al soporte ahora — su cuenta puede estar en riesgo.
           </span>
         </td>

--- a/templates/es/email/password-reset-initiated.jinja
+++ b/templates/es/email/password-reset-initiated.jinja
@@ -6,7 +6,7 @@
 
 {% block contenttable %}
 <tr>
-  <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #3f3f46; line-height: 1.6; padding-bottom: 20px;">
+  <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555; line-height: 1.6; padding-bottom: 24px;">
     Se solicitó un restablecimiento de contraseña para su cuenta en {{ domain_name }}.
     Use el código a continuación para continuar.
   </td>
@@ -15,16 +15,17 @@
   <td style="padding-bottom: 24px;">
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td bgcolor="#f4f4f5"
-          style="background-color: #f4f4f5; border: 1px solid #e4e4e7; padding: 24px; text-align: center;">
-          <span style="font-family: 'Courier New', Courier, monospace; font-size: 36px; font-weight: bold; color: #18181b; letter-spacing: 0.15em;">{{ verification_code }}</span>
+        <td align="center" bgcolor="#bae6fd"
+          style="background-color: #bae6fd; border-radius: 6px; padding: 16px 40px; text-align: center;">
+          <span style="font-family: 'JetBrains Mono', 'Courier New', Courier, monospace; font-size: 36px; font-weight: bold; color: #1a1a1a; letter-spacing: 0.18em;">{{ verification_code }}</span>
         </td>
       </tr>
       <tr>
-        <td height="8" style="font-size: 0; line-height: 0;">&nbsp;</td>
+        <td height="12" style="font-size: 0; line-height: 0;">&nbsp;</td>
       </tr>
       <tr>
-        <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #71717a; text-align: center;">
+        <td align="center"
+          style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12px; color: #999999; text-align: center;">
           Expira en 15 minutos.
         </td>
       </tr>
@@ -35,11 +36,11 @@
   <td>
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td width="3" bgcolor="#7c3aed"
-          style="background-color: #7c3aed; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
-        <td bgcolor="#faf5ff"
-          style="background-color: #faf5ff; padding: 10px 14px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #6d28d9;">
+        <td width="3" bgcolor="#7dd3fc"
+          style="background-color: #7dd3fc; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
+        <td bgcolor="#f0f9ff"
+          style="background-color: #f0f9ff; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12.5px; color: #4c1d95; line-height: 1.5;">
             ¿No fue usted? Ignórelo — su contraseña no cambiará.
           </span>
         </td>

--- a/templates/pt-br/email/activation-code.jinja
+++ b/templates/pt-br/email/activation-code.jinja
@@ -6,8 +6,8 @@
 
 {% block contenttable %}
 <tr>
-  <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #3f3f46; line-height: 1.6; padding-bottom: 20px;">
-    Obrigado por se registrar no <strong style="color: #18181b;">{{ domain_name }}</strong>.
+  <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555; line-height: 1.6; padding-bottom: 24px;">
+    Obrigado por se registrar no <strong style="color: #1a1a1a;">{{ domain_name }}</strong>.
     Use o código abaixo para confirmar seu e-mail e concluir a configuração da sua conta.
   </td>
 </tr>
@@ -15,16 +15,17 @@
   <td style="padding-bottom: 24px;">
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td bgcolor="#f4f4f5"
-          style="background-color: #f4f4f5; border: 1px solid #e4e4e7; padding: 24px; text-align: center;">
-          <span style="font-family: 'Courier New', Courier, monospace; font-size: 36px; font-weight: bold; color: #18181b; letter-spacing: 0.15em;">{{ verification_code }}</span>
+        <td align="center" bgcolor="#bae6fd"
+          style="background-color: #bae6fd; border-radius: 6px; padding: 16px 40px; text-align: center;">
+          <span style="font-family: 'JetBrains Mono', 'Courier New', Courier, monospace; font-size: 36px; font-weight: bold; color: #1a1a1a; letter-spacing: 0.18em;">{{ verification_code }}</span>
         </td>
       </tr>
       <tr>
-        <td height="8" style="font-size: 0; line-height: 0;">&nbsp;</td>
+        <td height="12" style="font-size: 0; line-height: 0;">&nbsp;</td>
       </tr>
       <tr>
-        <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #71717a; text-align: center;">
+        <td align="center"
+          style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12px; color: #999999; text-align: center;">
           Expira em 15 minutos.
         </td>
       </tr>
@@ -35,11 +36,11 @@
   <td>
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td width="3" bgcolor="#7c3aed"
-          style="background-color: #7c3aed; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
-        <td bgcolor="#faf5ff"
-          style="background-color: #faf5ff; padding: 10px 14px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #6d28d9;">
+        <td width="3" bgcolor="#7dd3fc"
+          style="background-color: #7dd3fc; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
+        <td bgcolor="#f0f9ff"
+          style="background-color: #f0f9ff; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12.5px; color: #4c1d95; line-height: 1.5;">
             Não se registrou no {{ domain_name }}? Pode ignorar este e-mail tranquilamente.
           </span>
         </td>

--- a/templates/pt-br/email/base.jinja
+++ b/templates/pt-br/email/base.jinja
@@ -7,104 +7,93 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="x-apple-disable-message-reformatting" />
   <title>{% block title %}{% endblock title %} — {{ domain_name }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="crossorigin" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;700&amp;display=swap" rel="stylesheet" />
   <style type="text/css">
+    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;700&display=swap');
     body, table, td, p, a, span { -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }
     table, td { mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse; }
     img { -ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none; }
-    body { margin: 0 !important; padding: 0 !important; background-color: #f4f4f5; }
+    body { margin: 0 !important; padding: 0 !important; background-color: #f5f3ff; }
   </style>
   {% endblock head %}
 </head>
 
-<body style="margin: 0; padding: 0; background-color: #f4f4f5;">
+<body style="margin: 0; padding: 0; background-color: #f5f3ff;">
 
 <!-- Outer wrapper -->
-<table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f4f4f5"
-  style="background-color: #f4f4f5;">
+<table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f5f3ff"
+  style="background-color: #f5f3ff;">
   <tr>
     <td align="center" style="padding: 40px 16px;">
 
-      <!-- Card: 600px max -->
-      <table width="600" cellpadding="0" cellspacing="0" border="0"
-        style="max-width: 600px; width: 100%;">
+      <!-- Card: 600px max, white, rounded, soft shadow. The card table alone owns the
+           white fill — no inner cell may set a background at the card edge, or it
+           would paint over the rounded corners. -->
+      <table width="600" cellpadding="0" cellspacing="0" border="0" bgcolor="#ffffff"
+        style="max-width: 600px; width: 100%; background-color: #ffffff; border-radius: 12px; box-shadow: 0 2px 12px rgba(0,0,0,0.08);">
 
-        <!-- ── HEADER ── -->
         <tr>
-          <td bgcolor="#18181b" style="background-color: #18181b; padding: 0;">
+          <td style="padding: 40px 40px 0;">
+
+            <!-- Brand eyebrow -->
             <table width="100%" cellpadding="0" cellspacing="0" border="0">
               <tr>
-                <!-- Violet accent bar -->
-                <td width="4" bgcolor="#7c3aed"
-                  style="background-color: #7c3aed; width: 4px; font-size: 0; line-height: 0;">&#8203;</td>
-                <!-- Wordmark -->
-                <td style="padding: 24px 32px;">
-                  <span
-                    style="font-family: Georgia, 'Times New Roman', Times, serif; font-size: 22px; font-weight: bold; color: #ffffff; letter-spacing: -0.02em;">{{ domain_name }}</span>
+                <td
+                  style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: 600; color: #8b5cf6; letter-spacing: 0.04em; text-transform: uppercase;">
+                  {{ domain_name }}
                 </td>
+              </tr>
+              <tr>
+                <td height="20" style="font-size: 0; line-height: 0;">&nbsp;</td>
               </tr>
             </table>
-          </td>
-        </tr>
-
-        <!-- ── CONTENT ── -->
-        <tr>
-          <td bgcolor="#ffffff"
-            style="background-color: #ffffff; border-left: 1px solid #e4e4e7; border-right: 1px solid #e4e4e7;">
 
             {% block content %}
-            <!-- Inner padding cell -->
+            <!-- Title -->
             <table width="100%" cellpadding="0" cellspacing="0" border="0">
               <tr>
-                <td style="padding: 36px 40px 0;">
-
-                  <!-- Title -->
-                  <table width="100%" cellpadding="0" cellspacing="0" border="0">
-                    <tr>
-                      <td>
-                        <h1
-                          style="margin: 0; font-family: Georgia, 'Times New Roman', Times, serif; font-size: 20px; font-weight: bold; color: #18181b; letter-spacing: -0.01em; line-height: 1.3;">
-                          {% block contenttitle %}{% endblock contenttitle %}
-                        </h1>
-                      </td>
-                    </tr>
-                    <!-- Violet underline (table row, not CSS border) -->
-                    <tr>
-                      <td height="2" bgcolor="#7c3aed"
-                        style="background-color: #7c3aed; height: 2px; font-size: 0; line-height: 0; padding-top: 12px;">&#8203;</td>
-                    </tr>
-                    <tr>
-                      <td height="28" style="font-size: 0; line-height: 0;">&nbsp;</td>
-                    </tr>
-                  </table>
-
-                  <!-- Body content -->
-                  <table width="100%" cellpadding="0" cellspacing="0" border="0">
-                    {% block contenttable %}{% endblock contenttable %}
-                  </table>
-
+                <td>
+                  <h1
+                    style="margin: 0; font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 22px; font-weight: 600; color: #4c1d95; line-height: 1.3;">
+                    {% block contenttitle %}{% endblock contenttitle %}
+                  </h1>
                 </td>
               </tr>
               <tr>
-                <td height="40" style="font-size: 0; line-height: 0;">&nbsp;</td>
+                <td height="20" style="font-size: 0; line-height: 0;">&nbsp;</td>
               </tr>
+            </table>
+
+            <!-- Body content -->
+            <table width="100%" cellpadding="0" cellspacing="0" border="0">
+              {% block contenttable %}{% endblock contenttable %}
             </table>
             {% endblock content %}
 
           </td>
         </tr>
 
-        <!-- ── FOOTER ── -->
+        <!-- ── FOOTER (inside the card, below a hairline) ── -->
         <tr>
-          <td bgcolor="#f4f4f5"
-            style="background-color: #f4f4f5; padding: 20px 40px; border: 1px solid #e4e4e7; border-top: none;">
+          <td style="padding: 28px 40px 32px;">
             <table width="100%" cellpadding="0" cellspacing="0" border="0">
+
+              <tr>
+                <td height="1" bgcolor="#ddd6fe"
+                  style="background-color: #ddd6fe; height: 1px; font-size: 0; line-height: 0;">&#8203;</td>
+              </tr>
+              <tr>
+                <td height="16" style="font-size: 0; line-height: 0;">&nbsp;</td>
+              </tr>
 
               {% if support_email %}
               <tr>
                 <td
-                  style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #71717a; line-height: 1.6; padding-bottom: 4px;">
-                  Questions?&#32;<a href="mailto:{{ support_email }}"
-                    style="color: #7c3aed; text-decoration: none;">{{ support_email }}</a>
+                  style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12px; color: #999999; line-height: 1.6;">
+                  D&#250;vidas?&#32;<a href="mailto:{{ support_email }}"
+                    style="color: #6d28d9; text-decoration: none;">{{ support_email }}</a>
                 </td>
               </tr>
               {% endif %}
@@ -112,24 +101,20 @@
               {% if domain_url %}
               <tr>
                 <td
-                  style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #71717a; line-height: 1.6; padding-bottom: 12px;">
-                  <a href="{{ domain_url }}" style="color: #7c3aed; text-decoration: none;">{{ domain_url }}</a>
+                  style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12px; color: #999999; line-height: 1.6;">
+                  <a href="{{ domain_url }}" style="color: #6d28d9; text-decoration: none;">{{ domain_url }}</a>
                 </td>
               </tr>
               {% endif %}
 
               <tr>
-                <td height="1" bgcolor="#e4e4e7"
-                  style="background-color: #e4e4e7; height: 1px; font-size: 0; line-height: 0;">&#8203;</td>
-              </tr>
-              <tr>
-                <td height="12" style="font-size: 0; line-height: 0;">&nbsp;</td>
+                <td height="8" style="font-size: 0; line-height: 0;">&nbsp;</td>
               </tr>
               <tr>
                 <td
-                  style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 11px; color: #a1a1aa; line-height: 1.5;">
+                  style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12px; color: #999999; line-height: 1.5;">
                   Desenvolvido por&#32;<a href="https://lepista.com.br"
-                    style="color: #a1a1aa; text-decoration: none;">LepistaBioinformatics</a>
+                    style="color: #999999; text-decoration: none;">LepistaBioinformatics</a>
                 </td>
               </tr>
 

--- a/templates/pt-br/email/create-connection-string.jinja
+++ b/templates/pt-br/email/create-connection-string.jinja
@@ -6,7 +6,7 @@
 
 {% block contenttable %}
 <tr>
-  <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #3f3f46; line-height: 1.6; padding-bottom: 20px;">
+  <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555; line-height: 1.6; padding-bottom: 24px;">
     Uma nova connection string foi adicionada à sua conta.
   </td>
 </tr>
@@ -14,14 +14,14 @@
   <td style="padding-bottom: 24px;">
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 11px; font-weight: 600; color: #71717a; text-transform: uppercase; letter-spacing: 0.05em; padding-bottom: 4px;">
+        <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: 500; color: #333333; padding-bottom: 6px;">
           Expira em
         </td>
       </tr>
       <tr>
-        <td bgcolor="#f4f4f5"
-          style="background-color: #f4f4f5; border: 1px solid #e4e4e7; padding: 12px 16px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; font-weight: 600; color: #18181b;">{{ expires_in }}</span>
+        <td bgcolor="#ffffff"
+          style="background-color: #ffffff; border: 1px solid #dddddd; border-radius: 6px; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555;">{{ expires_in }}</span>
         </td>
       </tr>
     </table>
@@ -31,11 +31,11 @@
   <td>
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td width="3" bgcolor="#7c3aed"
-          style="background-color: #7c3aed; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
-        <td bgcolor="#faf5ff"
-          style="background-color: #faf5ff; padding: 10px 14px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #6d28d9;">
+        <td width="3" bgcolor="#7dd3fc"
+          style="background-color: #7dd3fc; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
+        <td bgcolor="#f0f9ff"
+          style="background-color: #f0f9ff; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12.5px; color: #4c1d95; line-height: 1.5;">
             Não foi você? Entre em contato com seu administrador imediatamente.
           </span>
         </td>

--- a/templates/pt-br/email/create-user-account.jinja
+++ b/templates/pt-br/email/create-user-account.jinja
@@ -6,7 +6,7 @@
 
 {% block contenttable %}
 <tr>
-  <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #3f3f46; line-height: 1.6; padding-bottom: 20px;">
+  <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555; line-height: 1.6; padding-bottom: 24px;">
     Sua conta no {{ domain_name }} foi criada e está pronta para uso.
   </td>
 </tr>
@@ -14,14 +14,14 @@
   <td style="padding-bottom: 24px;">
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 11px; font-weight: 600; color: #71717a; text-transform: uppercase; letter-spacing: 0.05em; padding-bottom: 4px;">
+        <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: 500; color: #333333; padding-bottom: 6px;">
           Nome de usuário
         </td>
       </tr>
       <tr>
-        <td bgcolor="#f4f4f5"
-          style="background-color: #f4f4f5; border: 1px solid #e4e4e7; padding: 12px 16px;">
-          <span style="font-family: 'Courier New', Courier, monospace; font-size: 14px; font-weight: 600; color: #18181b;">{{ account_name }}</span>
+        <td bgcolor="#ffffff"
+          style="background-color: #ffffff; border: 1px solid #dddddd; border-radius: 6px; padding: 10px 12px;">
+          <span style="font-family: 'JetBrains Mono', 'Courier New', Courier, monospace; font-size: 14px; color: #555555;">{{ account_name }}</span>
         </td>
       </tr>
     </table>
@@ -31,11 +31,11 @@
   <td>
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td width="3" bgcolor="#7c3aed"
-          style="background-color: #7c3aed; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
-        <td bgcolor="#faf5ff"
-          style="background-color: #faf5ff; padding: 10px 14px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #6d28d9;">
+        <td width="3" bgcolor="#7dd3fc"
+          style="background-color: #7dd3fc; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
+        <td bgcolor="#f0f9ff"
+          style="background-color: #f0f9ff; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12.5px; color: #4c1d95; line-height: 1.5;">
             Não estava esperando isso? Fale com o administrador do sistema.
           </span>
         </td>

--- a/templates/pt-br/email/guest-to-subscription-account.jinja
+++ b/templates/pt-br/email/guest-to-subscription-account.jinja
@@ -6,23 +6,23 @@
 
 {% block contenttable %}
 <tr>
-  <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #3f3f46; line-height: 1.6; padding-bottom: 20px;">
-    Você foi convidado para fazer parte de <strong style="color: #18181b;">{{ account_name }}</strong>
-    como <strong style="color: #18181b;">{{ role_name }}</strong>.
+  <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555; line-height: 1.6; padding-bottom: 24px;">
+    Você foi convidado para fazer parte de <strong style="color: #1a1a1a;">{{ account_name }}</strong>
+    como <strong style="color: #1a1a1a;">{{ role_name }}</strong>.
   </td>
 </tr>
 <tr>
   <td style="padding-bottom: 24px;">
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 11px; font-weight: 600; color: #71717a; text-transform: uppercase; letter-spacing: 0.05em; padding-bottom: 4px;">
+        <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: 500; color: #333333; padding-bottom: 6px;">
           Permissões da função
         </td>
       </tr>
       <tr>
-        <td bgcolor="#f4f4f5"
-          style="background-color: #f4f4f5; border: 1px solid #e4e4e7; padding: 12px 16px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #18181b;">{{ role_permissions }}</span>
+        <td bgcolor="#ffffff"
+          style="background-color: #ffffff; border: 1px solid #dddddd; border-radius: 6px; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555;">{{ role_permissions }}</span>
         </td>
       </tr>
     </table>
@@ -32,11 +32,11 @@
   <td>
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td width="3" bgcolor="#7c3aed"
-          style="background-color: #7c3aed; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
-        <td bgcolor="#faf5ff"
-          style="background-color: #faf5ff; padding: 10px 14px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #6d28d9;">
+        <td width="3" bgcolor="#7dd3fc"
+          style="background-color: #7dd3fc; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
+        <td bgcolor="#f0f9ff"
+          style="background-color: #f0f9ff; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12.5px; color: #4c1d95; line-height: 1.5;">
             Não estava esperando este convite? Avise o administrador do sistema.
           </span>
         </td>

--- a/templates/pt-br/email/magic-link-request.jinja
+++ b/templates/pt-br/email/magic-link-request.jinja
@@ -6,19 +6,19 @@
 
 {% block contenttable %}
 <tr>
-  <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #3f3f46; line-height: 1.6; padding-bottom: 20px;">
+  <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555; line-height: 1.6; padding-bottom: 24px;">
     Aqui está seu link de acesso para o {{ domain_name }}. Clique no botão e você verá
     um código de 6 dígitos para inserir no aplicativo — válido por
-    <strong style="color: #18181b;">15 minutos</strong>, uso único.
+    <strong style="color: #1a1a1a;">15 minutos</strong>, uso único.
   </td>
 </tr>
 <tr>
-  <td style="padding-bottom: 24px;">
-    <table cellpadding="0" cellspacing="0" border="0">
+  <td align="center" style="padding-bottom: 24px; text-align: center;">
+    <table cellpadding="0" cellspacing="0" border="0" align="center">
       <tr>
-        <td bgcolor="#7c3aed" style="background-color: #7c3aed;">
+        <td bgcolor="#8b5cf6" style="background-color: #8b5cf6; border-radius: 6px;">
           <a href="{{ magic_link_url }}"
-            style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; font-weight: 600; color: #ffffff; text-decoration: none; display: inline-block; padding: 12px 32px; text-transform: uppercase;">
+            style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; font-weight: 600; color: #ffffff; text-decoration: none; display: inline-block; padding: 12px 32px;">
             Visualizar Código de Login
           </a>
         </td>
@@ -27,17 +27,17 @@
   </td>
 </tr>
 <tr>
-  <td style="padding-bottom: 20px;">
+  <td style="padding-bottom: 24px;">
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #71717a; padding-bottom: 6px;">
+        <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12px; color: #999999; padding-bottom: 6px;">
           O botão não funcionou? Copie e cole este endereço no navegador:
         </td>
       </tr>
       <tr>
-        <td bgcolor="#f4f4f5"
-          style="background-color: #f4f4f5; border: 1px solid #e4e4e7; padding: 10px 14px;">
-          <span style="font-family: 'Courier New', Courier, monospace; font-size: 12px; color: #18181b; word-break: break-all;">{{ magic_link_url }}</span>
+        <td bgcolor="#ffffff"
+          style="background-color: #ffffff; border: 1px solid #dddddd; border-radius: 6px; padding: 10px 12px;">
+          <span style="font-family: 'JetBrains Mono', 'Courier New', Courier, monospace; font-size: 12px; color: #555555; word-break: break-all;">{{ magic_link_url }}</span>
         </td>
       </tr>
     </table>
@@ -47,11 +47,11 @@
   <td>
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td width="3" bgcolor="#7c3aed"
-          style="background-color: #7c3aed; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
-        <td bgcolor="#faf5ff"
-          style="background-color: #faf5ff; padding: 10px 14px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #6d28d9;">
+        <td width="3" bgcolor="#7dd3fc"
+          style="background-color: #7dd3fc; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
+        <td bgcolor="#f0f9ff"
+          style="background-color: #f0f9ff; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12.5px; color: #4c1d95; line-height: 1.5;">
             Não foi você? Pode ignorar este e-mail — nada vai mudar na sua conta.
           </span>
         </td>

--- a/templates/pt-br/email/mfa-activation-start.jinja
+++ b/templates/pt-br/email/mfa-activation-start.jinja
@@ -6,7 +6,7 @@
 
 {% block contenttable %}
 <tr>
-  <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #3f3f46; line-height: 1.6; padding-bottom: 20px;">
+  <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555; line-height: 1.6; padding-bottom: 24px;">
     Você começou a ativar a autenticação de dois fatores (2FA) na sua conta do
     {{ domain_name }}. Acesse o aplicativo para concluir a configuração.
   </td>
@@ -15,11 +15,11 @@
   <td>
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td width="3" bgcolor="#7c3aed"
-          style="background-color: #7c3aed; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
-        <td bgcolor="#faf5ff"
-          style="background-color: #faf5ff; padding: 10px 14px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #6d28d9;">
+        <td width="3" bgcolor="#7dd3fc"
+          style="background-color: #7dd3fc; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
+        <td bgcolor="#f0f9ff"
+          style="background-color: #f0f9ff; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12.5px; color: #4c1d95; line-height: 1.5;">
             Não foi você? Proteja sua conta e entre em contato com o suporte agora.
           </span>
         </td>

--- a/templates/pt-br/email/mfa-activation-validated.jinja
+++ b/templates/pt-br/email/mfa-activation-validated.jinja
@@ -6,7 +6,7 @@
 
 {% block contenttable %}
 <tr>
-  <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #3f3f46; line-height: 1.6; padding-bottom: 20px;">
+  <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555; line-height: 1.6; padding-bottom: 24px;">
     A autenticação de dois fatores está ativa na sua conta do
     {{ domain_name }}. Sua conta está bem protegida.
   </td>
@@ -15,11 +15,11 @@
   <td>
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td width="3" bgcolor="#7c3aed"
-          style="background-color: #7c3aed; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
-        <td bgcolor="#faf5ff"
-          style="background-color: #faf5ff; padding: 10px 14px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #6d28d9;">
+        <td width="3" bgcolor="#7dd3fc"
+          style="background-color: #7dd3fc; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
+        <td bgcolor="#f0f9ff"
+          style="background-color: #f0f9ff; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12.5px; color: #4c1d95; line-height: 1.5;">
             Não foi você? Entre em contato com o suporte imediatamente.
           </span>
         </td>

--- a/templates/pt-br/email/mfa-disable.jinja
+++ b/templates/pt-br/email/mfa-disable.jinja
@@ -6,7 +6,7 @@
 
 {% block contenttable %}
 <tr>
-  <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #3f3f46; line-height: 1.6; padding-bottom: 20px;">
+  <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555; line-height: 1.6; padding-bottom: 24px;">
     A autenticação de dois fatores foi desativada na sua conta do {{ domain_name }}.
   </td>
 </tr>
@@ -17,8 +17,8 @@
         <td width="3" bgcolor="#f59e0b"
           style="background-color: #f59e0b; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
         <td bgcolor="#fff7ed"
-          style="background-color: #fff7ed; padding: 10px 14px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #92400e;">
+          style="background-color: #fff7ed; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12.5px; color: #92400e; line-height: 1.5;">
             Sem o 2FA sua conta fica menos protegida. Se não foi você, reative agora e entre em contato com o suporte.
           </span>
         </td>

--- a/templates/pt-br/email/password-reset-confirmation.jinja
+++ b/templates/pt-br/email/password-reset-confirmation.jinja
@@ -6,7 +6,7 @@
 
 {% block contenttable %}
 <tr>
-  <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #3f3f46; line-height: 1.6; padding-bottom: 20px;">
+  <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555; line-height: 1.6; padding-bottom: 24px;">
     A senha da sua conta no {{ domain_name }} foi alterada com sucesso.
   </td>
 </tr>
@@ -17,8 +17,8 @@
         <td width="3" bgcolor="#f59e0b"
           style="background-color: #f59e0b; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
         <td bgcolor="#fff7ed"
-          style="background-color: #fff7ed; padding: 10px 14px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #92400e;">
+          style="background-color: #fff7ed; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12.5px; color: #92400e; line-height: 1.5;">
             Não foi você? Entre em contato com o suporte agora — sua conta pode estar em risco.
           </span>
         </td>

--- a/templates/pt-br/email/password-reset-initiated.jinja
+++ b/templates/pt-br/email/password-reset-initiated.jinja
@@ -6,7 +6,7 @@
 
 {% block contenttable %}
 <tr>
-  <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; color: #3f3f46; line-height: 1.6; padding-bottom: 20px;">
+  <td style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 14px; color: #555555; line-height: 1.6; padding-bottom: 24px;">
     Uma redefinição de senha foi solicitada para sua conta no {{ domain_name }}.
     Use o código abaixo para continuar.
   </td>
@@ -15,16 +15,17 @@
   <td style="padding-bottom: 24px;">
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td bgcolor="#f4f4f5"
-          style="background-color: #f4f4f5; border: 1px solid #e4e4e7; padding: 24px; text-align: center;">
-          <span style="font-family: 'Courier New', Courier, monospace; font-size: 36px; font-weight: bold; color: #18181b; letter-spacing: 0.15em;">{{ verification_code }}</span>
+        <td align="center" bgcolor="#bae6fd"
+          style="background-color: #bae6fd; border-radius: 6px; padding: 16px 40px; text-align: center;">
+          <span style="font-family: 'JetBrains Mono', 'Courier New', Courier, monospace; font-size: 36px; font-weight: bold; color: #1a1a1a; letter-spacing: 0.18em;">{{ verification_code }}</span>
         </td>
       </tr>
       <tr>
-        <td height="8" style="font-size: 0; line-height: 0;">&nbsp;</td>
+        <td height="12" style="font-size: 0; line-height: 0;">&nbsp;</td>
       </tr>
       <tr>
-        <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #71717a; text-align: center;">
+        <td align="center"
+          style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12px; color: #999999; text-align: center;">
           Expira em 15 minutos.
         </td>
       </tr>
@@ -35,11 +36,11 @@
   <td>
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
       <tr>
-        <td width="3" bgcolor="#7c3aed"
-          style="background-color: #7c3aed; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
-        <td bgcolor="#faf5ff"
-          style="background-color: #faf5ff; padding: 10px 14px;">
-          <span style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 12px; color: #6d28d9;">
+        <td width="3" bgcolor="#7dd3fc"
+          style="background-color: #7dd3fc; width: 3px; font-size: 0; line-height: 0;">&#8203;</td>
+        <td bgcolor="#f0f9ff"
+          style="background-color: #f0f9ff; padding: 10px 12px;">
+          <span style="font-family: 'Inter', 'Open Sans', Helvetica, Arial, sans-serif; font-size: 12.5px; color: #4c1d95; line-height: 1.5;">
             Não foi você? Pode ignorar este e-mail — sua senha não será alterada.
           </span>
         </td>


### PR DESCRIPTION
## What

All 33 transactional email templates (`base.jinja` + 10 messages, ×3 locales) now use the visual
language of `templates/web/*.html`. Presentation only — no Rust, no config, no behaviour change,
`.subject` files untouched.

The gateway renders two families of user-facing HTML from the same Tera registry and they looked
like two unrelated products:

| | Before (email) | After (= `templates/web/`) |
|---|---|---|
| Canvas | `#f4f4f5` | `#f5f3ff` |
| Card | square, zinc borders | white, radius 12px, soft shadow |
| Brand | dark `#18181b` band, Georgia serif wordmark | violet `#8b5cf6` uppercase eyebrow inside the card |
| Heading | Georgia + 2px violet rule | Inter-first `#4c1d95`, no rule |
| Body | `#3f3f46`, system stack | `#555`, Inter-first stack |
| Code chip | `#f4f4f5` box + `#e4e4e7` border | `#bae6fd`, radius 6px, JetBrains-Mono-first, tracking `.18em` |
| Button | square uppercase `#7c3aed` | `#8b5cf6`, radius 6px, not uppercase |
| Fields / URL block | zinc box | web input token — `1px #ddd`, radius 6px |
| Info callout | `#faf5ff` + `#7c3aed` | `#f0f9ff` + 3px `#7dd3fc` |
| Footer | zinc band outside the card | inside the card, below a `#ddd6fe` hairline, muted-note styling |

## Deliberate divergences

Recorded in the spec so they aren't mistaken for oversights:

- **No inline SVG, no `<script>`, no `display:flex`.** The web pages lean on all three (check/error
  badges, eye toggle, copy button, clipboard JS). Gmail and Outlook strip them, leaving blank holes.
- **Webfonts are progressive enhancement.** `<link>` + `@import` for Inter and JetBrains Mono, with
  a complete inline fallback stack on every text element. Apple Mail/iOS get the real fonts; Gmail
  and Outlook fall back to Helvetica/Arial with no layout damage.
- **The amber warning tier stays** (`mfa-disable`, `password-reset-confirmation`). "2FA disabled" and
  "your password changed" are security notices, not errors, so they keep amber hues while adopting
  the web callout geometry.
- **Radius and shadow degrade** to square/flat in Word-engine clients (Outlook desktop) rather than
  shipping VML round-rect shims.
- The callout keeps the 3px left rule but not the 4px radius — a two-cell rule+fill construct can't
  round only its outer corners without a wrapper Outlook mishandles.

## Incidental fixes

- `pt-br/email/base.jinja` rendered the English string `Questions?` in the Portuguese footer.
- `es/magic-link-request` URL box used `padding: 12px 16px` where the other locales used `10px 14px`.
- `create-connection-string` / `create-user-account` value spans carried `font-weight: 600` in
  `en-us`/`pt-br` but not in `es`.

## Verification

`cargo fmt --check`, `cargo build --workspace` and `cargo test --workspace --all` all pass — but they
are **necessary, not sufficient**: no test asserts on rendered template HTML, and since `ports/api`
has `default = ["full"]`, the notifier's `local-transport` tests don't even compile in the default
run. A broken template would sail through every gate.

So correctness was established by rendering, using a throwaway harness (not committed) that mirrors
`core/src/settings.rs`:

| Check | Result |
|---|---|
| Render with a superset context | **64/64 PASS** — 30 bodies + 30 `.subject` + 4 `web/*.html` reference pages |
| Banned tokens under `templates/*/email/` | 0 hits for `<svg`, `<script`, `display:flex`, `Georgia`, `#18181b`, `#f4f4f5`, `#e4e4e7`, `#71717a`, `#a1a1aa`, `#7c3aed`, `#faf5ff`, `#3f3f46`, `BlinkMacSystemFont` |
| `text-transform: uppercase` | exactly 3 — the brand eyebrow in each `base.jinja` |
| Locale structural equivalence | `SAME` for all 11 files, `en-us`↔`pt-br` and `en-us`↔`es` (tags, colors, font stacks, weights, paddings, radii, spacer heights, letter-spacing) |
| `.subject` files | byte-identical to baseline renders |
| Diff scope | 33 `.jinja` files, all under `templates/{en-us,es,pt-br}/email/` |

Reviewed against the rendered previews side by side with `web/magic-link-display.html` and
`web/instance-bootstrap-claim.html`. **Not yet checked in a real Outlook client** — the expected
result there is a square, shadowless card with system fonts, which is the documented degradation.

Spec, design (token map + component recipes) and tasks are in
`.claude/specs/features/email-template-web-parity/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)