### PR TITLE
feat(guest): allow granting a parentless guest role to whoever already holds it

### DIFF
--- a/.claude/specs/features/parentless-guest-role-grant/spec.md
+++ b/.claude/specs/features/parentless-guest-role-grant/spec.md
@@ -1,0 +1,161 @@
+# Feat: allow granting a parentless (root) guest role when the requester already holds it
+
+**Status:** Implemented — gates pending, awaiting user UAT before commit
+**Scope:** Medium (1 file changed + tests)
+**Issue:** [LepistaBioinformatics/mycelium#187](https://github.com/LepistaBioinformatics/mycelium/issues/187)
+**Branch:** `feat/parentless-guest-role-grant`
+
+---
+
+## Problem
+
+`guest_to_children_account` (`core/src/use_cases/role_scoped/account_manager/guest/guest_to_children_account.rs`)
+gates a grant on four rules:
+
+1. the requester holds `accounts-manager` **with write** on the tenant + target account;
+2. the granted role **has a parent** (`get_parent_by_child_id`);
+3. the requester **holds that parent**;
+4. the granted role is listed in `parent_role.children`.
+
+Rule (2) makes a **root role undelegable by anyone**, because a root role has no parent. In
+production the call fails at rule (2):
+
+```
+[codes=MYC00013 error_type=use-case-error]
+Guest role parent not found: <role-id>
+```
+
+Working around it via data is impossible: `insert_role_child` requires
+`parent.permission >= child.permission`, `get_or_create` de-duplicates on `(slug, permission)`,
+and `Permission` has only `Read = 0` / `Write = 1`. A same-slug parent for a `(slug, write)` role
+is therefore inexpressible, and a different-slug parent breaks downstream authorization —
+`LicensedResource.role` carries the **slug** and consumers match it by equality.
+
+---
+
+## Requirements
+
+| ID | Requirement |
+|---|---|
+| **R1** | When the target role **has a parent**, the existing rules (3) and (4) apply unchanged. |
+| **R2** | When the target role is a **root** (no parent), the grant is allowed if — and only if — the requester **already holds the target role itself**. |
+| **R3** | The root-path possession check runs against the profile **scoped to the tenant and the target account** (`on_tenant(tenant_id).on_account(target_account_id)`), not the full license list. Otherwise holding the role on one account would authorize granting it on another. |
+| **R4** | Possession is matched by `role_id`, not by slug — same predicate the parent check already uses. `get_or_create` de-duplicates on `(slug, permission)`, so a `role_id` match already pins the permission. |
+| **R5** | Rule (1) is untouched: `accounts-manager` with write on the tenant + target account is still required. |
+| **R6** | The target role is resolved **before** the parent branch. A nonexistent `target_role_id` has no parent, so resolving the parent first would route a missing role into the root path and report it as "you do not hold this role" instead of "guest role not found". |
+| **R7** | The root-path denial carries `MYC00013` + `with_exp_true()`, with a message distinct from the parent-path denial so the two branches are distinguishable in logs. |
+| **R8** | The public signature of `guest_to_children_account` does not change — the three entry points (REST `guest_endpoints.rs`, the RPC dispatcher, openrpc) are unaffected. |
+| **R9** | Documentation that encodes the old rule is corrected: the use-case doc comment, and the openrpc method description (`ports/api/src/rpc/openrpc/methods/account_manager.rs`), which described the target as "(child role)". The utoipa REST annotations never stated the rule and are untouched. |
+
+---
+
+## Decisions
+
+**The parent-path possession check stays unscoped.** The issue's rule table reads
+"target role has a parent → current rule", and rule (1) forces `accounts-manager` on the *target*
+account but nothing guarantees the requester holds the *parent role* on that same account — in a
+"guest to children account" topology they plausibly hold it on the managing account. Scoping it
+would be a behavior change beyond the issue and could break live grants.
+
+**Resulting asymmetry:** the root path is scoped to tenant + target account, the parent path is
+not. Recorded deliberately; worth a follow-up ticket to align them (would require confirming the
+production topology first).
+
+**Staff and manager profiles stay strict.** `get_related_account_or_error` short-circuits for
+`is_staff` / `is_manager` and returns before touching `licensed_resources`, so such a profile can
+clear rule (1) with an empty license list and then fail the possession check. That is exactly
+today's behavior on the parent path, and it preserves the invariant the issue states: **nobody
+grants what they do not have.**
+
+---
+
+## Anti-escalation invariant
+
+Preserved. The requester must hold, on the target account, either the parent of the granted role
+(existing path) or the granted role itself (new path). No path lets a requester grant a role they
+do not have.
+
+The change also narrows an existing inconsistency: the `subscriptions-manager` path
+(`guest_user_to_subscription_account`) applies **no hierarchy at all**, so the restriction fell
+only on the less privileged `accounts-manager` path.
+
+---
+
+## Adapter contract — verified
+
+The change reinterprets `get_parent_by_child_id` returning `NotFound` as "this role is a root".
+Both backends agree on that semantics, so the feature is **not** Postgres-only:
+
+| Adapter | No-parent result |
+|---|---|
+| `adapters/diesel_postgres/.../guest_role_fetching.rs:78` | `.optional()` → `Ok(FetchResponseKind::NotFound(Some(id)))` |
+| `adapters/diesel_sqlite/.../guest_role_fetching.rs:67` | `.optional()` → `Ok(FetchResponseKind::NotFound(Some(id)))` |
+
+Neither returns `Err(diesel::NotFound)` (which `?` would propagate before the branch is reached),
+and neither synthesizes an empty `Found` parent (which would route a root role into the parent
+path and fail on the `children` check). No other adapter implements `GuestRoleFetching` —
+`mem_db`, `kv_db`, `moka_cache`, `postgres_kv`, `service`, `shared` and `notifier` do not.
+
+This matters because SQLite backs Standalone Mode, which is shipped, and the seven tests all stub
+the trait — they could not have caught a divergence.
+
+---
+
+## Documentation touched
+
+Signature unchanged, so no entry point needed code changes. Two descriptions encoded the old
+"child role" framing and were corrected:
+
+- the use-case doc comment on `guest_to_children_account`;
+- the openrpc method description in
+  `ports/api/src/rpc/openrpc/methods/account_manager.rs`.
+
+The utoipa `#[utoipa::path]` block in `guest_endpoints.rs` never stated the hierarchy rule —
+untouched.
+
+---
+
+## Adapter contract — verified on both backends
+
+The change reinterprets `get_parent_by_child_id` returning `NotFound` as "this role is a root".
+That is a contract the use case now depends on, so both implementations were read:
+
+| Adapter | No-parent case | |
+|---|---|---|
+| `adapters/diesel_postgres/.../guest_role_fetching.rs:78` | `.first(conn).optional()` → `Ok(FetchResponseKind::NotFound(Some(id)))` | ok |
+| `adapters/diesel_sqlite/.../guest_role_fetching.rs:66` | `.first(conn).optional()` → `Ok(FetchResponseKind::NotFound(Some(id)))` | ok |
+
+Both use `.optional()`, so the absent parent surfaces as `Ok(NotFound)` rather than
+`Err(diesel::NotFound)` wrapped by `map_err`. Neither synthesizes an empty `Found` parent, which
+would otherwise route a root role into the parent path and fail on the `children` check. No other
+adapter implements `GuestRoleFetching`. **The feature therefore works identically on Postgres and
+on SQLite (Standalone Mode).**
+
+---
+
+## Tests
+
+`guest_to_children_account` had **no test coverage**. Added, in-file `#[cfg(test)]` per repo
+convention (hand-rolled `Stub*` structs, `#[tokio::test]`):
+
+| Case | Expected |
+|---|---|
+| root role, held by the requester on the target account | Ok |
+| root role, not held | Err MYC00013 |
+| root role held on a **different account** of the same tenant | Err MYC00013 (R3) |
+| child role, parent held | Ok |
+| child role, parent not held | Err MYC00013 |
+| child role, parent held but target not in `parent.children` | Err MYC00013 |
+| target role not found | Err MYC00013 "Guest role not found" (R6) |
+
+---
+
+## Out of scope
+
+- **Client-side mirroring.** Checked: `mycelium-webapp` needs no change — `GuestRoleSelector`
+  lists guest roles without filtering by hierarchy, so root roles were never hidden there.
+- **The slug-equality SDK helper** described in the issue's *Related finding* — explicitly a
+  separate ticket, outside this repository.
+- **A third `Permission` level (`Admin = 2`).** Considered in the issue and rejected here:
+  `Permission::from_i32` maps `_ => Read`, so any not-yet-updated service would silently read `2`
+  as read-only.

--- a/.claude/specs/project/STATE.md
+++ b/.claude/specs/project/STATE.md
@@ -1,7 +1,12 @@
 # State
 
-**Last Updated:** 2026-08-12
-**Current Work:** **9.0.0 stable release prep.** Single-file Postgres install
+**Last Updated:** 2026-08-28
+**Current Work:** **Issue #187 — parentless guest role grant**
+(`features/parentless-guest-role-grant/`, AD-011) implemented on branch
+`feat/parentless-guest-role-grant`, all gates green (338 core tests, 0 failures),
+**awaiting user UAT before commit**.
+
+**Also open:** **9.0.0 stable release prep.** Single-file Postgres install
 (`features/single-file-postgres-install/`, AD-010) implemented and verified on Postgres
 12/14/16, **awaiting user UAT before commit** — `up.sql` is now the complete 9.0.0 schema plus
 a new migration fixing a grant bug the fold exposed. Latest tag is `9.0.0-rc.12`; **open
@@ -21,6 +26,46 @@ Execute (see block below). Standalone Mode G1-G9 done, not committed yet. M1 ong
 ---
 
 ## Recent Decisions (Last 60 days)
+
+### AD-011: a root guest role is grantable by whoever already holds it (2026-08-28)
+
+**Feature:** `features/parentless-guest-role-grant/`. Closes issue #187.
+
+`guest_to_children_account` required the granted role to have a parent, which made every **root
+role undelegable by anyone** — `get_parent_by_child_id` returns NotFound and the call dies at
+MYC00013. The data-side workarounds are all closed: `insert_role_child` requires
+`parent.permission >= child.permission`, `get_or_create` de-duplicates on `(slug, permission)`,
+and `Permission` stops at `Write = 1`, so a same-slug parent is inexpressible; a different-slug
+parent authorizes nothing downstream because `LicensedResource.role` carries the **slug** and
+consumers match it by equality.
+
+**Decisions:**
+
+- **Branch on the parent instead of requiring one.** Parent found → the existing rules (hold the
+  parent, target listed in `parent.children`). Parent absent → the requester must already hold
+  the target role itself. The invariant that matters is preserved: nobody grants what they do
+  not have.
+- **The root path is scoped, the parent path is not.** The new possession check runs on
+  `profile.on_tenant(tenant_id).on_account(target_account_id)` so holding the role on one account
+  cannot authorize granting it on another. The pre-existing parent check keeps reading the full
+  license list — rule (1) forces `accounts-manager` on the *target* account but nothing
+  guarantees the requester holds the *parent role* there, so tightening it could break live
+  grants. Deliberate asymmetry; **follow-up candidate** once the production topology is
+  confirmed.
+- **Resolve the target role before the parent branch.** A nonexistent role has no parent either,
+  so the old order would route a missing role into the root path and report it as a missing
+  license.
+- **Staff/manager stay strict.** `get_related_account_or_error` short-circuits on `is_staff` /
+  `is_manager` without touching `licensed_resources`, so such a profile clears rule (1) and then
+  fails the possession check. That is today's behavior on the parent path; kept.
+- **Rejected: a third `Permission` level (`Admin = 2`).** `Permission::from_i32` maps
+  `_ => Read`, so any not-yet-updated service would silently read `2` as read-only.
+
+**Coverage:** the use case had **no tests**. Seven added in-file (root held / not held / held on
+another account, child with parent held / not held / not in children, missing target role).
+
+**Out of scope:** the webapp needs no change — `GuestRoleSelector` does not filter by hierarchy.
+The SDK slug-equality helper from the issue's *Related finding* is a separate ticket.
 
 ### AD-010: `up.sql` is the complete Postgres schema; folding is mandatory (2026-08-12)
 

--- a/core/src/use_cases/role_scoped/account_manager/guest/guest_to_children_account.rs
+++ b/core/src/use_cases/role_scoped/account_manager/guest/guest_to_children_account.rs
@@ -24,8 +24,12 @@ use mycelium_base::{
 };
 use uuid::Uuid;
 
-/// Guest users to collaborate to an account children of a role which I have
-/// guest to collaborate.
+/// Guest users to collaborate to an account under a role which I can delegate.
+///
+/// A role is delegable when the requester holds its parent role, or — when the
+/// role is a root, having no parent at all — when the requester already holds
+/// the role itself on the target account. Either way nobody grants what they
+/// do not have.
 ///
 /// This action should be allowed only to accounts that contains registered
 /// children accounts already registered.
@@ -113,24 +117,10 @@ pub async fn guest_to_children_account(
     }
 
     //
-    // Use the parent role to verify if the user that perform this action has
-    // permission to access the child role.
-    //
-    let parent_role = match parent_role_response? {
-        FetchResponseKind::NotFound(id) => {
-            return use_case_err(format!(
-                "Guest role parent not found: {:?}",
-                id.unwrap()
-            ))
-            .with_exp_true()
-            .with_code(NativeErrorCodes::MYC00013)
-            .as_error()
-        }
-        FetchResponseKind::Found(role) => role,
-    };
-
-    //
-    // The target role must be a child of the parent role.
+    // Resolve the target role before branching on the hierarchy. A role that
+    // does not exist has no parent either, so resolving the parent first would
+    // route a missing role into the root path and report it as a missing
+    // license instead of a missing role.
     //
     let target_role = match target_role_response? {
         FetchResponseKind::NotFound(id) => {
@@ -146,74 +136,115 @@ pub async fn guest_to_children_account(
     };
 
     tracing::debug!("target_role: {:?}", target_role);
-    tracing::debug!("parent_role: {:?}", parent_role);
     tracing::debug!("profile: {:?}", profile);
 
-    let parent_role_id = if let Some(id) = parent_role.id {
-        id
-    } else {
-        return use_case_err(
-                "Invalid parent role. Only roles with guest to collaborate can receive guesting",
-            )
-            .with_exp_true()
-            .with_code(NativeErrorCodes::MYC00013)
-            .as_error();
-    };
+    match parent_role_response? {
+        //
+        // The target role has a parent. Use the parent role to verify if the
+        // user that perform this action has permission to access the child
+        // role.
+        //
+        FetchResponseKind::Found(parent_role) => {
+            tracing::debug!("parent_role: {:?}", parent_role);
 
-    //
-    // Verify if the current role has guest to collaborate to the parent role
-    //
-    if let Some(resources) = profile.licensed_resources {
-        if !resources
-            .to_licenses_vector()
-            .iter()
-            .any(|i| i.role_id == parent_role_id)
-        {
-            return use_case_err(
-                    "You are not allowed to perform this action. You must be a guest to the parent role to collaborate to the child role.",
+            let parent_role_id = if let Some(id) = parent_role.id {
+                id
+            } else {
+                return use_case_err(
+                    "Invalid parent role. Only roles with guest to collaborate can receive guesting",
                 )
                 .with_exp_true()
                 .with_code(NativeErrorCodes::MYC00013)
                 .as_error();
-        }
-    } else {
-        return use_case_err(
-            "You are not allowed to perform this action. You must have a guest role to collaborate to the parent role.",
-        )
-        .with_exp_true()
-        .with_code(NativeErrorCodes::MYC00013)
-        .as_error();
-    }
+            };
 
-    //
-    // Verify if the target role is a child of the parent role.
-    //
-    if let Some(children) = parent_role.children {
-        let target_ids = match children {
-            Children::Ids(ids) => ids,
-            Children::Records(records) => {
-                records.iter().filter_map(|i| i.id).collect::<Vec<Uuid>>()
+            //
+            // Verify if the current role has guest to collaborate to the
+            // parent role
+            //
+            if let Some(resources) = profile.licensed_resources.as_ref() {
+                if !resources
+                    .to_licenses_vector()
+                    .iter()
+                    .any(|i| i.role_id == parent_role_id)
+                {
+                    return use_case_err(
+                        "You are not allowed to perform this action. You must be a guest to the parent role to collaborate to the child role.",
+                    )
+                    .with_exp_true()
+                    .with_code(NativeErrorCodes::MYC00013)
+                    .as_error();
+                }
+            } else {
+                return use_case_err(
+                    "You are not allowed to perform this action. You must have a guest role to collaborate to the parent role.",
+                )
+                .with_exp_true()
+                .with_code(NativeErrorCodes::MYC00013)
+                .as_error();
             }
-        };
 
-        if !target_ids.contains(&target_role_id) {
-            return use_case_err(
-                "Invalid target role. Children role is not belong to the \
-                parent role",
-            )
-            .with_exp_true()
-            .with_code(NativeErrorCodes::MYC00013)
-            .as_error();
+            //
+            // Verify if the target role is a child of the parent role.
+            //
+            if let Some(children) = parent_role.children {
+                let target_ids = match children {
+                    Children::Ids(ids) => ids,
+                    Children::Records(records) => records
+                        .iter()
+                        .filter_map(|i| i.id)
+                        .collect::<Vec<Uuid>>(),
+                };
+
+                if !target_ids.contains(&target_role_id) {
+                    return use_case_err(
+                        "Invalid target role. Children role is not belong to \
+                        the parent role",
+                    )
+                    .with_exp_true()
+                    .with_code(NativeErrorCodes::MYC00013)
+                    .as_error();
+                }
+            } else {
+                return use_case_err(
+                    "Invalid parent role. Only roles with children can \
+                    receive guesting",
+                )
+                .with_exp_true()
+                .with_code(NativeErrorCodes::MYC00013)
+                .as_error();
+            }
         }
-    } else {
-        return use_case_err(
-            "Invalid parent role. Only roles with children can receive \
-            guesting",
-        )
-        .with_exp_true()
-        .with_code(NativeErrorCodes::MYC00013)
-        .as_error();
-    }
+        //
+        // The target role is a root role. Root roles have no parent to
+        // delegate from, so the requester must already hold the role itself.
+        // The check runs against the profile scoped to the tenant and the
+        // target account, otherwise holding the role on one account would
+        // authorize granting it on another.
+        //
+        FetchResponseKind::NotFound(_) => {
+            let holds_target_role = profile
+                .on_tenant(tenant_id)
+                .on_account(target_account_id)
+                .licensed_resources
+                .map(|resources| {
+                    resources
+                        .to_licenses_vector()
+                        .iter()
+                        .any(|i| i.role_id == target_role_id)
+                })
+                .unwrap_or(false);
+
+            if !holds_target_role {
+                return use_case_err(
+                    "You are not allowed to perform this action. The target role has no parent role, then you must already hold it on the target account to grant it.",
+                )
+                .with_exp_true()
+                .with_code(NativeErrorCodes::MYC00013)
+                .as_error();
+            }
+        }
+    };
 
     // ? -----------------------------------------------------------------------
     // ? Persist changes
@@ -269,4 +300,558 @@ pub async fn guest_to_children_account(
     // ? -----------------------------------------------------------------------
 
     Ok(guest_user)
+}
+
+// * ---------------------------------------------------------------------------
+// * TESTS
+// * ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::domain::dtos::{
+        account::Account,
+        guest_role::{GuestRole, Permission},
+        message::MessageSendingEvent,
+        profile::{LicensedResource, LicensedResources},
+        related_accounts::RelatedAccounts,
+        telegram::TelegramUserId,
+        tenant::{Tenant, TenantMetaKey},
+    };
+    use crate::models::{HmacSecretEntry, HmacSecretSet};
+
+    use async_trait::async_trait;
+    use myc_config::secret_resolver::SecretResolver;
+    use mycelium_base::entities::{CreateResponseKind, FetchManyResponseKind};
+
+    // ? -----------------------------------------------------------------------
+    // ? Fixtures
+    // ? -----------------------------------------------------------------------
+
+    fn config() -> AccountLifeCycle {
+        AccountLifeCycle {
+            domain_name: SecretResolver::Value("Test Domain".to_string()),
+            domain_url: Some(SecretResolver::Value(
+                "https://test.com".to_string(),
+            )),
+            locale: Some(SecretResolver::Value("en-us".to_string())),
+            token_expiration: SecretResolver::Value(3600),
+            noreply_name: Some(SecretResolver::Value(
+                "Test System".to_string(),
+            )),
+            noreply_email: SecretResolver::Value(
+                "noreply@test.com".to_string(),
+            ),
+            support_name: None,
+            support_email: SecretResolver::Value(
+                "support@test.com".to_string(),
+            ),
+            token_secret: SecretResolver::Value("test-secret".to_string()),
+            hmac_primary_version: 1,
+            hmac_secrets: HmacSecretSet::new(vec![HmacSecretEntry {
+                version: 1,
+                secret: SecretResolver::Value("test-hmac".to_string()),
+            }]),
+            staff_bootstrap_secret: None,
+        }
+    }
+
+    fn guest_role(
+        id: Uuid,
+        name: &str,
+        children: Option<Children<GuestRole, Uuid>>,
+    ) -> GuestRole {
+        GuestRole::new(
+            Some(id),
+            name.to_string(),
+            None,
+            Permission::Write,
+            children,
+            false,
+        )
+    }
+
+    fn license(
+        tenant_id: Uuid,
+        acc_id: Uuid,
+        role_id: Uuid,
+        role: &str,
+    ) -> LicensedResource {
+        LicensedResource {
+            acc_id,
+            tenant_id,
+            role_id,
+            acc_name: "Target Account".to_string(),
+            sys_acc: false,
+            role: role.to_string(),
+            perm: Permission::Write,
+            verified: true,
+            permit_flags: None,
+            deny_flags: None,
+        }
+    }
+
+    fn profile_with(licenses: Vec<LicensedResource>) -> Profile {
+        let mut profile = Profile::default();
+
+        profile.licensed_resources = Some(LicensedResources::Records(licenses));
+
+        profile
+    }
+
+    // ? -----------------------------------------------------------------------
+    // ? Stubs
+    // ? -----------------------------------------------------------------------
+
+    struct StubAccountFetching {
+        account: Account,
+    }
+
+    #[async_trait]
+    impl AccountFetching for StubAccountFetching {
+        async fn get(
+            &self,
+            _: Uuid,
+            _: RelatedAccounts,
+        ) -> Result<FetchResponseKind<Account, Uuid>, MappedErrors> {
+            Ok(FetchResponseKind::Found(self.account.to_owned()))
+        }
+
+        async fn list(
+            &self,
+            _: RelatedAccounts,
+            _: Option<String>,
+            _: Option<bool>,
+            _: Option<bool>,
+            _: Option<bool>,
+            _: Option<bool>,
+            _: Option<bool>,
+            _: Option<Uuid>,
+            _: Option<String>,
+            _: Option<Uuid>,
+            _: AccountType,
+            _: Option<i32>,
+            _: Option<i32>,
+        ) -> Result<FetchManyResponseKind<Account>, MappedErrors> {
+            unimplemented!()
+        }
+
+        async fn get_by_telegram_id(
+            &self,
+            _: TelegramUserId,
+        ) -> Result<FetchResponseKind<Account, i64>, MappedErrors> {
+            unimplemented!()
+        }
+    }
+
+    struct StubGuestRoleFetching {
+        target_role: Option<GuestRole>,
+        parent_role: Option<GuestRole>,
+    }
+
+    #[async_trait]
+    impl GuestRoleFetching for StubGuestRoleFetching {
+        async fn get(
+            &self,
+            id: Uuid,
+        ) -> Result<FetchResponseKind<GuestRole, Uuid>, MappedErrors> {
+            Ok(match self.target_role.to_owned() {
+                Some(role) => FetchResponseKind::Found(role),
+                None => FetchResponseKind::NotFound(Some(id)),
+            })
+        }
+
+        async fn get_parent_by_child_id(
+            &self,
+            id: Uuid,
+        ) -> Result<FetchResponseKind<GuestRole, Uuid>, MappedErrors> {
+            Ok(match self.parent_role.to_owned() {
+                Some(role) => FetchResponseKind::Found(role),
+                None => FetchResponseKind::NotFound(Some(id)),
+            })
+        }
+
+        async fn list(
+            &self,
+            _: Option<String>,
+            _: Option<String>,
+            _: Option<bool>,
+            _: Option<i32>,
+            _: Option<i32>,
+        ) -> Result<FetchManyResponseKind<GuestRole>, MappedErrors> {
+            unimplemented!()
+        }
+    }
+
+    struct StubGuestUserRegistration;
+
+    #[async_trait]
+    impl GuestUserRegistration for StubGuestUserRegistration {
+        async fn get_or_create(
+            &self,
+            guest_user: GuestUser,
+            _: Uuid,
+        ) -> Result<GetOrCreateResponseKind<GuestUser>, MappedErrors> {
+            Ok(GetOrCreateResponseKind::Created(guest_user))
+        }
+    }
+
+    struct StubLocalMessageWrite;
+
+    #[async_trait]
+    impl LocalMessageWrite for StubLocalMessageWrite {
+        async fn send(
+            &self,
+            _: MessageSendingEvent,
+        ) -> Result<CreateResponseKind<Option<Uuid>>, MappedErrors> {
+            Ok(CreateResponseKind::Created(Some(Uuid::new_v4())))
+        }
+
+        async fn update_message_event(
+            &self,
+            _: MessageSendingEvent,
+        ) -> Result<(), MappedErrors> {
+            unimplemented!()
+        }
+
+        async fn delete_message_event(
+            &self,
+            _: Uuid,
+        ) -> Result<(), MappedErrors> {
+            unimplemented!()
+        }
+
+        async fn ping(&self) -> Result<(), MappedErrors> {
+            unimplemented!()
+        }
+    }
+
+    struct StubTenantFetching;
+
+    #[async_trait]
+    impl TenantFetching for StubTenantFetching {
+        async fn get_tenant_owned_by_me(
+            &self,
+            _: Uuid,
+            _: Vec<Uuid>,
+        ) -> Result<FetchResponseKind<Tenant, String>, MappedErrors> {
+            unimplemented!()
+        }
+
+        async fn get_tenant_public_by_id(
+            &self,
+            _: Uuid,
+        ) -> Result<FetchResponseKind<Tenant, String>, MappedErrors> {
+            Ok(FetchResponseKind::NotFound(None))
+        }
+
+        async fn get_tenants_by_manager_account(
+            &self,
+            _: Uuid,
+            _: Vec<Uuid>,
+        ) -> Result<FetchResponseKind<Tenant, String>, MappedErrors> {
+            unimplemented!()
+        }
+
+        async fn filter_tenants_as_manager(
+            &self,
+            _: Option<String>,
+            _: Option<Uuid>,
+            _: Option<(TenantMetaKey, String)>,
+            _: Option<(String, String)>,
+            _: Option<i32>,
+            _: Option<i32>,
+        ) -> Result<FetchManyResponseKind<Tenant>, MappedErrors> {
+            unimplemented!()
+        }
+    }
+
+    // ? -----------------------------------------------------------------------
+    // ? Runner
+    // ? -----------------------------------------------------------------------
+
+    async fn run(
+        profile: Profile,
+        tenant_id: Uuid,
+        target_account_id: Uuid,
+        target_role_id: Uuid,
+        target_role: Option<GuestRole>,
+        parent_role: Option<GuestRole>,
+    ) -> Result<GetOrCreateResponseKind<GuestUser>, MappedErrors> {
+        let account_fetching_repo = StubAccountFetching {
+            account: Account {
+                id: Some(target_account_id),
+                name: "Target Account".to_string(),
+                verbose_status: Some(VerboseStatus::Verified),
+                account_type: AccountType::Subscription { tenant_id },
+                ..Default::default()
+            },
+        };
+
+        let guest_role_fetching_repo = StubGuestRoleFetching {
+            target_role,
+            parent_role,
+        };
+
+        let guest_user_registration_repo = StubGuestUserRegistration;
+        let message_sending_repo = StubLocalMessageWrite;
+        let tenant_fetching_repo = StubTenantFetching;
+
+        guest_to_children_account(
+            profile,
+            tenant_id,
+            Email::from_string("guest@example.com".to_string())
+                .expect("valid email"),
+            target_role_id,
+            target_account_id,
+            config(),
+            Box::new(&account_fetching_repo),
+            Box::new(&guest_role_fetching_repo),
+            Box::new(&guest_user_registration_repo),
+            Box::new(&message_sending_repo),
+            Box::new(&tenant_fetching_repo),
+        )
+        .await
+    }
+
+    // ? -----------------------------------------------------------------------
+    // ? Root (parentless) role path
+    // ? -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn root_role_is_granted_when_requester_holds_it() {
+        let tenant_id = Uuid::new_v4();
+        let target_account_id = Uuid::new_v4();
+        let target_role_id = Uuid::new_v4();
+
+        let profile = profile_with(vec![
+            license(
+                tenant_id,
+                target_account_id,
+                Uuid::new_v4(),
+                SystemActor::AccountManager.str(),
+            ),
+            license(tenant_id, target_account_id, target_role_id, "customer"),
+        ]);
+
+        let result = run(
+            profile,
+            tenant_id,
+            target_account_id,
+            target_role_id,
+            Some(guest_role(target_role_id, "Customer", None)),
+            None,
+        )
+        .await;
+
+        assert!(result.is_ok(), "unexpected error: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn root_role_is_denied_when_requester_does_not_hold_it() {
+        let tenant_id = Uuid::new_v4();
+        let target_account_id = Uuid::new_v4();
+        let target_role_id = Uuid::new_v4();
+
+        let profile = profile_with(vec![license(
+            tenant_id,
+            target_account_id,
+            Uuid::new_v4(),
+            SystemActor::AccountManager.str(),
+        )]);
+
+        let result = run(
+            profile,
+            tenant_id,
+            target_account_id,
+            target_role_id,
+            Some(guest_role(target_role_id, "Customer", None)),
+            None,
+        )
+        .await;
+
+        let err = result.expect_err("expected an unauthorized error");
+
+        assert!(err.has_str_code("MYC00013"));
+        assert!(err.msg().contains("has no parent role"));
+    }
+
+    #[tokio::test]
+    async fn root_role_is_denied_when_held_on_another_account() {
+        let tenant_id = Uuid::new_v4();
+        let target_account_id = Uuid::new_v4();
+        let another_account_id = Uuid::new_v4();
+        let target_role_id = Uuid::new_v4();
+
+        let profile = profile_with(vec![
+            license(
+                tenant_id,
+                target_account_id,
+                Uuid::new_v4(),
+                SystemActor::AccountManager.str(),
+            ),
+            //
+            // The role is held, but on a different account of the same tenant.
+            //
+            license(tenant_id, another_account_id, target_role_id, "customer"),
+        ]);
+
+        let result = run(
+            profile,
+            tenant_id,
+            target_account_id,
+            target_role_id,
+            Some(guest_role(target_role_id, "Customer", None)),
+            None,
+        )
+        .await;
+
+        let err = result.expect_err("expected an unauthorized error");
+
+        assert!(err.has_str_code("MYC00013"));
+        assert!(err.msg().contains("has no parent role"));
+    }
+
+    // ? -----------------------------------------------------------------------
+    // ? Child role path
+    // ? -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn child_role_is_granted_when_requester_holds_the_parent() {
+        let tenant_id = Uuid::new_v4();
+        let target_account_id = Uuid::new_v4();
+        let target_role_id = Uuid::new_v4();
+        let parent_role_id = Uuid::new_v4();
+
+        let profile = profile_with(vec![
+            license(
+                tenant_id,
+                target_account_id,
+                Uuid::new_v4(),
+                SystemActor::AccountManager.str(),
+            ),
+            license(tenant_id, target_account_id, parent_role_id, "manager"),
+        ]);
+
+        let result = run(
+            profile,
+            tenant_id,
+            target_account_id,
+            target_role_id,
+            Some(guest_role(target_role_id, "Customer", None)),
+            Some(guest_role(
+                parent_role_id,
+                "Manager",
+                Some(Children::Ids(vec![target_role_id])),
+            )),
+        )
+        .await;
+
+        assert!(result.is_ok(), "unexpected error: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn child_role_is_denied_when_requester_does_not_hold_the_parent() {
+        let tenant_id = Uuid::new_v4();
+        let target_account_id = Uuid::new_v4();
+        let target_role_id = Uuid::new_v4();
+        let parent_role_id = Uuid::new_v4();
+
+        let profile = profile_with(vec![license(
+            tenant_id,
+            target_account_id,
+            Uuid::new_v4(),
+            SystemActor::AccountManager.str(),
+        )]);
+
+        let result = run(
+            profile,
+            tenant_id,
+            target_account_id,
+            target_role_id,
+            Some(guest_role(target_role_id, "Customer", None)),
+            Some(guest_role(
+                parent_role_id,
+                "Manager",
+                Some(Children::Ids(vec![target_role_id])),
+            )),
+        )
+        .await;
+
+        let err = result.expect_err("expected an unauthorized error");
+
+        assert!(err.has_str_code("MYC00013"));
+        assert!(err.msg().contains("guest to the parent role"));
+    }
+
+    #[tokio::test]
+    async fn child_role_is_denied_when_not_listed_in_the_parent_children() {
+        let tenant_id = Uuid::new_v4();
+        let target_account_id = Uuid::new_v4();
+        let target_role_id = Uuid::new_v4();
+        let parent_role_id = Uuid::new_v4();
+
+        let profile = profile_with(vec![
+            license(
+                tenant_id,
+                target_account_id,
+                Uuid::new_v4(),
+                SystemActor::AccountManager.str(),
+            ),
+            license(tenant_id, target_account_id, parent_role_id, "manager"),
+        ]);
+
+        let result = run(
+            profile,
+            tenant_id,
+            target_account_id,
+            target_role_id,
+            Some(guest_role(target_role_id, "Customer", None)),
+            Some(guest_role(
+                parent_role_id,
+                "Manager",
+                Some(Children::Ids(vec![Uuid::new_v4()])),
+            )),
+        )
+        .await;
+
+        let err = result.expect_err("expected an unauthorized error");
+
+        assert!(err.has_str_code("MYC00013"));
+        assert!(err.msg().contains("is not belong to the parent role"));
+    }
+
+    // ? -----------------------------------------------------------------------
+    // ? Ordering
+    // ? -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn missing_target_role_is_reported_before_the_parent_branch() {
+        let tenant_id = Uuid::new_v4();
+        let target_account_id = Uuid::new_v4();
+        let target_role_id = Uuid::new_v4();
+
+        let profile = profile_with(vec![license(
+            tenant_id,
+            target_account_id,
+            Uuid::new_v4(),
+            SystemActor::AccountManager.str(),
+        )]);
+
+        let result = run(
+            profile,
+            tenant_id,
+            target_account_id,
+            target_role_id,
+            None,
+            None,
+        )
+        .await;
+
+        let err = result.expect_err("expected a not found error");
+
+        assert!(err.has_str_code("MYC00013"));
+        assert!(err.msg().contains("Guest role not found"));
+    }
 }

--- a/ports/api/src/rpc/openrpc/methods/account_manager.rs
+++ b/ports/api/src/rpc/openrpc/methods/account_manager.rs
@@ -13,7 +13,7 @@ pub fn methods() -> Vec<serde_json::Value> {
         serde_json::json!({
             "name": method_names::ACCOUNT_MANAGER_GUESTS_GUEST_TO_CHILDREN_ACCOUNT,
             "summary": "Guest user to children account",
-            "description": "Adds a guest user to an account under the given guest role (child role). Requires account manager privileges on the tenant. Tenant ID, account ID and role ID must be provided.",
+            "description": "Adds a guest user to an account under the given guest role. The requester must hold the role's parent role, or the role itself when it has no parent. Requires account manager privileges on the tenant. Tenant ID, account ID and role ID must be provided.",
             "tags": [{ "name": "accountManager" }, { "name": "guests" }],
             "params": [{ "name": "params", "required": true, "schema": guest_to_children_account_schema }],
             "result": { "name": "result", "description": "Created or existing guest user (GetOrCreateResponseKind)", "schema": { "type": "object" } },


### PR DESCRIPTION
Closes #187.

## Problem

`guest_to_children_account` gated a grant on the granted role **having a parent**, so a **root role was undelegable by anyone** — not even by someone who already holds it. In production the call dies at rule (2):

```
[codes=MYC00013 error_type=use-case-error]
Guest role parent not found: <role-id>
```

Configuring around it is impossible. `insert_role_child` requires `parent.permission >= child.permission`, `get_or_create` de-duplicates on `(slug, permission)`, and `Permission` stops at `Write = 1` — so a same-slug parent for a `(slug, write)` role is inexpressible. A **different**-slug parent authorizes nothing downstream: `LicensedResource.role` carries the **slug** and consumers match it by equality, so the holder looks authorized in the UI and gets a 403 from the service.

## Change

Branch on the parent instead of requiring one:

| Target role | Rule |
|---|---|
| has a parent | unchanged — hold the parent, and the target must be listed in `parent.children` |
| is a root | allowed if the requester **already holds the role itself** |

The anti-escalation invariant is preserved: **nobody grants what they do not have.** Rule (1) — `accounts-manager` with write on the tenant + target account — is untouched, and the public signature does not change, so the three entry points (REST, RPC dispatcher, openrpc) are unaffected.

Two details worth review:

- **The root-path possession check is scoped** to `profile.on_tenant(tenant_id).on_account(target_account_id)`, per the issue. Otherwise holding the role on one account would authorize granting it on another.
- **The target role is now resolved before the parent branch.** A nonexistent role has no parent either, so the old order would route a missing role into the root path and report it as a missing license instead of a missing role.

## Deliberate asymmetry

The **pre-existing parent check keeps reading the full license list** (unscoped). Rule (1) forces `accounts-manager` on the *target* account, but nothing guarantees the requester holds the *parent role* on that same account — in a "guest to children account" topology they plausibly hold it on the managing account. Scoping it would be a behavior change beyond this issue and could break live grants. Recorded as a follow-up candidate rather than done silently.

Staff/manager profiles stay strict: `get_related_account_or_error` short-circuits on `is_staff` / `is_manager` without touching `licensed_resources`, so such a profile clears rule (1) and then fails the possession check — exactly today's behavior on the parent path.

## Adapter contract

The change reinterprets `get_parent_by_child_id` returning `NotFound` as "this role is a root", so both implementations were checked:

| Adapter | No-parent case |
|---|---|
| `diesel_postgres/.../guest_role_fetching.rs:78` | `.first(conn).optional()` → `Ok(NotFound(Some(id)))` |
| `diesel_sqlite/.../guest_role_fetching.rs:66` | `.first(conn).optional()` → `Ok(NotFound(Some(id)))` |

Both use `.optional()`, so an absent parent surfaces as `Ok(NotFound)` rather than `Err(diesel::NotFound)`. Neither synthesizes an empty `Found` parent. No other adapter implements `GuestRoleFetching`. **Behaves identically on Postgres and on SQLite (Standalone Mode).**

## Tests

The use case had **no coverage**. Seven added in-file:

- root role held by the requester on the target account → Ok
- root role not held → MYC00013
- root role held on a **different account** of the same tenant → MYC00013 (proves the scoping)
- child role, parent held → Ok
- child role, parent not held → MYC00013
- child role, parent held but target not in `parent.children` → MYC00013
- target role not found → MYC00013 "Guest role not found" (proves the reordering)

Gates: `cargo fmt --all -- --check` clean, `cargo build --workspace` clean, `cargo test --workspace --all` → **464 passed, 0 failed**.

## Out of scope

- **Client-side mirroring.** Checked: `mycelium-webapp`'s `GuestRoleSelector` does not filter by hierarchy, so no webapp change is needed.
- **The SDK slug-equality helper** from the issue's *Related finding* — a separate ticket, outside this repository.
- **A third `Permission` level (`Admin = 2`).** Rejected: `Permission::from_i32` maps `_ => Read`, so any not-yet-updated service would silently read `2` as read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
