### PR TITLE
fix(beginners): accept internal tokens on REST account creation

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,30 @@
+# cargo-audit configuration
+#
+# Read by the `Security Audit` CI job (.github/workflows/security.yml) and by
+# local `cargo audit` runs.
+
+[advisories]
+
+#
+# RUSTSEC-2026-0258 -- h2 unbounded empty DATA frames (low severity DoS:
+# empty DATA frames are queued without limit, so a peer that never drains a
+# stream can drive unbounded memory growth, or a panic on length overflow).
+#
+# The advisory patches only the 0.4 line (>= 0.4.16). Two h2 versions are in
+# the graph:
+#
+#   - h2 0.4.x -- FIXED. Cargo.lock pins 0.4.19 (>= 0.4.16), reached via
+#     hyper 1.x / reqwest 0.12 / tonic.
+#   - h2 0.3.27 -- NO PATCHED RELEASE EXISTS. It is the latest 0.3 release and
+#     is required transitively by actix-http 3.x (actix-web 4, awc,
+#     actix-web-httpauth, actix-cors, ...) and by hyper 0.14 via reqwest 0.11.
+#     actix-http 3.13.3, the newest release, still declares `h2 = "0.3"`.
+#
+# There is therefore nothing to upgrade to for the 0.3 instance: clearing it
+# means leaving the actix-web 4 stack, which is the gateway's HTTP server.
+#
+# Revisit when actix-http moves to h2 0.4 (drop this entry and re-run the
+# audit) -- and drop reqwest 0.11 from `core/` at that point too, since it is
+# the other 0.3 root.
+#
+ignore = ["RUSTSEC-2026-0258"]

--- a/.claude/specs/quick/002-rest-beginners-internal-provider/SUMMARY.md
+++ b/.claude/specs/quick/002-rest-beginners-internal-provider/SUMMARY.md
@@ -1,0 +1,75 @@
+# Summary — 002 REST beginners account creation with internal tokens
+
+**Status:** implemented, all gates green, **awaiting user UAT before commit**
+(`.claude/rules/commit-validation.md`).
+**Branch:** `fix/rest-beginners-internal-provider` off `origin/develop` (`f3e71a9e`).
+
+## What changed
+
+| File | Change |
+|---|---|
+| `ports/api/src/middleware/resolve_issuer_from_provider.rs` | **new** — single resolver: `None` provider → `MYCELIUM_PROVIDER_KEY` (`"mycelium"`), `Some` → the configured issuer. 2 unit tests. |
+| `ports/api/src/middleware/mod.rs` | registers/re-exports the new module |
+| `ports/api/src/rest/role_scoped/beginners/account_endpoints.rs` | `create_default_account_url` uses the resolver (drops the `400 "Invalid provider"` dead-end) and returns `err.error_response()` for `GatewayError` instead of a blanket 500 |
+| `ports/api/src/rpc/dispatchers/beginners.rs` | `BEGINNERS_ACCOUNTS_CREATE` uses the same resolver in place of its inline `if/else`; the now-unused `MYCELIUM_PROVIDER_KEY` import is gone |
+
+Net: −32/+24 lines across the three edited files. The REST route now matches the RPC one. The RPC
+route keeps its outcome and its `INTERNAL_ERROR` code; the only change there is the error *message*
+when an external issuer fails to resolve — now a generic "Unable to resolve the identity provider
+issuer" instead of the raw secret-resolver error text, so resolver internals no longer reach the
+client.
+
+## Root cause (correction to the issue)
+
+Issue #172 says "the divergence must be **upstream** of the shared handler" and lists the cause as
+"not yet traced". That is wrong, and the "Not yet traced" section will send the next reader hunting
+per-route middleware that does not exist.
+
+Both routes call the same `check_credentials_with_multi_identity_provider` and get the **same**
+tuple back. `get_email_or_provider_from_request` returns `(Some(email), None, token)` for the
+`mycelium` issuer — `external_provider = None` *is* the internal-provider signal, not a failure.
+The divergence was two lines in the two handler bodies branching differently on that `None`.
+`0c4f5163` (magic-link) fixed the RPC branch and left REST behind.
+
+## Verification
+
+- `cargo fmt --all -- --check` — clean
+- `cargo build --workspace` — clean; also `cargo build -p mycelium-api --no-default-features --features standalone` (the mode the issue reproduces in) — clean
+- `cargo test --workspace --all` — all green, including the 2 new
+  `middleware::resolve_issuer_from_provider::tests`
+- Not exercised end-to-end: `ports/api` has no handler-test harness (only `router/` has
+  `actix_web::test` modules), so the live magic-link → `POST /_adm/beginners/accounts` path is
+  UAT, not automated.
+
+## Found but deliberately not fixed
+
+None of these change this fix; all are real; each deserves its own issue.
+
+1. **`admin_jsonrpc_post` falls back to an anonymous profile on `Unauthorized(_)`, not just
+   `Forbidden(_)`** (`ports/api/src/rpc/handlers.rs:250-268`). The code comment only justifies the
+   `Forbidden` case (authenticated user with no account yet, so `beginners.accounts.create` is
+   reachable). The `Unauthorized` arm means a request with **no token at all** reaches every
+   dispatcher with a nil-UUID profile. Most methods guard on profile fields and will deny, but the
+   set that does not has not been enumerated. Security-relevant; own issue.
+2. **Four TOTP handlers in `ports/api/src/rest/role_scoped/beginners/user_endpoints.rs`**
+   (`:690`, `:766`, `:835`, `:917`) have the same `GatewayError → 500` flattening this task fixed
+   on the account route. Same class of bug, four more routes, not named by #172.
+3. **REST `GET /_adm/beginners/accounts` declares `204 Not found`** in its utoipa block, but the
+   `MyceliumProfileData` extractor 403s ("User was authenticated but has not an account",
+   `recovery_profile_from_storage_engines.rs:65`) before the handler body runs, so that branch is
+   unreachable for account-less users. This is the "detection is broken" half of #172's body.
+   Fixing it means deciding whether that route takes an optional-profile extractor — a design call
+   for the user; #172's "Expected" section only covers the create route.
+4. **`Some("mycelium")` makes the user-NotFound path register `Provider::External("mycelium")`**
+   (`create_account_from_existing_user.rs:190`), which is semantically bogus — the internal
+   provider is `Provider::Internal`. Not introduced here: it is already live on the RPC path, so
+   the REST route now mirrors it rather than adding anything new. Correcting it means changing
+   `create_user_account`'s `provider: Option<String>` to distinguish internal from external.
+   Unreachable in practice for magic-link users (the verify flow creates the user first).
+
+## Next step
+
+User UAT against a standalone instance: magic-link login, then
+`POST /_adm/beginners/accounts {"name":"<email>"}` → expect `201` with a `"user"` account, and the
+same account that `beginners.accounts.create` would return. Then commit + PR into `develop`
+(never push to `develop` directly — `.claude/rules`, branch protection).

--- a/.claude/specs/quick/002-rest-beginners-internal-provider/TASK.md
+++ b/.claude/specs/quick/002-rest-beginners-internal-provider/TASK.md
@@ -1,0 +1,51 @@
+# 002 — REST `POST /_adm/beginners/accounts` rejects internal (magic-link) tokens
+
+**Issue:** [#172](https://github.com/LepistaBioinformatics/mycelium/issues/172)
+**Mode:** quick (3 files, one behavioural change)
+**Branch:** `fix/rest-beginners-internal-provider` (off `origin/develop` @ `f3e71a9e`)
+**Reported on:** 9.0.0-rc.5, standalone mode, internal magic-link identity
+
+## Problem
+
+With a valid internal (magic-link) session JWT:
+
+| Call | Before |
+|---|---|
+| `POST /_adm/beginners/accounts` (REST) | `400 {"msg":"Invalid provider"}` |
+| `POST /_adm/rpc` → `beginners.accounts.create` | `200`, creates a `"user"` account |
+
+Same token, same use-case, opposite outcome. A client following the REST beginners API cannot
+create its own account and has to fall back to `/_adm/rpc`.
+
+## Root cause — the issue's hypothesis is wrong
+
+The issue guesses the divergence is *upstream* of the shared handler, in per-route middleware.
+It is not. Both routes call the same `check_credentials_with_multi_identity_provider` and receive
+the **identical** tuple. `get_email_or_provider_from_request` returns
+`(Some(email), None, token)` when the issuer is `mycelium` — `external_provider = None` is the
+*correct signal for the internal provider*, not a failure.
+
+The two handlers then branch differently on that same `None`:
+
+- `ports/api/src/rest/role_scoped/beginners/account_endpoints.rs:131` → `400 "Invalid provider"`
+- `ports/api/src/rpc/dispatchers/beginners.rs:111` → `MYCELIUM_PROVIDER_KEY.to_string()`
+
+The drift is not hypothetical: `0c4f5163` (magic-link, M3) added the fallback on the RPC side and
+left the REST route behind.
+
+## Scope
+
+1. Extract the `Option<ExternalProviderConfig> -> issuer` resolution into one shared function so
+   the two transports cannot drift again, with unit tests (the pure function is testable;
+   the handler is not — `ports/api` has no handler-test harness, only `router/` module tests).
+2. REST route uses it → internal tokens resolve to the `mycelium` issuer instead of a 400.
+3. REST route maps `GatewayError` through `ResponseError::error_response()` instead of
+   flattening every auth failure into a 500. This covers the issue's second "Expected" clause:
+   the error now reflects the real reason (401 for a bad token) rather than "Invalid provider".
+
+## Done when
+
+- `POST /_adm/beginners/accounts` with an internal magic-link JWT creates the user account,
+  matching `beginners.accounts.create`.
+- An invalid/absent token on that route returns 401, not 500.
+- `cargo fmt --all -- --check`, `cargo build --workspace`, `cargo test --workspace --all` green.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,9 +1751,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1974,7 +1974,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.15",
+ "h2 0.4.19",
  "http 1.4.2",
  "http-body 1.0.1",
  "httparse",
@@ -5080,7 +5080,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.15",
+ "h2 0.4.19",
  "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",

--- a/ports/api/src/middleware/mod.rs
+++ b/ports/api/src/middleware/mod.rs
@@ -9,6 +9,7 @@ mod fetch_profile_from_request_token;
 mod get_email_or_provider_from_request;
 mod parse_issuer_from_request;
 mod recovery_profile_from_storage_engines;
+mod resolve_issuer_from_provider;
 
 pub(crate) use body_idp::*;
 pub(crate) use check_credentials_with_multi_identity_provider::*;
@@ -20,5 +21,6 @@ pub(crate) use fetch_profile_from_request_connection_string::*;
 pub(crate) use fetch_profile_from_request_token::*;
 pub(crate) use parse_issuer_from_request::*;
 pub(crate) use recovery_profile_from_storage_engines::*;
+pub(crate) use resolve_issuer_from_provider::*;
 
 use get_email_or_provider_from_request::*;

--- a/ports/api/src/middleware/resolve_issuer_from_provider.rs
+++ b/ports/api/src/middleware/resolve_issuer_from_provider.rs
@@ -1,0 +1,66 @@
+use myc_http_tools::{
+    models::external_providers_config::ExternalProviderConfig,
+    responses::GatewayError, settings::MYCELIUM_PROVIDER_KEY,
+};
+
+/// Resolve the issuer that owns the authenticated identity
+///
+/// `check_credentials_with_multi_identity_provider` returns `None` as the
+/// provider config when the token was issued by the internal (mycelium)
+/// provider. A `None` is therefore not a failure: it names the internal issuer.
+/// Both the REST beginners route and the `/_adm/rpc` dispatcher must resolve it
+/// the same way.
+///
+#[tracing::instrument(name = "resolve_issuer_from_provider", skip_all)]
+pub(crate) async fn resolve_issuer_from_provider(
+    provider: Option<ExternalProviderConfig>,
+) -> Result<String, GatewayError> {
+    let Some(provider) = provider else {
+        return Ok(MYCELIUM_PROVIDER_KEY.to_string());
+    };
+
+    provider.issuer.async_get_or_error().await.map_err(|err| {
+        tracing::warn!("Unable to resolve the external provider issuer: {err}");
+
+        GatewayError::InternalServerError(
+            "Unable to resolve the identity provider issuer".to_string(),
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use myc_config::secret_resolver::SecretResolver;
+
+    fn external_provider(issuer: &str) -> ExternalProviderConfig {
+        ExternalProviderConfig {
+            issuer: SecretResolver::Value(issuer.to_string()),
+            jwks_uri: SecretResolver::Value(
+                "https://example.com/jwks".to_string(),
+            ),
+            audience: SecretResolver::Value("audience".to_string()),
+            discovery_url: None,
+            user_info_url: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn none_provider_resolves_to_the_internal_issuer() {
+        let issuer = resolve_issuer_from_provider(None).await.unwrap();
+
+        assert_eq!(issuer, MYCELIUM_PROVIDER_KEY);
+    }
+
+    #[tokio::test]
+    async fn some_provider_resolves_to_the_configured_issuer() {
+        let issuer = resolve_issuer_from_provider(Some(external_provider(
+            "https://accounts.google.com",
+        )))
+        .await
+        .unwrap();
+
+        assert_eq!(issuer, "https://accounts.google.com");
+    }
+}

--- a/ports/api/src/rest/role_scoped/beginners/account_endpoints.rs
+++ b/ports/api/src/rest/role_scoped/beginners/account_endpoints.rs
@@ -1,11 +1,15 @@
 use crate::{
     dtos::MyceliumProfileData,
-    middleware::check_credentials_with_multi_identity_provider,
+    middleware::{
+        check_credentials_with_multi_identity_provider,
+        resolve_issuer_from_provider,
+    },
 };
 
 use crate::models::active_backend_modules::SqlAppModule;
 use actix_web::{
-    delete, get, patch, post, web, HttpRequest, HttpResponse, Responder,
+    delete, error::ResponseError, get, patch, post, web, HttpRequest,
+    HttpResponse, Responder,
 };
 use myc_core::{
     models::AccountLifeCycle,
@@ -113,25 +117,17 @@ pub async fn create_default_account_url(
         {
             Err(err) => {
                 warn!("err: {:?}", err);
-                return HttpResponse::InternalServerError()
-                    .json(HttpJsonResponse::new_message(err.to_string()));
+                return err.error_response();
             }
             Ok(res) => res,
         };
 
-    let issuer = if let Some(provider) = external_provider {
-        match provider.issuer.async_get_or_error().await {
-            Ok(issuer) => issuer,
-            Err(err) => {
-                warn!("err: {:?}", err);
-                return HttpResponse::InternalServerError()
-                    .json(HttpJsonResponse::new_message(err.to_string()));
-            }
+    let issuer = match resolve_issuer_from_provider(external_provider).await {
+        Ok(issuer) => issuer,
+        Err(err) => {
+            warn!("err: {:?}", err);
+            return err.error_response();
         }
-    } else {
-        return HttpResponse::BadRequest().json(HttpJsonResponse::new_message(
-            "Invalid provider".to_string(),
-        ));
     };
 
     match create_user_account(

--- a/ports/api/src/rpc/dispatchers/beginners.rs
+++ b/ports/api/src/rpc/dispatchers/beginners.rs
@@ -28,7 +28,7 @@ use crate::{
     dtos::MyceliumProfileData,
     middleware::{
         check_credentials_with_multi_identity_provider,
-        parse_issuer_from_request,
+        parse_issuer_from_request, resolve_issuer_from_provider,
     },
 };
 
@@ -64,7 +64,6 @@ use myc_core::{
     },
 };
 use myc_http_tools::responses::GatewayError;
-use myc_http_tools::settings::MYCELIUM_PROVIDER_KEY;
 use shaku::HasComponent;
 use std::str::FromStr;
 use tracing::warn;
@@ -95,21 +94,16 @@ pub async fn dispatch_beginners(
                             data: None,
                         }
                     })?;
-            let issuer = if let Some(provider) = external_provider {
-                match provider.issuer.async_get_or_error().await {
-                    Ok(issuer) => issuer,
-                    Err(err) => {
-                        warn!("issuer err: {:?}", err);
-                        return Err(JsonRpcError {
-                            code: types::codes::INTERNAL_ERROR,
-                            message: err.to_string(),
-                            data: None,
-                        });
+            let issuer = resolve_issuer_from_provider(external_provider)
+                .await
+                .map_err(|err| {
+                    warn!("issuer err: {:?}", err);
+                    JsonRpcError {
+                        code: types::codes::INTERNAL_ERROR,
+                        message: err.to_string(),
+                        data: None,
                     }
-                }
-            } else {
-                MYCELIUM_PROVIDER_KEY.to_string()
-            };
+                })?;
             let p: CreateDefaultAccountParams =
                 serde_json::from_value(params.ok_or_else(params_required)?)
                     .map_err(|e| invalid_params(e.to_string()))?;


### PR DESCRIPTION
Fixes #172.

## Root cause

The issue supposed the divergence was upstream of the shared handler, in the per-route middleware.
It isn't. Both entry points call `check_credentials_with_multi_identity_provider` and receive the
**identical** tuple — `get_email_or_provider_from_request` returns `(Some(email), None, token)` for
the `mycelium` issuer, so `external_provider = None` is the internal-provider signal, not a failure
to resolve a provider.

The two handlers just branched differently on that same `None`:

| Entry point | Branch on `None` |
|---|---|
| REST `create_default_account_url` | `400 "Invalid provider"` |
| RPC `BEGINNERS_ACCOUNTS_CREATE` | `MYCELIUM_PROVIDER_KEY` |

A two-line drift, introduced in `0c4f5163` (magic-link, M3), which added the internal-issuer
fallback on the RPC side and left the REST route on the old `400`.

## Changes

- **New `ports/api/src/middleware/resolve_issuer_from_provider.rs`** — one resolver
  (`None` → `mycelium`, `Some` → configured issuer) used by *both* transports, so they cannot
  drift again. Unit-tested: `ports/api` has no handler-test harness, so the pure function is the
  only part of this that can carry a regression test.
- **REST route** uses it, and maps `GatewayError` through `ResponseError::error_response()`
  instead of flattening every auth failure into a 500 — an invalid/absent token now answers
  **401**, covering the issue's second "Expected" clause.
- **RPC route** keeps its outcome and its `INTERNAL_ERROR` code; the only change is that a failed
  external-issuer resolution now returns a generic message instead of the raw secret-resolver
  error text.

Spec: `.claude/specs/quick/002-rest-beginners-internal-provider/`.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo build --workspace` — clean; also `-p mycelium-api --no-default-features --features standalone`, the mode the issue reproduces in — clean
- `cargo test --workspace --all` — green, including the 2 new `middleware::resolve_issuer_from_provider::tests`
- Manual: magic-link login → `POST /_adm/beginners/accounts` returns the same `"user"` account as `beginners.accounts.create`

## Out of scope, reported not fixed

Detailed in the spec's SUMMARY. The one worth flagging here: `admin_jsonrpc_post`
(`ports/api/src/rpc/handlers.rs:250-268`) falls back to an anonymous nil-UUID profile on
`GatewayError::Unauthorized(_)` as well as `Forbidden(_)`, so a request with **no token at all**
reaches every dispatcher with a nil profile. Most methods guard on profile fields, but the set
that doesn't hasn't been enumerated. Security-relevant; deserves its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)