### PR TITLE
fix(build): vendor the Swagger UI archive instead of downloading it at build time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5511,8 +5511,15 @@ dependencies = [
  "serde_json",
  "url",
  "utoipa",
+ "utoipa-swagger-ui-vendored",
  "zip 3.0.0",
 ]
+
+[[package]]
+name = "utoipa-swagger-ui-vendored"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ tracing-opentelemetry = "0.32"
 toml = "0.9"
 uuid = { version = "1.1", features = ["v3", "v4", "v7", "serde", "fast-rng"] }
 utoipa-redoc = { version = "5", features = ["actix-web"] }
-utoipa-swagger-ui = { version = "9", features = ["actix-web"] }
+utoipa-swagger-ui = { version = "9", features = ["actix-web", "vendored"] }
 wildmatch = "2.1"
 zstd = "0.13"
 


### PR DESCRIPTION
This is the durable fix for the CI failures on #183, #184 and `develop`. One line in `Cargo.toml`. Your call whether it goes in before the release.

## The problem

`utoipa-swagger-ui`'s build script downloads `swagger-ui/archive/refs/tags/v5.17.14.zip` from GitHub on every cold build, with **no retry**. When that fetch is disturbed the build dies, and the error does not look like a network error:

```
failed to open downloaded Swagger UI: InvalidArchive("Could not find EOCD")
failed to download Swagger UI: curl download file exited with error status: exit status: 56
```

Both are the same thing — a truncated or aborted download. `EOCD` is the zip end-of-central-directory record, missing because the archive is incomplete; curl 56 is "failure in receiving network data".

**Three CI runs hit this today:**

| Run | Branch | Symptom |
|---|---|---|
| `31623378288` | `feat/single-file-postgres-install` (#183) | `InvalidArchive("Could not find EOCD")` — Build + Test |
| `31624551978` | `develop`, after #183 merged | same |
| `31625000873` | `docs/i18n-catalog-sync` (#184) | `curl … exit status: 56` — Test |

Each was cleared by nothing more than a re-run, on changes that touched no Rust at all (#183 was SQL and docs; #184 was a `.po` file). `Standalone Build` looked immune only because its `Swatinem/rust-cache` entry still held a prebuilt artifact — the `Build` and `Test` caches had aged out, since `develop` had not run CI since 2026-07-29. Now that the caches are cold, this will keep recurring, and #185 is exposed to it.

Verified the URL itself is healthy: fetched it locally, HTTP 200, 4,388,280 bytes, 1097 entries, valid archive. The upstream artifact is fine; the fetch is what is unreliable.

## The fix

The crate already ships a `vendored` feature that embeds the archive through `utoipa-swagger-ui-vendored`:

```rust
// utoipa-swagger-ui-9.0.2/build.rs
if env::var("CARGO_FEATURE_VENDORED").is_ok() {
    println!("using vendored Swagger UI");
    let vendred_bytes = utoipa_swagger_ui_vendored::SWAGGER_UI_VENDORED;
```

With it enabled the build script takes an offline branch and never invokes curl.

**No behavioural change:** `utoipa-swagger-ui-vendored` 0.1.2 embeds `res/v5.17.14.zip` — the same version and the same file the default URL serves:

```rust
pub const SWAGGER_UI_VENDORED: &[u8] = std::include_bytes!("../res/v5.17.14.zip");
```

This fixes **every** build path, not just CI: Docker image builds, the release pipeline, and cold local builds all stop depending on GitHub being reachable and well-behaved. That matters more than usual right now — the stable release publishes ~15 crates and builds a signed image, all from cold caches.

Considered and rejected: caching the zip in CI with `actions/cache` + a retrying `curl` and pointing `SWAGGER_UI_DOWNLOAD_URL` at a `file://` path. It works, but it needs duplicating across three jobs, leaves the Docker and local paths still exposed, and hardcodes a version string that has to be kept in step with whatever `utoipa-swagger-ui` defaults to. The feature flag is one line and cannot drift.

## New dependency justification

Per the repo's security rule. `utoipa-swagger-ui-vendored` is a **build**-dependency of an existing direct dependency, from the same authors and repository (`juhaku/utoipa`), behind a feature that crate already declares. It removes a network fetch from the build rather than adding capability. It adds ~4.4 MB to the crate download, once, cached like any other crate.

## Verification

- Build script log now reports `using vendored Swagger UI` and no download line.
- `cargo fmt --all -- --check` — pass
- `cargo build --workspace` — pass
- `cargo test --workspace --all` — **455 passed, 0 failed**
- `cargo build -p mycelium-api --no-default-features --features standalone` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)